### PR TITLE
chore(docker-compose): add env scaffolding instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,16 @@ $(GIT_SUBMODULES): %/.git: .gitmodules
 	$(GIT) submodule init
 	$(GIT) submodule update $*
 	@touch $@
+
+.EXPORT_ALL_VARIABLES:
+
+REDIS_PORT=6379
+ANVIL_PORT=8545
+
+start:
+	docker compose up -d
+	until cast chain-id --rpc-url "http://localhost:${ANVIL_PORT}" 2> /dev/null; do sleep 1; done
+	cd contracts && forge script --rpc-url "http://localhost:${ANVIL_PORT}" script/Deploy.s.sol:Deploy --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+stop:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Decentralized MLS PoC using a smart contract for group coordination
 
 1. `Foundry`
 2. `make deps`
+
+## Scaffold Environment
+
+1. `make start`: This command will start the docker compose instance, and deploy the smart contract to the local network.
+
+2. `make stop`: This command will stop the docker compose instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,31 @@
 version: "3.8"
 services:
   redis:
-    image: redis:7-alpine
+    image: redis@sha256:0c6f34a2d41992ee1e02d52d712c12ac46c4d5a63efdab74915141a52c529586
+    entrypoint: ["redis-server", "--port", "${REDIS_PORT}"]
     ports:
-      - 6379:6379
+      - "${REDIS_PORT}:${REDIS_PORT}"
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+
+  anvil:
+    image: ghcr.io/foundry-rs/foundry:latest
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "cast",
+          "chain-id",
+          "--rpc-url",
+          "http://localhost:${ANVIL_PORT}",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    ports:
+      - "${ANVIL_PORT}:${ANVIL_PORT}"
+    entrypoint: ["anvil", "--host", "0.0.0.0"]
+    platform: linux/amd64


### PR DESCRIPTION
adds foundry to the docker-compose, and starts anvil at a specified port. Makefile entries to make setup easier.
