### PR TITLE
feat(core): enhance steward list generation and validation

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -144,6 +144,7 @@ mod group_update_handle;
 mod peer_scoring;
 mod proposal_priority;
 mod provider;
+mod steward_list;
 mod types;
 
 // ── Core group operations ──
@@ -173,6 +174,9 @@ pub use group_update_handle::ProposalId;
 
 // ── Proposal priority ──
 pub use proposal_priority::ProposalPriority;
+
+// ── Steward list ──
+pub use steward_list::{StewardList, StewardListConfig};
 
 // ── Provider traits ──
 pub use provider::{DeMlsProvider, DefaultProvider};

--- a/src/core/steward_list.rs
+++ b/src/core/steward_list.rs
@@ -1,0 +1,544 @@
+//! Deterministic steward list generation and rotation.
+//!
+//! The steward list is an ordered list of member identities that determines
+//! who creates commits for each epoch. All members independently derive the
+//! same list using `SHA256(epoch || member_id || group_id)` sorting.
+//!
+//! # Generation Algorithm (RFC §Steward list creation)
+//!
+//! 1. For each candidate member, compute `SHA256(epoch || member_id || group_id)`
+//! 2. Sort candidates in ascending order by hash value
+//! 3. Take the first `sn` members (`sn_min ≤ sn ≤ sn_max`)
+//!
+//! # Rotation
+//!
+//! - **Epoch steward**: steward at index `epoch % list_len`
+//! - **Backup steward**: steward at index `(epoch + 1) % list_len`
+//!
+//! When all stewards have served (epoch reaches `start_epoch + list_len`),
+//! the list is exhausted and a new election MUST be initiated.
+
+use sha2::{Digest, Sha256};
+
+/// Configuration for steward list size bounds, set at group creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StewardListConfig {
+    /// Minimum steward list size. If total members < sn_min, list size = total members.
+    pub sn_min: usize,
+    /// Maximum steward list size.
+    pub sn_max: usize,
+}
+
+impl StewardListConfig {
+    /// Create a new config with the given bounds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sn_min` is 0 or `sn_min > sn_max`.
+    pub fn new(sn_min: usize, sn_max: usize) -> Self {
+        assert!(sn_min >= 1, "sn_min must be at least 1");
+        assert!(sn_min <= sn_max, "sn_min must be <= sn_max");
+        Self { sn_min, sn_max }
+    }
+
+    /// Check if a given list size is valid for this config and member count.
+    pub fn is_valid_size(&self, size: usize, total_members: usize) -> bool {
+        if total_members < self.sn_min {
+            // RFC: if total members < sn_min, list size = total member count
+            size == total_members
+        } else {
+            size >= self.sn_min && size <= self.sn_max && size <= total_members
+        }
+    }
+}
+
+/// An ordered list of steward identities for a range of epochs.
+///
+/// Generated deterministically so all group members arrive at the same list.
+/// The list covers epochs `[start_epoch, start_epoch + len)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StewardList {
+    /// Ordered steward identities (sorted by deterministic hash).
+    members: Vec<Vec<u8>>,
+    /// Configuration bounds.
+    config: StewardListConfig,
+    /// The epoch at which this steward list became active.
+    start_epoch: u64,
+}
+
+impl StewardList {
+    /// Generate a deterministic steward list from the given members.
+    ///
+    /// Sorts candidates by `SHA256(epoch || member_id || group_id)` and takes
+    /// the first `sn` entries. The `sn` parameter controls list size and must
+    /// satisfy `sn_min ≤ sn ≤ sn_max` (or equal total members if below sn_min).
+    ///
+    /// Returns `None` if:
+    /// - `member_ids` is empty
+    /// - `sn` is not valid for the config and member count
+    pub fn generate(
+        election_epoch: u64,
+        group_id: &[u8],
+        member_ids: &[Vec<u8>],
+        sn: usize,
+        config: StewardListConfig,
+    ) -> Option<Self> {
+        if member_ids.is_empty() {
+            return None;
+        }
+
+        if !config.is_valid_size(sn, member_ids.len()) {
+            return None;
+        }
+
+        let mut scored: Vec<(Vec<u8>, Vec<u8>)> = member_ids
+            .iter()
+            .map(|member_id| {
+                let hash = compute_steward_hash(election_epoch, member_id, group_id);
+                (hash, member_id.clone())
+            })
+            .collect();
+
+        // Sort ascending by hash value
+        scored.sort_by(|(hash_a, _), (hash_b, _)| hash_a.cmp(hash_b));
+
+        let members: Vec<Vec<u8>> = scored.into_iter().take(sn).map(|(_, id)| id).collect();
+
+        Some(Self {
+            members,
+            config,
+            start_epoch: election_epoch,
+        })
+    }
+
+    /// Validate that a proposed steward list matches the deterministic generation.
+    ///
+    /// Returns `true` if `proposed` equals the list that `generate()` would produce
+    /// with the same parameters.
+    pub fn validate(
+        proposed: &[Vec<u8>],
+        election_epoch: u64,
+        group_id: &[u8],
+        member_ids: &[Vec<u8>],
+        config: &StewardListConfig,
+    ) -> bool {
+        let sn = proposed.len();
+        let Some(expected) =
+            StewardList::generate(election_epoch, group_id, member_ids, sn, config.clone())
+        else {
+            return false;
+        };
+        expected.members == proposed
+    }
+
+    /// Get the epoch steward for the given epoch.
+    ///
+    /// The epoch steward is at index `(epoch - start_epoch) % len`.
+    /// Returns `None` if the list is exhausted for this epoch.
+    pub fn epoch_steward(&self, epoch: u64) -> Option<&[u8]> {
+        if self.is_exhausted(epoch) {
+            return None;
+        }
+        let index = ((epoch - self.start_epoch) as usize) % self.members.len();
+        Some(&self.members[index])
+    }
+
+    /// Get the backup steward for the given epoch.
+    ///
+    /// The backup steward is at index `(epoch - start_epoch + 1) % len`.
+    /// Returns `None` if the list is exhausted for this epoch.
+    pub fn backup_steward(&self, epoch: u64) -> Option<&[u8]> {
+        if self.is_exhausted(epoch) {
+            return None;
+        }
+        let index = ((epoch - self.start_epoch) as usize + 1) % self.members.len();
+        Some(&self.members[index])
+    }
+
+    /// Check if the list is exhausted at the given epoch.
+    ///
+    /// The list covers epochs `[start_epoch, start_epoch + len)`. Once all
+    /// stewards have served, a new election MUST be initiated.
+    pub fn is_exhausted(&self, epoch: u64) -> bool {
+        if epoch < self.start_epoch {
+            return true;
+        }
+        (epoch - self.start_epoch) >= self.members.len() as u64
+    }
+
+    /// Check if a member is in the steward list.
+    pub fn contains(&self, member_id: &[u8]) -> bool {
+        self.members.iter().any(|m| m.as_slice() == member_id)
+    }
+
+    /// Check if a member is the epoch steward for the given epoch.
+    pub fn is_epoch_steward(&self, member_id: &[u8], epoch: u64) -> bool {
+        self.epoch_steward(epoch).is_some_and(|s| s == member_id)
+    }
+
+    /// Get the ordered steward identities.
+    pub fn members(&self) -> &[Vec<u8>] {
+        &self.members
+    }
+
+    /// Get the number of stewards in the list.
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Check if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// Get the config.
+    pub fn config(&self) -> &StewardListConfig {
+        &self.config
+    }
+
+    /// Get the start epoch.
+    pub fn start_epoch(&self) -> u64 {
+        self.start_epoch
+    }
+
+    /// Get the last epoch this list covers (inclusive).
+    pub fn last_epoch(&self) -> u64 {
+        self.start_epoch + self.members.len() as u64 - 1
+    }
+}
+
+/// Compute the deterministic hash for steward list sorting.
+///
+/// `SHA256(epoch || member_id || group_id)` where epoch is big-endian u64.
+fn compute_steward_hash(epoch: u64, member_id: &[u8], group_id: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(epoch.to_be_bytes());
+    hasher.update(member_id);
+    hasher.update(group_id);
+    hasher.finalize().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn member(id: u8) -> Vec<u8> {
+        vec![id; 20] // 20-byte member id
+    }
+
+    fn members(ids: &[u8]) -> Vec<Vec<u8>> {
+        ids.iter().map(|&id| member(id)).collect()
+    }
+
+    #[test]
+    fn test_config_validation() {
+        let config = StewardListConfig::new(2, 5);
+
+        // Normal range
+        assert!(config.is_valid_size(3, 10));
+        assert!(config.is_valid_size(2, 10));
+        assert!(config.is_valid_size(5, 10));
+
+        // Out of range
+        assert!(!config.is_valid_size(1, 10));
+        assert!(!config.is_valid_size(6, 10));
+
+        // Below sn_min members: list size must equal total
+        assert!(config.is_valid_size(1, 1));
+        assert!(!config.is_valid_size(2, 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "sn_min must be at least 1")]
+    fn test_config_zero_sn_min() {
+        StewardListConfig::new(0, 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "sn_min must be <= sn_max")]
+    fn test_config_min_exceeds_max() {
+        StewardListConfig::new(5, 3);
+    }
+
+    #[test]
+    fn test_generate_empty_members() {
+        let config = StewardListConfig::new(1, 3);
+        assert!(StewardList::generate(0, b"group1", &[], 1, config).is_none());
+    }
+
+    #[test]
+    fn test_generate_invalid_sn() {
+        let config = StewardListConfig::new(2, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        // sn below sn_min
+        assert!(StewardList::generate(0, b"group1", &mems, 1, config.clone()).is_none());
+        // sn above sn_max
+        assert!(StewardList::generate(0, b"group1", &mems, 6, config).is_none());
+    }
+
+    #[test]
+    fn test_deterministic_generation() {
+        let config = StewardListConfig::new(2, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+        let group_id = b"test-group";
+
+        let list1 = StewardList::generate(0, group_id, &mems, 3, config.clone()).unwrap();
+        let list2 = StewardList::generate(0, group_id, &mems, 3, config).unwrap();
+
+        assert_eq!(list1.members(), list2.members());
+        assert_eq!(list1.len(), 3);
+    }
+
+    #[test]
+    fn test_different_epoch_shuffles() {
+        // Use all members so the set is the same; order must differ for at least one epoch.
+        let config = StewardListConfig::new(5, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let base = StewardList::generate(0, b"group", &mems, 5, config.clone()).unwrap();
+        let any_diff = (1..10).any(|e| {
+            let other = StewardList::generate(e, b"group", &mems, 5, config.clone()).unwrap();
+            other.members() != base.members()
+        });
+        assert!(any_diff);
+    }
+
+    #[test]
+    fn test_different_group_shuffles() {
+        let config = StewardListConfig::new(5, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let base = StewardList::generate(0, b"group1", &mems, 5, config.clone()).unwrap();
+        let other = StewardList::generate(0, b"group2", &mems, 5, config).unwrap();
+        // With 5! = 120 possible orderings, collision is extremely unlikely
+        assert_ne!(base.members(), other.members());
+    }
+
+    #[test]
+    fn test_member_order_does_not_affect_result() {
+        let config = StewardListConfig::new(2, 5);
+        let mems_a = members(&[1, 2, 3, 4, 5]);
+        let mems_b = members(&[5, 3, 1, 4, 2]);
+
+        let list_a = StewardList::generate(0, b"group", &mems_a, 3, config.clone()).unwrap();
+        let list_b = StewardList::generate(0, b"group", &mems_b, 3, config).unwrap();
+
+        assert_eq!(list_a.members(), list_b.members());
+    }
+
+    #[test]
+    fn test_epoch_steward_rotation() {
+        let config = StewardListConfig::new(3, 3);
+        let mems = members(&[1, 2, 3]);
+
+        let list = StewardList::generate(0, b"group", &mems, 3, config).unwrap();
+        let s0 = list.epoch_steward(0).unwrap().to_vec();
+        let s1 = list.epoch_steward(1).unwrap().to_vec();
+        let s2 = list.epoch_steward(2).unwrap().to_vec();
+
+        // All three stewards should be different (different members)
+        assert_ne!(s0, s1);
+        assert_ne!(s1, s2);
+        assert_ne!(s0, s2);
+    }
+
+    #[test]
+    fn test_backup_steward() {
+        let config = StewardListConfig::new(3, 3);
+        let mems = members(&[1, 2, 3]);
+
+        let list = StewardList::generate(0, b"group", &mems, 3, config).unwrap();
+
+        // Backup for epoch 0 should be epoch steward for epoch 1
+        assert_eq!(
+            list.backup_steward(0).unwrap(),
+            list.epoch_steward(1).unwrap()
+        );
+        // Backup for epoch 1 should be epoch steward for epoch 2
+        assert_eq!(
+            list.backup_steward(1).unwrap(),
+            list.epoch_steward(2).unwrap()
+        );
+        // Backup for epoch 2 wraps around to epoch steward for epoch 0
+        assert_eq!(
+            list.backup_steward(2).unwrap(),
+            list.epoch_steward(0).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_list_exhaustion() {
+        let config = StewardListConfig::new(2, 3);
+        let mems = members(&[1, 2, 3]);
+
+        let list = StewardList::generate(5, b"group", &mems, 3, config).unwrap();
+        assert_eq!(list.start_epoch(), 5);
+        assert_eq!(list.last_epoch(), 7);
+
+        // Epochs 5, 6, 7 are covered
+        assert!(!list.is_exhausted(5));
+        assert!(!list.is_exhausted(6));
+        assert!(!list.is_exhausted(7));
+
+        // Epoch 8 is exhausted
+        assert!(list.is_exhausted(8));
+
+        // Before start is also exhausted
+        assert!(list.is_exhausted(4));
+    }
+
+    #[test]
+    fn test_exhausted_returns_none() {
+        let config = StewardListConfig::new(2, 2);
+        let mems = members(&[1, 2]);
+
+        let list = StewardList::generate(0, b"group", &mems, 2, config).unwrap();
+
+        assert!(list.epoch_steward(2).is_none());
+        assert!(list.backup_steward(2).is_none());
+    }
+
+    #[test]
+    fn test_validate_correct_list() {
+        let config = StewardListConfig::new(2, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let list = StewardList::generate(0, b"group", &mems, 3, config.clone()).unwrap();
+        assert!(StewardList::validate(
+            list.members(),
+            0,
+            b"group",
+            &mems,
+            &config,
+        ));
+    }
+
+    #[test]
+    fn test_validate_tampered_list() {
+        let config = StewardListConfig::new(2, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let mut list = StewardList::generate(0, b"group", &mems, 3, config.clone()).unwrap();
+        // Swap first two members
+        list.members.swap(0, 1);
+
+        assert!(!StewardList::validate(
+            list.members(),
+            0,
+            b"group",
+            &mems,
+            &config,
+        ));
+    }
+
+    #[test]
+    fn test_validate_wrong_epoch() {
+        let config = StewardListConfig::new(5, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let list = StewardList::generate(0, b"group", &mems, 5, config.clone()).unwrap();
+        // Find an epoch that produces a different ordering
+        let diff_epoch = (1..100u64)
+            .find(|&e| {
+                let o = StewardList::generate(e, b"group", &mems, 5, config.clone()).unwrap();
+                o.members() != list.members()
+            })
+            .expect("should differ within 100 epochs");
+
+        assert!(!StewardList::validate(
+            list.members(),
+            diff_epoch,
+            b"group",
+            &mems,
+            &config,
+        ));
+    }
+
+    #[test]
+    fn test_validate_wrong_members() {
+        // Use full selection so any change in the candidate set changes the output.
+        let config = StewardListConfig::new(5, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+        let other_mems = members(&[1, 2, 3, 4, 6]); // different member 6
+
+        let list = StewardList::generate(0, b"group", &mems, 5, config.clone()).unwrap();
+        assert!(!StewardList::validate(
+            list.members(),
+            0,
+            b"group",
+            &other_mems,
+            &config,
+        ));
+    }
+
+    #[test]
+    fn test_contains() {
+        let config = StewardListConfig::new(2, 3);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let list = StewardList::generate(0, b"group", &mems, 3, config).unwrap();
+
+        // Some of the 5 members should be in the list of 3
+        let in_list: Vec<bool> = (1..=5).map(|id| list.contains(&member(id))).collect();
+        assert_eq!(in_list.iter().filter(|&&b| b).count(), 3);
+    }
+
+    #[test]
+    fn test_is_epoch_steward() {
+        let config = StewardListConfig::new(2, 3);
+        let mems = members(&[1, 2, 3]);
+
+        let list = StewardList::generate(0, b"group", &mems, 3, config).unwrap();
+        let steward_0 = list.epoch_steward(0).unwrap().to_vec();
+
+        assert!(list.is_epoch_steward(&steward_0, 0));
+        // The epoch-0 steward is not necessarily the epoch-1 steward
+        // (unless the list has only 1 member)
+    }
+
+    #[test]
+    fn test_below_sn_min_uses_total_members() {
+        // sn_min=3 but only 2 members — list size must be 2
+        let config = StewardListConfig::new(3, 5);
+        let mems = members(&[1, 2]);
+
+        let list = StewardList::generate(0, b"group", &mems, 2, config).unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_single_member() {
+        let config = StewardListConfig::new(1, 3);
+        let mems = members(&[1]);
+
+        let list = StewardList::generate(0, b"group", &mems, 1, config).unwrap();
+        assert_eq!(list.len(), 1);
+
+        // Same steward for every epoch in range
+        assert_eq!(
+            list.epoch_steward(0).unwrap(),
+            list.backup_steward(0).unwrap()
+        );
+        assert!(list.is_exhausted(1));
+    }
+
+    #[test]
+    fn test_sha256_sorting_is_ascending() {
+        let config = StewardListConfig::new(5, 5);
+        let mems = members(&[1, 2, 3, 4, 5]);
+
+        let list = StewardList::generate(0, b"group", &mems, 5, config).unwrap();
+
+        // Verify that the list is sorted by ascending hash
+        let hashes: Vec<Vec<u8>> = list
+            .members()
+            .iter()
+            .map(|m| compute_steward_hash(0, m, b"group"))
+            .collect();
+
+        for window in hashes.windows(2) {
+            assert!(window[0] < window[1], "hashes must be in ascending order");
+        }
+    }
+}

--- a/tests/core_steward_list.rs
+++ b/tests/core_steward_list.rs
@@ -1,0 +1,315 @@
+use de_mls::core::{StewardList, StewardListConfig};
+
+fn member(id: u8) -> Vec<u8> {
+    vec![id; 20]
+}
+
+fn members(ids: &[u8]) -> Vec<Vec<u8>> {
+    ids.iter().map(|&id| member(id)).collect()
+}
+
+const GROUP: &[u8] = b"test-group";
+
+// ── Deterministic generation ──────────────────────────────────────
+
+#[test]
+fn deterministic_same_inputs_same_output() {
+    let config = StewardListConfig::new(3, 5);
+    let mems = members(&[1, 2, 3, 4, 5]);
+
+    let list1 = StewardList::generate(0, GROUP, &mems, 3, config.clone()).unwrap();
+    let list2 = StewardList::generate(0, GROUP, &mems, 3, config).unwrap();
+
+    assert_eq!(list1.members(), list2.members());
+}
+
+#[test]
+fn input_order_does_not_matter() {
+    let config = StewardListConfig::new(3, 5);
+
+    let list_a =
+        StewardList::generate(0, GROUP, &members(&[1, 2, 3, 4, 5]), 3, config.clone()).unwrap();
+    let list_b = StewardList::generate(0, GROUP, &members(&[5, 3, 1, 4, 2]), 3, config).unwrap();
+
+    assert_eq!(list_a.members(), list_b.members());
+}
+
+#[test]
+fn different_epoch_shuffles_order() {
+    // With all 10 members selected, the set is identical but the ordering
+    // must differ for at least one pair of epochs out of 10 trials.
+    let config = StewardListConfig::new(10, 10);
+    let mems: Vec<Vec<u8>> = (1..=10).map(member).collect();
+
+    let base = StewardList::generate(0, GROUP, &mems, 10, config.clone()).unwrap();
+    let any_different = (1..10).any(|epoch| {
+        let other = StewardList::generate(epoch, GROUP, &mems, 10, config.clone()).unwrap();
+        other.members() != base.members()
+    });
+    assert!(
+        any_different,
+        "at least one epoch must produce a different ordering"
+    );
+}
+
+#[test]
+fn different_group_shuffles_order() {
+    // Same logic: full selection, at least one of several group IDs must differ.
+    let config = StewardListConfig::new(10, 10);
+    let mems: Vec<Vec<u8>> = (1..=10).map(member).collect();
+
+    let base = StewardList::generate(0, b"group-0", &mems, 10, config.clone()).unwrap();
+    let any_different = (1..10).any(|i| {
+        let gid = format!("group-{i}");
+        let other = StewardList::generate(0, gid.as_bytes(), &mems, 10, config.clone()).unwrap();
+        other.members() != base.members()
+    });
+    assert!(
+        any_different,
+        "at least one group must produce a different ordering"
+    );
+}
+
+// ── Epoch steward and backup rotation ─────────────────────────────
+
+#[test]
+fn epoch_steward_rotates_through_all_members() {
+    let config = StewardListConfig::new(3, 3);
+    let mems = members(&[1, 2, 3]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config).unwrap();
+
+    let s0 = list.epoch_steward(0).unwrap().to_vec();
+    let s1 = list.epoch_steward(1).unwrap().to_vec();
+    let s2 = list.epoch_steward(2).unwrap().to_vec();
+
+    // All three are different
+    assert_ne!(s0, s1);
+    assert_ne!(s1, s2);
+    assert_ne!(s0, s2);
+
+    // All three are from the members list
+    assert!(list.contains(&s0));
+    assert!(list.contains(&s1));
+    assert!(list.contains(&s2));
+}
+
+#[test]
+fn backup_steward_is_next_epoch_steward() {
+    let config = StewardListConfig::new(3, 3);
+    let mems = members(&[1, 2, 3]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config).unwrap();
+
+    assert_eq!(
+        list.backup_steward(0).unwrap(),
+        list.epoch_steward(1).unwrap()
+    );
+    assert_eq!(
+        list.backup_steward(1).unwrap(),
+        list.epoch_steward(2).unwrap()
+    );
+    // Backup wraps around
+    assert_eq!(
+        list.backup_steward(2).unwrap(),
+        list.epoch_steward(0).unwrap()
+    );
+}
+
+#[test]
+fn start_epoch_offset() {
+    let config = StewardListConfig::new(2, 3);
+    let mems = members(&[1, 2, 3]);
+
+    // List starts at epoch 10
+    let list = StewardList::generate(10, GROUP, &mems, 3, config).unwrap();
+
+    assert_eq!(list.start_epoch(), 10);
+    assert_eq!(list.last_epoch(), 12);
+
+    // Epochs before start are exhausted
+    assert!(list.is_exhausted(9));
+
+    // Epochs 10-12 are valid
+    assert!(list.epoch_steward(10).is_some());
+    assert!(list.epoch_steward(11).is_some());
+    assert!(list.epoch_steward(12).is_some());
+
+    // Epoch 13 is exhausted
+    assert!(list.is_exhausted(13));
+    assert!(list.epoch_steward(13).is_none());
+}
+
+// ── List exhaustion ───────────────────────────────────────────────
+
+#[test]
+fn exhaustion_detection() {
+    let config = StewardListConfig::new(2, 2);
+    let mems = members(&[1, 2]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 2, config).unwrap();
+
+    assert!(!list.is_exhausted(0));
+    assert!(!list.is_exhausted(1));
+    assert!(list.is_exhausted(2));
+}
+
+#[test]
+fn exhausted_epoch_returns_none() {
+    let config = StewardListConfig::new(2, 2);
+    let mems = members(&[1, 2]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 2, config).unwrap();
+
+    assert!(list.epoch_steward(2).is_none());
+    assert!(list.backup_steward(2).is_none());
+}
+
+// ── Validation ────────────────────────────────────────────────────
+
+#[test]
+fn validate_correct_list() {
+    let config = StewardListConfig::new(3, 5);
+    let mems = members(&[1, 2, 3, 4, 5]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config.clone()).unwrap();
+    assert!(StewardList::validate(
+        list.members(),
+        0,
+        GROUP,
+        &mems,
+        &config
+    ));
+}
+
+#[test]
+fn validate_rejects_tampered_order() {
+    let config = StewardListConfig::new(3, 5);
+    let mems = members(&[1, 2, 3, 4, 5]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config.clone()).unwrap();
+    let mut tampered = list.members().to_vec();
+    tampered.swap(0, 1);
+
+    assert!(!StewardList::validate(&tampered, 0, GROUP, &mems, &config));
+}
+
+#[test]
+fn validate_rejects_wrong_epoch() {
+    // Use full selection (all 10 members) so the ordering is epoch-sensitive.
+    let config = StewardListConfig::new(10, 10);
+    let mems: Vec<Vec<u8>> = (1..=10).map(member).collect();
+
+    let list = StewardList::generate(0, GROUP, &mems, 10, config.clone()).unwrap();
+
+    // Find an epoch whose ordering differs from epoch 0
+    let mismatched_epoch = (1..100u64)
+        .find(|&e| {
+            let other = StewardList::generate(e, GROUP, &mems, 10, config.clone()).unwrap();
+            other.members() != list.members()
+        })
+        .expect("should find a different ordering within 100 epochs");
+
+    assert!(!StewardList::validate(
+        list.members(),
+        mismatched_epoch,
+        GROUP,
+        &mems,
+        &config
+    ));
+}
+
+#[test]
+fn validate_rejects_substituted_member() {
+    let config = StewardListConfig::new(3, 5);
+    let mems = members(&[1, 2, 3, 4, 5]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config.clone()).unwrap();
+    let mut substituted = list.members().to_vec();
+    // Replace first member with someone not in the original generation
+    substituted[0] = member(99);
+
+    assert!(!StewardList::validate(
+        &substituted,
+        0,
+        GROUP,
+        &mems,
+        &config
+    ));
+}
+
+#[test]
+fn validate_rejects_empty_list() {
+    let config = StewardListConfig::new(3, 5);
+    let mems = members(&[1, 2, 3, 4, 5]);
+    let empty: Vec<Vec<u8>> = vec![];
+
+    assert!(!StewardList::validate(&empty, 0, GROUP, &mems, &config));
+}
+
+// ── Edge cases ────────────────────────────────────────────────────
+
+#[test]
+fn single_member_group() {
+    let config = StewardListConfig::new(1, 3);
+    let mems = members(&[1]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 1, config).unwrap();
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(
+        list.epoch_steward(0).unwrap(),
+        list.backup_steward(0).unwrap()
+    );
+    assert!(list.is_exhausted(1));
+}
+
+#[test]
+fn below_sn_min_uses_all_members() {
+    // sn_min=5 but only 3 members
+    let config = StewardListConfig::new(5, 10);
+    let mems = members(&[1, 2, 3]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config).unwrap();
+    assert_eq!(list.len(), 3);
+}
+
+#[test]
+fn is_epoch_steward_check() {
+    let config = StewardListConfig::new(3, 3);
+    let mems = members(&[1, 2, 3]);
+
+    let list = StewardList::generate(0, GROUP, &mems, 3, config).unwrap();
+    let epoch_0_steward = list.epoch_steward(0).unwrap().to_vec();
+
+    assert!(list.is_epoch_steward(&epoch_0_steward, 0));
+
+    // Non-steward member should return false
+    let non_steward = if epoch_0_steward == list.members()[1] {
+        list.members()[2].clone()
+    } else {
+        list.members()[1].clone()
+    };
+    assert!(!list.is_epoch_steward(&non_steward, 0));
+}
+
+#[test]
+fn generate_returns_none_for_empty_members() {
+    let config = StewardListConfig::new(1, 3);
+    assert!(StewardList::generate(0, GROUP, &[], 1, config).is_none());
+}
+
+#[test]
+fn large_group_subset_selection() {
+    let config = StewardListConfig::new(3, 5);
+    // 20 members, select top 5
+    let mems: Vec<Vec<u8>> = (1..=20).map(member).collect();
+
+    let list = StewardList::generate(0, GROUP, &mems, 5, config).unwrap();
+    assert_eq!(list.len(), 5);
+
+    // All selected members should be from the input
+    for steward in list.members() {
+        assert!(mems.contains(steward));
+    }
+}


### PR DESCRIPTION
## Summary
- Complete: Steward list data structures — the foundation for multi-steward support (critical path)
- Implements RFC §Steward list creation: deterministic SHA256(epoch || member_id || group_id) sorting, epoch rotation, backup steward, exhaustion detection, and proposal validation

## Changes
- `src/core/steward_list.rs` — new module: `StewardListConfig` (sn_min/sn_max bounds), `StewardList` (deterministic generation, epoch_steward/backup_steward rotation, is_exhausted, validate)
- `src/core/mod.rs` — module declaration + public exports
- `tests/core_steward_list.rs` — 19 integration tests covering determinism, rotation, exhaustion, validation, and edge cases