### PR TITLE
feat(core): add peer scoring service

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -6,7 +6,7 @@ use de_mls::{
     ds::WakuDeliveryService, mls_crypto::format_wallet_address,
     protos::de_mls::messages::v1::group_update_request,
 };
-use de_mls_ui_protocol::v1::AppEvent;
+use de_mls_ui_protocol::v1::{AppEvent, MemberInfo};
 
 use crate::{CoreCtx, Gateway, UserRef};
 
@@ -93,6 +93,38 @@ pub(crate) async fn push_consensus_state(
     }
 }
 
+/// Push refreshed member scores to the UI.
+///
+/// Called after consensus events that may have changed peer scores
+/// (emergency criteria proposals produce score ops on resolution).
+pub(crate) async fn push_member_scores(
+    user: &UserRef,
+    evt_tx: &UnboundedSender<AppEvent>,
+    group_name: &str,
+) {
+    let user = user.read().await;
+    let addresses = match user.get_group_members(group_name).await {
+        Ok(a) => a,
+        Err(_) => return,
+    };
+    let scores = user.get_member_scores(group_name);
+    let members: Vec<MemberInfo> = addresses
+        .into_iter()
+        .map(|address| {
+            let score = scores
+                .iter()
+                .find(|(raw_id, _)| format_wallet_address(raw_id.as_slice()) == address)
+                .map(|(_, s)| *s)
+                .unwrap_or(100);
+            MemberInfo { address, score }
+        })
+        .collect();
+    let _ = evt_tx.unbounded_send(AppEvent::GroupMembers {
+        group_id: group_name.to_string(),
+        members,
+    });
+}
+
 impl Gateway<WakuDeliveryService> {
     /// Spawn the consensus event forwarder.
     ///
@@ -122,8 +154,9 @@ impl Gateway<WakuDeliveryService> {
                     tracing::warn!("handle_consensus_event failed: {e}");
                 }
 
-                // Push refreshed approved queue + epoch history
+                // Push refreshed approved queue, epoch history, and member scores
                 push_consensus_state(&user, &evt_tx, &group_name).await;
+                push_member_scores(&user, &evt_tx, &group_name).await;
             }
             tracing::info!("gateway: consensus forwarder ended");
         });

--- a/src/app/display.rs
+++ b/src/app/display.rs
@@ -18,6 +18,7 @@ impl ViolationEvidence {
             Ok(ViolationType::BrokenCommit) => "Broken Commit",
             Ok(ViolationType::BrokenMlsProposal) => "Broken MLS Proposal",
             Ok(ViolationType::CensorshipInactivity) => "Censorship/Inactivity",
+            Ok(ViolationType::ScoreBelowThreshold) => "Score Below Threshold",
             _ => "Unknown Violation",
         }
     }

--- a/src/app/message_type.rs
+++ b/src/app/message_type.rs
@@ -50,6 +50,7 @@ impl MessageType for GroupUpdateRequest {
                     Ok(ViolationType::BrokenCommit) => "Emergency: Broken Commit",
                     Ok(ViolationType::BrokenMlsProposal) => "Emergency: Broken MLS Proposal",
                     Ok(ViolationType::CensorshipInactivity) => "Emergency: Censorship/Inactivity",
+                    Ok(ViolationType::ScoreBelowThreshold) => "Emergency: Score Below Threshold",
                     _ => "Emergency: Unknown Violation",
                 })
                 .unwrap_or("Emergency: Unknown Violation"),

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -139,6 +139,9 @@ pub struct GroupStateMachine {
     /// finalized by consensus. While non-empty, lower-priority proposals MUST be blocked
     /// (RFC §"Partial Freeze Semantics").
     active_emergency_proposal_ids: HashSet<ProposalId>,
+    /// Member IDs for which a `SCORE_BELOW_THRESHOLD` ECP has already been submitted
+    /// but not yet finalized. Prevents duplicate ECPs for the same target.
+    pending_removal_targets: HashSet<Vec<u8>>,
 }
 
 impl Default for GroupStateMachine {
@@ -166,6 +169,7 @@ impl GroupStateMachine {
             freeze_duration: config.freeze_duration(),
             allow_subset_candidates: config.allow_subset_candidates,
             active_emergency_proposal_ids: HashSet::new(),
+            pending_removal_targets: HashSet::new(),
         }
     }
 
@@ -187,6 +191,7 @@ impl GroupStateMachine {
             freeze_duration: config.freeze_duration(),
             allow_subset_candidates: config.allow_subset_candidates,
             active_emergency_proposal_ids: HashSet::new(),
+            pending_removal_targets: HashSet::new(),
         }
     }
 
@@ -208,6 +213,7 @@ impl GroupStateMachine {
             freeze_duration: config.freeze_duration(),
             allow_subset_candidates: config.allow_subset_candidates,
             active_emergency_proposal_ids: HashSet::new(),
+            pending_removal_targets: HashSet::new(),
         }
     }
 
@@ -250,6 +256,23 @@ impl GroupStateMachine {
     /// lower-priority proposals MUST NOT be created or propagated while this is true.
     pub fn has_active_emergency_proposal(&self) -> bool {
         !self.active_emergency_proposal_ids.is_empty()
+    }
+
+    // ── Pending Removal Targets (steward-triggered removal dedup) ──
+
+    /// Record that a `SCORE_BELOW_THRESHOLD` ECP has been submitted for this member.
+    pub fn observe_removal_target(&mut self, member_id: Vec<u8>) {
+        self.pending_removal_targets.insert(member_id);
+    }
+
+    /// Check if a removal ECP is already pending for this member.
+    pub fn has_pending_removal_for(&self, member_id: &[u8]) -> bool {
+        self.pending_removal_targets.contains(member_id)
+    }
+
+    /// Mark a pending removal target as finalized (ECP resolved, regardless of outcome).
+    pub fn resolve_removal_target(&mut self, member_id: &[u8]) {
+        self.pending_removal_targets.remove(member_id);
     }
 
     /// Start working state.

--- a/src/app/user.rs
+++ b/src/app/user.rs
@@ -97,8 +97,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             (ScoreEvent::BrokenCommit, -50),
             (ScoreEvent::BrokenMlsProposal, -30),
             (ScoreEvent::CensorshipInactivity, -40),
-            // Steward-triggered removal
-            (ScoreEvent::ScoreBelowThreshold, -50),
             // ECP creator outcomes
             (ScoreEvent::EmergencyYesCreator, 20),
             (ScoreEvent::EmergencyNoCreator, -50),
@@ -364,8 +362,20 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                  (score={current_score}) in group {group_name}",
                 target_id
             );
-            self.start_voting_on_request_background(group_name.to_string(), request)
-                .await?;
+            if let Err(e) = self
+                .start_voting_on_request_background(group_name.to_string(), request)
+                .await
+            {
+                // Clean up pending target on failure so it can be retried next time.
+                let mut groups = self.groups.write().await;
+                if let Some(entry) = groups.get_mut(group_name) {
+                    entry.state_machine.resolve_removal_target(&target_id);
+                }
+                error!(
+                    "Failed to start SCORE_BELOW_THRESHOLD vote for {:?}: {e}",
+                    target_id
+                );
+            }
         }
 
         Ok(())

--- a/src/app/user.rs
+++ b/src/app/user.rs
@@ -97,6 +97,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             (ScoreEvent::BrokenCommit, -50),
             (ScoreEvent::BrokenMlsProposal, -30),
             (ScoreEvent::CensorshipInactivity, -40),
+            // Steward-triggered removal
+            (ScoreEvent::ScoreBelowThreshold, -50),
             // ECP creator outcomes
             (ScoreEvent::EmergencyYesCreator, 20),
             (ScoreEvent::EmergencyNoCreator, -50),
@@ -297,6 +299,76 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 scoring.remove_member(group_name, member_id);
             }
         }
+    }
+
+    /// Check if any members are below the removal threshold and initiate ECPs.
+    ///
+    /// Only the steward initiates score-based removals. Skips self and any
+    /// member for which a removal ECP is already pending.
+    async fn check_and_initiate_score_removals(&self, group_name: &str) -> Result<(), UserError> {
+        let (is_steward, epoch, self_id) = {
+            let groups = self.groups.read().await;
+            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            (
+                entry.state_machine.is_steward(),
+                entry.handle.current_epoch(),
+                self.mls_service.wallet_bytes(),
+            )
+        };
+
+        if !is_steward {
+            return Ok(());
+        }
+
+        let targets: Vec<(Vec<u8>, i64)> = {
+            let scoring = self.scoring();
+            scoring
+                .members_below_threshold(group_name)
+                .into_iter()
+                .filter(|id| *id != self_id) // skip self (deferred to M2)
+                .map(|id| {
+                    let score = scoring.score_for(group_name, &id).unwrap_or(0);
+                    (id, score)
+                })
+                .collect()
+        };
+
+        for (target_id, current_score) in targets {
+            // Skip if already pending
+            {
+                let groups = self.groups.read().await;
+                if let Some(entry) = groups.get(group_name) {
+                    if entry.state_machine.has_pending_removal_for(&target_id) {
+                        continue;
+                    }
+                }
+            }
+
+            let evidence =
+                ViolationEvidence::score_below_threshold(target_id.clone(), epoch, current_score)
+                    .with_creator(self_id.clone());
+            let request = evidence.into_update_request()?;
+
+            // Track before submitting to prevent duplicates
+            {
+                let mut groups = self.groups.write().await;
+                if let Some(entry) = groups.get_mut(group_name) {
+                    entry
+                        .state_machine
+                        .observe_removal_target(target_id.clone());
+                }
+            }
+
+            info!(
+                "Steward initiating SCORE_BELOW_THRESHOLD removal for member {:?} \
+                 (score={current_score}) in group {group_name}",
+                target_id
+            );
+            self.start_voting_on_request_background(group_name.to_string(), request)
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Get current epoch proposals for a group.
@@ -1030,11 +1102,33 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 }
             }
 
+            // Resolve removal target tracking for SCORE_BELOW_THRESHOLD ECPs.
+            // Extract the target_member_id from the payload evidence.
+            if let Ok(req) = GroupUpdateRequest::decode(payload.as_slice()) {
+                if let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload {
+                    if let Some(ev) = &ec.evidence {
+                        let mut groups = self.groups.write().await;
+                        if let Some(entry) = groups.get_mut(group_name) {
+                            entry
+                                .state_machine
+                                .resolve_removal_target(&ev.target_member_id);
+                        }
+                    }
+                }
+            }
+
             // RFC §"Partial Freeze Semantics": lift the freeze once the emergency
             // proposal is resolved (approved or rejected — either way it's finalized).
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
-                entry.state_machine.resolve_emergency_proposal(proposal_id);
+            {
+                let mut groups = self.groups.write().await;
+                if let Some(entry) = groups.get_mut(group_name) {
+                    entry.state_machine.resolve_emergency_proposal(proposal_id);
+                }
+            }
+
+            // After scoring changes, check if any members now fall below the threshold.
+            if let Err(e) = self.check_and_initiate_score_removals(group_name).await {
+                error!("[handle_consensus_event] check_and_initiate_score_removals failed: {e}");
             }
         }
 

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -24,7 +24,9 @@ fn target_score_event(violation_type: i32) -> ScoreEvent {
         Ok(ViolationType::BrokenCommit) => ScoreEvent::BrokenCommit,
         Ok(ViolationType::BrokenMlsProposal) => ScoreEvent::BrokenMlsProposal,
         Ok(ViolationType::CensorshipInactivity) => ScoreEvent::CensorshipInactivity,
-        Ok(ViolationType::ScoreBelowThreshold) => ScoreEvent::ScoreBelowThreshold,
+        // ScoreBelowThreshold has no target penalty (target is being removed).
+        // Fall through to default.
+        //
         // Unspecified or unknown — fall back to the most severe penalty.
         _ => ScoreEvent::BrokenCommit,
     }
@@ -137,9 +139,17 @@ pub fn apply_consensus_result(
                  target={:?}, creator={:?}",
                 ev.target_member_id, ev.creator_member_id
             );
-            Ok(ConsensusApplyResult::with_ops(
-                emergency_accepted_score_ops(&ev).into(),
-            ))
+            let ops = if is_score_below_threshold(&ev) {
+                // Target is already at/below threshold and will be removed —
+                // skip the redundant penalty, only reward the creator.
+                vec![ScoreOp::new(
+                    ev.creator_member_id.clone(),
+                    ScoreEvent::EmergencyYesCreator,
+                )]
+            } else {
+                emergency_accepted_score_ops(&ev).into()
+            };
+            Ok(ConsensusApplyResult::with_ops(ops))
         }
         Some(ev) => {
             info!(

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -15,7 +15,7 @@ use tracing::info;
 use crate::core::peer_scoring::{ConsensusApplyResult, ScoreEvent, ScoreOp};
 use crate::core::{CoreError, GroupHandle};
 use crate::protos::de_mls::messages::v1::{
-    GroupUpdateRequest, ViolationEvidence, ViolationType, group_update_request,
+    GroupUpdateRequest, RemoveMember, ViolationEvidence, ViolationType, group_update_request,
 };
 
 /// Map a proto `ViolationType` to the corresponding target penalty `ScoreEvent`.
@@ -24,6 +24,7 @@ fn target_score_event(violation_type: i32) -> ScoreEvent {
         Ok(ViolationType::BrokenCommit) => ScoreEvent::BrokenCommit,
         Ok(ViolationType::BrokenMlsProposal) => ScoreEvent::BrokenMlsProposal,
         Ok(ViolationType::CensorshipInactivity) => ScoreEvent::CensorshipInactivity,
+        Ok(ViolationType::ScoreBelowThreshold) => ScoreEvent::ScoreBelowThreshold,
         // Unspecified or unknown — fall back to the most severe penalty.
         _ => ScoreEvent::BrokenCommit,
     }
@@ -61,6 +62,20 @@ fn extract_emergency_evidence(req: &GroupUpdateRequest) -> Option<&ViolationEvid
     }
 }
 
+/// Check whether evidence is a `SCORE_BELOW_THRESHOLD` violation.
+fn is_score_below_threshold(evidence: &ViolationEvidence) -> bool {
+    ViolationType::try_from(evidence.violation_type) == Ok(ViolationType::ScoreBelowThreshold)
+}
+
+/// Build a `RemoveMember` `GroupUpdateRequest` for the target in score-below-threshold evidence.
+fn removal_request_for(evidence: &ViolationEvidence) -> GroupUpdateRequest {
+    GroupUpdateRequest {
+        payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+            identity: evidence.target_member_id.clone(),
+        })),
+    }
+}
+
 /// Apply a consensus result to the group handle (pure, synchronous).
 ///
 /// Determines ownership from the handle and updates proposal state:
@@ -85,14 +100,27 @@ pub fn apply_consensus_result(
     let evidence = extract_emergency_evidence(&request).cloned();
     let is_emergency = evidence.is_some();
 
+    // Should the approved ECP transform into a RemoveMember?
+    let transforms_to_removal =
+        approved && is_emergency && evidence.as_ref().is_some_and(is_score_below_threshold);
+
     // Mutate handle state.
     if approved {
         if is_owner {
             handle.mark_proposal_as_approved(proposal_id);
-            if is_emergency {
-                // Emergency proposals don't produce MLS operations.
+            if transforms_to_removal {
+                // Replace ECP with RemoveMember in approved queue (reuse proposal_id).
+                let removal = removal_request_for(evidence.as_ref().unwrap());
+                handle.remove_approved_proposal(proposal_id);
+                handle.insert_approved_proposal(proposal_id, removal);
+            } else if is_emergency {
+                // Other emergencies don't produce MLS operations.
                 handle.remove_approved_proposal(proposal_id);
             }
+        } else if transforms_to_removal {
+            // Non-owner: insert RemoveMember directly (the ECP was never stored).
+            let removal = removal_request_for(evidence.as_ref().unwrap());
+            handle.insert_approved_proposal(proposal_id, removal);
         } else if !is_emergency {
             // Regular proposal: add to approved queue for the next commit.
             handle.insert_approved_proposal(proposal_id, request);

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -43,6 +43,10 @@ pub enum ScoreEvent {
     /// Misbehavior — penalty. (RFC: "MUST be classified as misbehavior")
     MisbehavingCommit,
 
+    // ── Steward-triggered removal ──
+    /// ECP accepted: member's peer score dropped to/below the removal threshold.
+    ScoreBelowThreshold,
+
     // ── Partial freeze (M2) ──
     /// Propagated lower-priority governance traffic during active emergency freeze.
     /// RFC MAY penalize.

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -43,10 +43,6 @@ pub enum ScoreEvent {
     /// Misbehavior — penalty. (RFC: "MUST be classified as misbehavior")
     MisbehavingCommit,
 
-    // ── Steward-triggered removal ──
-    /// ECP accepted: member's peer score dropped to/below the removal threshold.
-    ScoreBelowThreshold,
-
     // ── Partial freeze (M2) ──
     /// Propagated lower-priority governance traffic during active emergency freeze.
     /// RFC MAY penalize.

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -131,6 +131,17 @@ impl ViolationEvidence {
         }
     }
 
+    /// Member's peer score dropped to or below the removal threshold.
+    pub fn score_below_threshold(target: Vec<u8>, epoch: u64, current_score: i64) -> Self {
+        Self {
+            violation_type: ViolationType::ScoreBelowThreshold as i32,
+            target_member_id: target,
+            evidence_payload: current_score.to_le_bytes().to_vec(),
+            epoch,
+            creator_member_id: Vec::new(),
+        }
+    }
+
     /// Set the creator identity on this evidence (called by app layer before voting).
     pub fn with_creator(mut self, creator: Vec<u8>) -> Self {
         self.creator_member_id = creator;

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -62,6 +62,7 @@ enum ViolationType {
   BROKEN_COMMIT = 1;        // Commit doesn't match voted proposals
   BROKEN_MLS_PROPOSAL = 2;  // MLS proposal doesn't match voting proposal
   CENSORSHIP_INACTIVITY = 3; // Steward didn't commit within threshold_duration
+  SCORE_BELOW_THRESHOLD = 4; // Member's peer score dropped to/below removal threshold
 }
 
 message ViolationEvidence {

--- a/tests/async_scoring_removal.rs
+++ b/tests/async_scoring_removal.rs
@@ -1,0 +1,404 @@
+//! Async integration tests for the peer scoring → steward-triggered removal pipeline.
+//!
+//! Exercises the full `User` layer with a shared `DefaultConsensusService`
+//! and mock handlers. Packets are manually relayed between users.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use prost::Message;
+
+use hashgraph_like_consensus::service::DefaultConsensusService;
+
+use de_mls::app::{GroupConfig, GroupState, StateChangeHandler, User};
+use de_mls::core::{CallbackError, DefaultProvider, GroupEventHandler};
+use de_mls::ds::{InboundPacket, OutboundPacket};
+use de_mls::protos::de_mls::messages::v1::{
+    AppMessage, GroupUpdateRequest, ViolationEvidence, ViolationType, app_message,
+    group_update_request,
+};
+
+// ─────────────────────────── Mocks ───────────────────────────
+
+#[derive(Clone)]
+struct H {
+    packets: Arc<Mutex<Vec<OutboundPacket>>>,
+    app_msgs: Arc<Mutex<Vec<AppMessage>>>,
+}
+
+impl H {
+    fn new() -> Self {
+        Self {
+            packets: Arc::new(Mutex::new(Vec::new())),
+            app_msgs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+    fn drain_packets(&self) -> Vec<OutboundPacket> {
+        std::mem::take(&mut *self.packets.lock().unwrap())
+    }
+    fn drain_app_msgs(&self) -> Vec<AppMessage> {
+        std::mem::take(&mut *self.app_msgs.lock().unwrap())
+    }
+    fn last_vote_pid(&self) -> Option<u32> {
+        self.app_msgs
+            .lock()
+            .unwrap()
+            .iter()
+            .rev()
+            .find_map(|msg| match &msg.payload {
+                Some(app_message::Payload::VotePayload(vp)) => Some(vp.proposal_id),
+                _ => None,
+            })
+    }
+}
+
+#[async_trait]
+impl GroupEventHandler for H {
+    async fn on_outbound(&self, _: &str, p: OutboundPacket) -> Result<String, CallbackError> {
+        self.packets.lock().unwrap().push(p);
+        Ok("ok".into())
+    }
+    async fn on_app_message(&self, _: &str, m: AppMessage) -> Result<(), CallbackError> {
+        self.app_msgs.lock().unwrap().push(m);
+        Ok(())
+    }
+    async fn on_leave_group(&self, _: &str) -> Result<(), CallbackError> {
+        Ok(())
+    }
+    async fn on_joined_group(&self, _: &str) -> Result<(), CallbackError> {
+        Ok(())
+    }
+    async fn on_error(&self, _: &str, _: &str, _: &str) {}
+}
+
+#[derive(Clone)]
+struct SH;
+#[async_trait]
+impl StateChangeHandler for SH {
+    async fn on_state_changed(&self, _: &str, _: GroupState) {}
+}
+
+// ─────────────────────────── Helpers ───────────────────────────
+
+const ALICE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB_KEY: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE_KEY: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+
+type TU = User<DefaultProvider, H, SH>;
+
+fn make(key: &str, cs: Arc<DefaultConsensusService>, cfg: GroupConfig) -> (TU, H) {
+    let h = H::new();
+    let u =
+        User::with_private_key_and_config(key, cs, Arc::new(h.clone()), Arc::new(SH), cfg).unwrap();
+    (u, h)
+}
+
+fn to_in(p: &OutboundPacket) -> InboundPacket {
+    InboundPacket::new(
+        p.payload.clone(),
+        &p.subtopic,
+        &p.group_id,
+        p.app_id.clone(),
+        0,
+    )
+}
+
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(300)).await;
+}
+
+/// Complete join flow: KP → vote → steward epoch → welcome.
+async fn do_join(
+    steward: &mut TU,
+    steward_h: &H,
+    joiner: &mut TU,
+    joiner_h: &H,
+    others: &mut [(&mut TU, &H)],
+    cs: &DefaultConsensusService,
+    group: &str,
+) {
+    joiner.send_kp_message(group).await.unwrap();
+
+    // Deliver KP to steward → triggers start_voting_on_request_background (tokio::spawn)
+    for p in joiner_h.drain_packets() {
+        let _ = steward.process_inbound_packet(to_in(&p)).await;
+    }
+    settle().await;
+
+    let pid = steward_h
+        .last_vote_pid()
+        .expect("should have invite VotePayload");
+    // Steward auto-voted YES on creation (auto_vote=true). Don't vote again.
+
+    // Relay proposal to others so they can vote
+    for p in steward_h.drain_packets() {
+        for (u, _) in others.iter_mut() {
+            let _ = u.process_inbound_packet(to_in(&p)).await;
+        }
+    }
+    settle().await;
+
+    // Others vote YES
+    for (u, h) in others.iter_mut() {
+        let _ = u.process_user_vote(group, pid, true).await;
+        for p in h.drain_packets() {
+            let _ = steward.process_inbound_packet(to_in(&p)).await;
+        }
+    }
+    settle().await;
+
+    // Instead of subscribing to broadcast (unreliable in tests with auto-vote),
+    // poll the consensus service for the result and call handle_consensus_event directly.
+    {
+        use hashgraph_like_consensus::api::ConsensusServiceAPI;
+        let scope = group.to_string();
+        // Try to get the payload — if the proposal resolved, this should work
+        if let Ok(payload) = cs.get_proposal_payload(&scope, pid).await {
+            // We know it resolved. Build a ConsensusReached event.
+            let ev = hashgraph_like_consensus::types::ConsensusEvent::ConsensusReached {
+                proposal_id: pid,
+                result: true,
+                timestamp: 0,
+            };
+            let mut all: Vec<&mut TU> = vec![steward, joiner];
+            for (u, _) in others.iter_mut() {
+                all.push(u);
+            }
+            for u in all.iter_mut() {
+                let _ = u.handle_consensus_event(group, ev.clone()).await;
+            }
+            let _ = payload; // suppress unused warning
+        }
+    }
+
+    // Steward epoch → freeze → commit
+    steward.start_steward_epoch(group).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    steward.check_freeze_timeout(group).await;
+
+    // Deliver welcome/commit
+    for p in steward_h.drain_packets() {
+        let _ = joiner.process_inbound_packet(to_in(&p)).await;
+        for (u, _) in others.iter_mut() {
+            let _ = u.process_inbound_packet(to_in(&p)).await;
+        }
+    }
+}
+
+/// Submit ECP from `submitter`, have everyone vote YES, apply consensus result directly.
+async fn approve_ecp(
+    submitter: &mut TU,
+    submitter_h: &H,
+    request: GroupUpdateRequest,
+    group: &str,
+    voters: &mut [(&mut TU, &H)],
+    cs: &DefaultConsensusService,
+) {
+    submitter
+        .start_voting_on_request_background(group.to_string(), request)
+        .await
+        .unwrap();
+    settle().await;
+
+    let pid = submitter_h
+        .last_vote_pid()
+        .expect("should have ECP VotePayload");
+
+    // Submitter auto-voted YES on creation. Relay proposal to voters.
+    for p in submitter_h.drain_packets() {
+        for (u, _) in voters.iter_mut() {
+            let _ = u.process_inbound_packet(to_in(&p)).await;
+        }
+    }
+    settle().await;
+
+    // Voters vote YES
+    for (u, h) in voters.iter_mut() {
+        let _ = u.process_user_vote(group, pid, true).await;
+        for p in h.drain_packets() {
+            let _ = submitter.process_inbound_packet(to_in(&p)).await;
+        }
+    }
+    settle().await;
+
+    // Directly dispatch the consensus event to all users
+    {
+        use hashgraph_like_consensus::api::ConsensusServiceAPI;
+        let scope = group.to_string();
+        if (cs.get_proposal_payload(&scope, pid).await).is_ok() {
+            let ev = hashgraph_like_consensus::types::ConsensusEvent::ConsensusReached {
+                proposal_id: pid,
+                result: true,
+                timestamp: 0,
+            };
+            let mut all: Vec<&mut TU> = vec![submitter];
+            for (u, _) in voters.iter_mut() {
+                all.push(u);
+            }
+            for u in all.iter_mut() {
+                let _ = u.handle_consensus_event(group, ev.clone()).await;
+            }
+        }
+    }
+    settle().await;
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+/// Full pipeline: penalties → threshold → auto SCORE_BELOW_THRESHOLD ECP → RemoveMember.
+#[tokio::test]
+async fn test_user_layer_score_removal_pipeline() {
+    let group = "score-removal";
+    let cfg = GroupConfig {
+        epoch_duration: Duration::from_secs(60),
+        freeze_duration: Duration::from_millis(10),
+        allow_subset_candidates: false,
+    };
+    let cs = Arc::new(DefaultConsensusService::new_with_max_sessions(100));
+
+    let (mut alice, ah) = make(ALICE_KEY, cs.clone(), cfg.clone());
+    let (mut bob, bh) = make(BOB_KEY, cs.clone(), cfg.clone());
+    let (mut charlie, ch) = make(CHARLIE_KEY, cs.clone(), cfg.clone());
+
+    // Step 1: Create group + join Bob + Charlie
+    alice.create_group(group, true).await.unwrap();
+
+    bob.create_group(group, false).await.unwrap();
+    do_join(&mut alice, &ah, &mut bob, &bh, &mut [], &cs, group).await;
+    assert_eq!(
+        bob.get_group_state(group).await.unwrap(),
+        GroupState::Working
+    );
+
+    charlie.create_group(group, false).await.unwrap();
+    do_join(
+        &mut alice,
+        &ah,
+        &mut charlie,
+        &ch,
+        &mut [(&mut bob, &bh)],
+        &cs,
+        group,
+    )
+    .await;
+    assert_eq!(
+        charlie.get_group_state(group).await.unwrap(),
+        GroupState::Working
+    );
+
+    assert_eq!(alice.get_group_members(group).await.unwrap().len(), 3);
+
+    // Step 2: Initial scores = 100
+    for (_, score) in alice.get_member_scores(group) {
+        assert_eq!(score, 100);
+    }
+
+    let bob_bytes = de_mls::mls_crypto::parse_wallet_to_bytes(&bob.identity_string()).unwrap();
+    let alice_bytes = de_mls::mls_crypto::parse_wallet_to_bytes(&alice.identity_string()).unwrap();
+
+    // Step 3: ECP #1 (BrokenCommit against Bob) → Bob goes 100→50
+    let ecp1 = ViolationEvidence::broken_commit(bob_bytes.clone(), 0, Vec::<u8>::new())
+        .with_creator(alice_bytes.clone())
+        .into_update_request()
+        .unwrap();
+
+    approve_ecp(
+        &mut alice,
+        &ah,
+        ecp1,
+        group,
+        &mut [(&mut bob, &bh), (&mut charlie, &ch)],
+        &cs,
+    )
+    .await;
+
+    assert_eq!(alice.get_member_score(group, &bob_bytes), Some(50));
+    assert_eq!(alice.get_member_score(group, &alice_bytes), Some(120));
+
+    // Step 4: ECP #2 (BrokenCommit against Bob) → Bob goes 50→0
+    let ecp2 = ViolationEvidence::broken_commit(bob_bytes.clone(), 0, Vec::<u8>::new())
+        .with_creator(alice_bytes.clone())
+        .into_update_request()
+        .unwrap();
+
+    approve_ecp(
+        &mut alice,
+        &ah,
+        ecp2,
+        group,
+        &mut [(&mut bob, &bh), (&mut charlie, &ch)],
+        &cs,
+    )
+    .await;
+
+    assert_eq!(alice.get_member_score(group, &bob_bytes), Some(0));
+
+    // Step 5: Steward should have auto-created SCORE_BELOW_THRESHOLD ECP.
+    // check_and_initiate_score_removals runs inside handle_consensus_event.
+    settle().await;
+
+    // Check that the SCORE_BELOW_THRESHOLD ECP was created
+    let removal_created = ah.drain_app_msgs().iter().any(|msg| {
+        if let Some(app_message::Payload::VotePayload(vp)) = &msg.payload {
+            if let Ok(req) = GroupUpdateRequest::decode(vp.payload.as_slice()) {
+                if let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload {
+                    if let Some(ev) = &ec.evidence {
+                        return ViolationType::try_from(ev.violation_type)
+                            == Ok(ViolationType::ScoreBelowThreshold)
+                            && ev.target_member_id == bob_bytes;
+                    }
+                }
+            }
+        }
+        false
+    });
+
+    assert!(
+        removal_created,
+        "Steward should have auto-created a SCORE_BELOW_THRESHOLD ECP for Bob"
+    );
+
+    // The core transformation (ECP YES → RemoveMember in approved queue) is
+    // thoroughly tested in steward_triggered_removal.rs. Here we verified the
+    // full User-layer pipeline: penalties → threshold detection → auto ECP creation.
+}
+
+/// Accepted ECP updates scores consistently on all nodes.
+#[tokio::test]
+async fn test_ecp_scores_applied_on_all_nodes() {
+    let group = "score-sync";
+    let cfg = GroupConfig {
+        epoch_duration: Duration::from_secs(60),
+        freeze_duration: Duration::from_millis(10),
+        allow_subset_candidates: false,
+    };
+    let cs = Arc::new(DefaultConsensusService::new_with_max_sessions(100));
+
+    let (mut alice, ah) = make(ALICE_KEY, cs.clone(), cfg.clone());
+    let (mut bob, bh) = make(BOB_KEY, cs.clone(), cfg.clone());
+
+    alice.create_group(group, true).await.unwrap();
+    bob.create_group(group, false).await.unwrap();
+    do_join(&mut alice, &ah, &mut bob, &bh, &mut [], &cs, group).await;
+    assert_eq!(
+        bob.get_group_state(group).await.unwrap(),
+        GroupState::Working
+    );
+
+    let bob_bytes = de_mls::mls_crypto::parse_wallet_to_bytes(&bob.identity_string()).unwrap();
+    let alice_bytes = de_mls::mls_crypto::parse_wallet_to_bytes(&alice.identity_string()).unwrap();
+
+    let ecp = ViolationEvidence::broken_mls_proposal(bob_bytes.clone(), 0, Vec::<u8>::new())
+        .with_creator(alice_bytes.clone())
+        .into_update_request()
+        .unwrap();
+
+    approve_ecp(&mut alice, &ah, ecp, group, &mut [(&mut bob, &bh)], &cs).await;
+
+    // Both nodes should agree
+    assert_eq!(alice.get_member_score(group, &bob_bytes), Some(70));
+    assert_eq!(bob.get_member_score(group, &bob_bytes), Some(70));
+    assert_eq!(alice.get_member_score(group, &alice_bytes), Some(120));
+    assert_eq!(bob.get_member_score(group, &alice_bytes), Some(120));
+}

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -1,0 +1,338 @@
+//! Tests for D3: Steward-Triggered Removal.
+//!
+//! Verifies the flow: score drops below threshold → steward creates
+//! SCORE_BELOW_THRESHOLD ECP → consensus vote → YES transforms into
+//! RemoveMember in approved queue (or NO penalizes creator).
+
+use std::collections::HashMap;
+
+use prost::Message;
+
+use de_mls::app::{
+    FixedScoringProvider, GroupStateMachine, InMemoryPeerScoreStorage, PeerScoringService,
+};
+use de_mls::core::{ScoreEvent, ScoringConfig, apply_consensus_result, create_group};
+use de_mls::mls_crypto::{MemoryDeMlsStorage, MlsService, parse_wallet_address};
+use de_mls::protos::de_mls::messages::v1::{
+    ViolationEvidence, ViolationType, group_update_request,
+};
+
+// ─────────────────────────── Helpers ───────────────────────────
+
+const DEFAULT_SCORE: i64 = 100;
+const REMOVAL_THRESHOLD: i64 = 0;
+
+fn setup_mls(wallet_hex: &str) -> MlsService<MemoryDeMlsStorage> {
+    let storage = MemoryDeMlsStorage::new();
+    let mls = MlsService::new(storage);
+    let wallet = parse_wallet_address(wallet_hex).unwrap();
+    mls.init(wallet).unwrap();
+    mls
+}
+
+fn default_deltas() -> HashMap<ScoreEvent, i64> {
+    HashMap::from([
+        (ScoreEvent::BrokenCommit, -50),
+        (ScoreEvent::BrokenMlsProposal, -30),
+        (ScoreEvent::CensorshipInactivity, -40),
+        (ScoreEvent::ScoreBelowThreshold, -50),
+        (ScoreEvent::EmergencyYesCreator, 20),
+        (ScoreEvent::EmergencyNoCreator, -50),
+        (ScoreEvent::SuccessfulCommit, 10),
+        (ScoreEvent::NonFinalizedProposalCommit, -30),
+    ])
+}
+
+fn make_scoring() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
+    PeerScoringService::new(
+        InMemoryPeerScoreStorage::new(),
+        FixedScoringProvider::new(default_deltas()),
+        ScoringConfig {
+            default_score: DEFAULT_SCORE,
+            removal_threshold: REMOVAL_THRESHOLD,
+        },
+    )
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+/// ECP YES for SCORE_BELOW_THRESHOLD: RemoveMember appears in approved queue + correct score ops.
+#[test]
+fn test_score_below_threshold_yes_transforms_to_remove_member() {
+    let group_name = "removal-yes";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let mut handle = create_group(group_name, &alice_mls).unwrap();
+    let steward_id = alice_mls.wallet_bytes();
+
+    let target_id = vec![0xBB];
+    let proposal_id = 100;
+
+    // Steward creates SCORE_BELOW_THRESHOLD ECP
+    let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, -10)
+        .with_creator(steward_id.clone());
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+
+    // Owner path: store in voting queue first
+    handle.store_voting_proposal(proposal_id, request);
+
+    // Consensus approves
+    let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
+
+    // Score ops: target penalized + creator rewarded
+    assert_eq!(result.score_ops.len(), 2);
+    assert_eq!(result.score_ops[0].member_id, target_id);
+    assert_eq!(result.score_ops[0].event, ScoreEvent::ScoreBelowThreshold);
+    assert_eq!(result.score_ops[1].member_id, steward_id);
+    assert_eq!(result.score_ops[1].event, ScoreEvent::EmergencyYesCreator);
+
+    // RemoveMember should be in the approved queue (transformed from ECP)
+    assert_eq!(handle.approved_proposals_count(), 1);
+    let approved = handle.approved_proposals();
+    let (_, gur) = approved.iter().next().unwrap();
+    match &gur.payload {
+        Some(group_update_request::Payload::RemoveMember(rm)) => {
+            assert_eq!(rm.identity, target_id);
+        }
+        other => panic!("Expected RemoveMember, got {:?}", other),
+    }
+}
+
+/// ECP YES for SCORE_BELOW_THRESHOLD (non-owner path): RemoveMember in approved queue.
+#[test]
+fn test_score_below_threshold_yes_non_owner() {
+    let group_name = "removal-yes-nonowner";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let mut handle = create_group(group_name, &alice_mls).unwrap();
+
+    let target_id = vec![0xBB];
+    let creator_id = vec![0xCC]; // someone else
+    let proposal_id = 101;
+
+    let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, -5)
+        .with_creator(creator_id.clone());
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+
+    // Non-owner: do NOT store in voting queue
+    let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
+
+    // Score ops still produced
+    assert_eq!(result.score_ops.len(), 2);
+
+    // RemoveMember should be in approved queue
+    assert_eq!(handle.approved_proposals_count(), 1);
+    let approved = handle.approved_proposals();
+    let (_, gur) = approved.iter().next().unwrap();
+    match &gur.payload {
+        Some(group_update_request::Payload::RemoveMember(rm)) => {
+            assert_eq!(rm.identity, target_id);
+        }
+        other => panic!("Expected RemoveMember, got {:?}", other),
+    }
+}
+
+/// ECP NO for SCORE_BELOW_THRESHOLD: no RemoveMember, creator penalized.
+#[test]
+fn test_score_below_threshold_no_penalizes_creator() {
+    let group_name = "removal-no";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let mut handle = create_group(group_name, &alice_mls).unwrap();
+    let steward_id = alice_mls.wallet_bytes();
+
+    let target_id = vec![0xBB];
+    let proposal_id = 102;
+
+    let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, -10)
+        .with_creator(steward_id.clone());
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+
+    handle.store_voting_proposal(proposal_id, request);
+
+    // Consensus rejects
+    let result = apply_consensus_result(&mut handle, proposal_id, false, &payload).unwrap();
+
+    // Creator penalized, target unaffected
+    assert_eq!(result.score_ops.len(), 1);
+    assert_eq!(result.score_ops[0].member_id, steward_id);
+    assert_eq!(result.score_ops[0].event, ScoreEvent::EmergencyNoCreator);
+
+    // No RemoveMember in approved queue
+    assert_eq!(handle.approved_proposals_count(), 0);
+}
+
+/// Full pipeline: penalties → below threshold → ECP → YES → RemoveMember in queue.
+#[test]
+fn test_full_pipeline_penalties_to_removal() {
+    let group_name = "removal-pipeline";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let mut handle = create_group(group_name, &alice_mls).unwrap();
+    let steward_id = alice_mls.wallet_bytes();
+    let target_id = vec![0xDD];
+
+    let mut scoring = make_scoring();
+    scoring.add_member(group_name, &steward_id);
+    scoring.add_member(group_name, &target_id);
+
+    // Apply penalties until target drops below threshold
+    // 100 - 50 = 50 (BrokenCommit)
+    scoring.apply_event(group_name, &target_id, ScoreEvent::BrokenCommit);
+    assert!(!scoring.is_below_threshold(group_name, &target_id));
+
+    // 50 - 50 = 0 (EmergencyNoCreator)
+    scoring.apply_event(group_name, &target_id, ScoreEvent::EmergencyNoCreator);
+    assert!(scoring.is_below_threshold(group_name, &target_id));
+
+    // Now steward creates SCORE_BELOW_THRESHOLD ECP
+    let below = scoring.members_below_threshold(group_name);
+    assert!(below.contains(&target_id));
+
+    let current_score = scoring.score_for(group_name, &target_id).unwrap();
+    let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, current_score)
+        .with_creator(steward_id.clone());
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+
+    let proposal_id = 200;
+    handle.store_voting_proposal(proposal_id, request);
+
+    // Consensus approves
+    let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
+
+    // Apply score ops
+    for op in &result.score_ops {
+        scoring.apply_event(group_name, &op.member_id, op.event);
+    }
+
+    // RemoveMember should be in approved queue
+    assert_eq!(handle.approved_proposals_count(), 1);
+    let approved = handle.approved_proposals();
+    let (_, gur) = approved.iter().next().unwrap();
+    match &gur.payload {
+        Some(group_update_request::Payload::RemoveMember(rm)) => {
+            assert_eq!(rm.identity, target_id);
+        }
+        other => panic!("Expected RemoveMember, got {:?}", other),
+    }
+}
+
+/// Dedup: state machine prevents duplicate ECP for same target.
+#[test]
+fn test_dedup_pending_removal_targets() {
+    let mut sm = GroupStateMachine::new_as_steward();
+    let target = vec![0xAA];
+
+    assert!(!sm.has_pending_removal_for(&target));
+
+    sm.observe_removal_target(target.clone());
+    assert!(sm.has_pending_removal_for(&target));
+
+    // Second observation is idempotent
+    sm.observe_removal_target(target.clone());
+    assert!(sm.has_pending_removal_for(&target));
+
+    // Resolve clears it
+    sm.resolve_removal_target(&target);
+    assert!(!sm.has_pending_removal_for(&target));
+}
+
+/// Self-guard: steward skips itself when checking members below threshold.
+#[test]
+fn test_steward_skips_self_for_removal() {
+    let group_name = "removal-self-guard";
+    let mut scoring = make_scoring();
+
+    let steward_id = vec![0x01];
+    let other_id = vec![0x02];
+
+    scoring.add_member(group_name, &steward_id);
+    scoring.add_member(group_name, &other_id);
+
+    // Drop both below threshold
+    scoring.apply_event(group_name, &steward_id, ScoreEvent::BrokenCommit);
+    scoring.apply_event(group_name, &steward_id, ScoreEvent::EmergencyNoCreator);
+    scoring.apply_event(group_name, &other_id, ScoreEvent::BrokenCommit);
+    scoring.apply_event(group_name, &other_id, ScoreEvent::EmergencyNoCreator);
+
+    assert!(scoring.is_below_threshold(group_name, &steward_id));
+    assert!(scoring.is_below_threshold(group_name, &other_id));
+
+    // Filter as the steward would
+    let targets: Vec<Vec<u8>> = scoring
+        .members_below_threshold(group_name)
+        .into_iter()
+        .filter(|id| *id != steward_id)
+        .collect();
+
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0], other_id);
+}
+
+/// ViolationEvidence::score_below_threshold constructor correctness.
+#[test]
+fn test_violation_evidence_score_below_threshold_constructor() {
+    let target = vec![0xAA, 0xBB];
+    let epoch = 42;
+    let score = -15_i64;
+
+    let ev = ViolationEvidence::score_below_threshold(target.clone(), epoch, score);
+
+    assert_eq!(ev.violation_type, ViolationType::ScoreBelowThreshold as i32);
+    assert_eq!(ev.target_member_id, target);
+    assert_eq!(ev.epoch, epoch);
+    assert_eq!(ev.evidence_payload, score.to_le_bytes().to_vec());
+    assert!(ev.creator_member_id.is_empty());
+
+    // with_creator works
+    let creator = vec![0xCC];
+    let ev = ev.with_creator(creator.clone());
+    assert_eq!(ev.creator_member_id, creator);
+
+    // into_update_request works
+    let gur = ev.into_update_request().unwrap();
+    match &gur.payload {
+        Some(group_update_request::Payload::EmergencyCriteria(ec)) => {
+            let inner_ev = ec.evidence.as_ref().unwrap();
+            assert_eq!(
+                inner_ev.violation_type,
+                ViolationType::ScoreBelowThreshold as i32
+            );
+            assert_eq!(inner_ev.target_member_id, target);
+        }
+        other => panic!("Expected EmergencyCriteria, got {:?}", other),
+    }
+}
+
+/// Regular (non-score) emergency YES still removes from approved queue (no transform).
+#[test]
+fn test_regular_emergency_yes_no_transform() {
+    let group_name = "no-transform";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let mut handle = create_group(group_name, &alice_mls).unwrap();
+
+    let target_id = vec![0xBB];
+    let creator_id = alice_mls.wallet_bytes();
+    let proposal_id = 300;
+
+    // Regular violation (not score-below-threshold)
+    let evidence = ViolationEvidence::broken_commit(target_id.clone(), 0, Vec::<u8>::new())
+        .with_creator(creator_id);
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+
+    handle.store_voting_proposal(proposal_id, request);
+
+    let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
+
+    // Score ops present (it's an accepted emergency)
+    assert_eq!(result.score_ops.len(), 2);
+
+    // But NO RemoveMember in approved queue (regular emergencies are consumed)
+    assert_eq!(handle.approved_proposals_count(), 0);
+}

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -35,7 +35,6 @@ fn default_deltas() -> HashMap<ScoreEvent, i64> {
         (ScoreEvent::BrokenCommit, -50),
         (ScoreEvent::BrokenMlsProposal, -30),
         (ScoreEvent::CensorshipInactivity, -40),
-        (ScoreEvent::ScoreBelowThreshold, -50),
         (ScoreEvent::EmergencyYesCreator, 20),
         (ScoreEvent::EmergencyNoCreator, -50),
         (ScoreEvent::SuccessfulCommit, 10),
@@ -80,12 +79,10 @@ fn test_score_below_threshold_yes_transforms_to_remove_member() {
     // Consensus approves
     let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
 
-    // Score ops: target penalized + creator rewarded
-    assert_eq!(result.score_ops.len(), 2);
-    assert_eq!(result.score_ops[0].member_id, target_id);
-    assert_eq!(result.score_ops[0].event, ScoreEvent::ScoreBelowThreshold);
-    assert_eq!(result.score_ops[1].member_id, steward_id);
-    assert_eq!(result.score_ops[1].event, ScoreEvent::EmergencyYesCreator);
+    // Score ops: creator rewarded only (target already at threshold, penalty skipped)
+    assert_eq!(result.score_ops.len(), 1);
+    assert_eq!(result.score_ops[0].member_id, steward_id);
+    assert_eq!(result.score_ops[0].event, ScoreEvent::EmergencyYesCreator);
 
     // RemoveMember should be in the approved queue (transformed from ECP)
     assert_eq!(handle.approved_proposals_count(), 1);
@@ -119,8 +116,9 @@ fn test_score_below_threshold_yes_non_owner() {
     // Non-owner: do NOT store in voting queue
     let result = apply_consensus_result(&mut handle, proposal_id, true, &payload).unwrap();
 
-    // Score ops still produced
-    assert_eq!(result.score_ops.len(), 2);
+    // Score ops: creator rewarded only (target penalty skipped)
+    assert_eq!(result.score_ops.len(), 1);
+    assert_eq!(result.score_ops[0].event, ScoreEvent::EmergencyYesCreator);
 
     // RemoveMember should be in approved queue
     assert_eq!(handle.approved_proposals_count(), 1);


### PR DESCRIPTION
## Summary
Complete M1 Peer Scoring milestone: steward-triggered removal per RFC §Peer Scoring — when a member's score drops to/below the removal threshold, the steward initiates a SCORE_BELOW_THRESHOLD ECP via consensus. Approved ECP transforms into RemoveMember in the approved queue (single vote, no double consensus round). This is the final piece needed before M2 (Multi-Steward).

## Changes
- `application.proto` — add `SCORE_BELOW_THRESHOLD = 4` to ViolationType
- `src/core/consensus.rs` — approved SCORE_BELOW_THRESHOLD ECP transforms into RemoveMember in approved queue (owner + non-owner paths); skip redundant target penalty
- `src/core/types.rs` — `ViolationEvidence::score_below_threshold()` constructor
- `src/app/state_machine.rs` — `pending_removal_targets` HashSet for dedup (observe/has/resolve)
- `src/app/user.rs` — `check_and_initiate_score_removals()` called after score ops in `handle_consensus_event`; cleanup on failure
- `src/app/display.rs`, `src/app/message_type.rs` — display labels for new violation type
- `crates/de_mls_gateway/src/forwarder.rs` — `push_member_scores()` after consensus events
- `tests/steward_triggered_removal.rs` — 8 core-level tests (transform, reject, pipeline, dedup, self-guard, constructor)
- `tests/async_scoring_removal.rs` — 2 async User-layer tests (full 3-node pipeline, cross-node score consistency)

## Tests 
- Verify ECP YES transforms to RemoveMember: `test_score_below_threshold_yes_transforms_to_remove_member`
- Verify ECP NO penalizes creator only: `test_score_below_threshold_no_penalizes_creator`
- Verify full User-layer pipeline (3 nodes, penalties → threshold → auto ECP): `test_user_layer_score_removal_pipeline`
- Verify score consistency across nodes: `test_ecp_scores_applied_on_all_nodes`