### PR TITLE
feat(core): group sync — retry_round as list-frozen tag

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+pub use crate::core::DEFAULT_MAX_REELECTION_RETRIES;
 use crate::core::ProtocolConfig;
 
 pub const DEFAULT_EPOCH_DURATION: Duration = Duration::from_secs(60);
@@ -14,10 +15,6 @@ pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
 /// strictly less than `consensus_timeout` so the auto-vote has time to
 /// propagate and land in every peer's session before the library deadline.
 pub const DEFAULT_VOTING_DELAY: Duration = Duration::from_secs(10);
-
-/// One retry gives the responsible proposer a second shot with a different
-/// list composition; beyond that human/policy intervention is expected.
-pub const DEFAULT_MAX_REELECTION_RETRIES: u32 = 1;
 
 /// Under the Δ-synchrony assumption every honest voter reaches a decision
 /// within `consensus_timeout`; counting silent voters as YES keeps small

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -143,6 +143,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 election.election_epoch,
                 &election.proposed_stewards,
                 election.proposed_stewards.len(),
+                election.retry_round,
             )?;
             entry.group.reset_reelection_round();
             if entry.state_machine.current_state() == GroupState::Reelection {
@@ -178,9 +179,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 return;
             };
             entry.group.bump_reelection_round();
+            // Read the ceiling from the group, not the user-level default:
+            // joiners honor the group's configured policy via `GroupSync`.
             (
                 entry.group.reelection_round(),
-                self.default_group_config.max_reelection_retries,
+                entry.group.max_reelection_retries(),
             )
         };
         if round > max {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -313,10 +313,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     sync.start_epoch,
                     &sync.steward_members,
                     sn,
+                    sync.retry_round,
                 )?;
                 entry
                     .group
                     .set_allow_subset_candidates(sync.allow_subset_candidates);
+                entry
+                    .group
+                    .set_max_reelection_retries(sync.max_reelection_retries);
                 if let Some(timing) = &sync.timing {
                     let epoch_dur = std::time::Duration::from_millis(timing.epoch_duration_ms);
                     let freeze_dur = std::time::Duration::from_millis(timing.freeze_duration_ms);

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -38,7 +38,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             return Err(UserError::GroupAlreadyExists);
         }
 
-        let (group, state_machine) = if is_creation {
+        let max_reelection_retries = config.max_reelection_retries;
+        let (mut group, state_machine) = if is_creation {
             let group = create_group(group_name, &self.mls_service, config.protocol.clone())?;
             let state_machine = GroupStateMachine::new_as_member_with_config(config);
             (group, state_machine)
@@ -51,6 +52,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             let state_machine = GroupStateMachine::new_as_pending_join_with_config(config);
             (group, state_machine)
         };
+        group.set_max_reelection_retries(max_reelection_retries);
 
         let initial_state = state_machine.current_state();
         if initial_state == GroupState::PendingJoin {

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -68,9 +68,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 .group
                 .protocol_config()
                 .compute_list_size(members.len());
+            // sn_min auto-fill isn't an election outcome — no retry seed.
             entry
                 .group
-                .generate_and_set_steward_list(epoch, &members, sn)?;
+                .generate_and_set_steward_list(epoch, &members, sn, 0)?;
         }
 
         Ok(())
@@ -179,9 +180,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .group
             .protocol_config()
             .compute_list_size(members.len());
+        // Test/admin regenerate — no election, no retry seed.
         entry
             .group
-            .generate_and_set_steward_list(current_epoch, &members, sn)?;
+            .generate_and_set_steward_list(current_epoch, &members, sn, 0)?;
         Ok(())
     }
 
@@ -328,6 +330,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     as u64,
             };
 
+            // `retry_round` is the seed that produced the *stored* list —
+            // a frozen tag on `StewardList`, not `Group::reelection_round`
+            // (the dynamic counter for the next attempt, which resets to 0
+            // on accept). Joiners re-derive the ordering from this seed.
             let sync = GroupSync {
                 steward_members: list.members().to_vec(),
                 start_epoch: list.start_epoch(),
@@ -336,7 +342,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 allow_subset_candidates: entry.group.allow_subset_candidates(),
                 peer_scores: scores,
                 timing: Some(timing),
-                retry_round: entry.group.reelection_round(),
+                retry_round: list.retry_round(),
+                max_reelection_retries: entry.group.max_reelection_retries(),
             };
 
             let app_msg: AppMessage = sync.into();

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -132,11 +132,22 @@ pub struct Group {
     /// [`StewardList::generate`] so each retry proposes a different
     /// list composition.
     reelection_round: u32,
+    /// Group-configured ceiling on steward-election retries before the
+    /// "stuck" error surfaces. Every member in the group holds the same
+    /// value — joiners pick it up from `GroupSync` — so the error path
+    /// triggers consistently across the group. Overridden at group
+    /// creation from `GroupConfig`; defaults to [`DEFAULT_MAX_REELECTION_RETRIES`].
+    max_reelection_retries: u32,
     /// Proposal IDs already dispatched through `apply_consensus_outcome`.
     /// The consensus library can re-emit `ConsensusReached` (timeout-path
     /// race); this guards against re-applying state and double-firing events.
     consensus_outcomes_applied: HashSet<ProposalId>,
 }
+
+/// Fallback ceiling on steward-election retries. One retry gives the
+/// responsible proposer a second shot with a different list composition;
+/// beyond that human/policy intervention is expected.
+pub const DEFAULT_MAX_REELECTION_RETRIES: u32 = 1;
 
 impl Group {
     fn new_base(group_name: &str, self_identity: Vec<u8>, protocol_config: ProtocolConfig) -> Self {
@@ -154,6 +165,7 @@ impl Group {
             freeze_round: None,
             pending_updates: HashMap::new(),
             reelection_round: 0,
+            max_reelection_retries: DEFAULT_MAX_REELECTION_RETRIES,
             consensus_outcomes_applied: HashSet::new(),
         }
     }
@@ -192,7 +204,7 @@ impl Group {
             &[creator_identity],
             1,
             protocol_config,
-            0,
+            0, // initial list — no election, no retries
         )?;
         group.steward_list = Some(list);
 
@@ -414,15 +426,27 @@ impl Group {
     }
 
     /// Generate a steward list and set it on the group.
+    ///
+    /// `retry_round` is the seed fed into the SHA256 sort and stored on the
+    /// resulting list as its historical tag. Pass the round from the
+    /// accepted election proposal; use 0 for the creator's initial list and
+    /// for `sn_min` auto-fills, where no election happened.
     pub fn generate_and_set_steward_list(
         &mut self,
         epoch: u64,
         member_ids: &[Vec<u8>],
         sn: usize,
+        retry_round: u32,
     ) -> Result<(), CoreError> {
         let config = self.protocol_config.clone();
-        let list =
-            StewardList::generate(epoch, self.group_name.as_bytes(), member_ids, sn, config, 0)?;
+        let list = StewardList::generate(
+            epoch,
+            self.group_name.as_bytes(),
+            member_ids,
+            sn,
+            config,
+            retry_round,
+        )?;
         self.steward_list = Some(list);
         Ok(())
     }
@@ -666,6 +690,18 @@ impl Group {
         self.reelection_round = 0;
     }
 
+    /// Group-configured ceiling on retries before the stuck-election error
+    /// surfaces. Shared across the group via `GroupSync`.
+    pub fn max_reelection_retries(&self) -> u32 {
+        self.max_reelection_retries
+    }
+
+    /// Overwrite the retry ceiling. Called from group-creation (from
+    /// `GroupConfig`) and on joiner sync (from `GroupSync.max_reelection_retries`).
+    pub fn set_max_reelection_retries(&mut self, max: u32) {
+        self.max_reelection_retries = max;
+    }
+
     fn has_pending_remove(&self, identity: &[u8]) -> bool {
         self.pending_updates
             .get(identity)
@@ -791,7 +827,7 @@ mod tests {
         assert!(group.steward_list().is_none());
 
         let mems = members(&[1, 2, 3]);
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         assert!(group.steward_list().is_some());
         assert_eq!(group.steward_list().unwrap().len(), 3);
@@ -818,7 +854,7 @@ mod tests {
         assert_eq!(group.steward_list().unwrap().len(), 1);
 
         let mems = members(&[1, 2, 3, 4]);
-        assert!(group.generate_and_set_steward_list(1, &mems, 4).is_ok());
+        assert!(group.generate_and_set_steward_list(1, &mems, 4, 0).is_ok());
 
         let list = group.steward_list().unwrap();
         assert_eq!(list.len(), 4);
@@ -833,7 +869,7 @@ mod tests {
         assert!(!group.is_steward());
 
         let mems = members(&[1, 2, 3]);
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
         assert!(group.is_steward());
 
         let outsider = Group::new_as_joiner("test-group", member(99), default_config());
@@ -845,7 +881,7 @@ mod tests {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         let leaver = member(2);
         assert_eq!(group.approved_proposals_count(), 0);
@@ -872,7 +908,7 @@ mod tests {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         // One auto-approved leave + one consensus-approved proposal.
         let leaver = member(2);
@@ -904,7 +940,7 @@ mod tests {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         let leaver = member(2);
         group.accept_auto_approved_leave(leaver.clone());
@@ -926,7 +962,7 @@ mod tests {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         let target = member(2);
         let ban_remove = GroupUpdateRequest {
@@ -949,7 +985,7 @@ mod tests {
         let config = ProtocolConfig::new(3, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         let nominal = group.epoch_steward(0).unwrap().to_vec();
         assert_eq!(group.live_epoch_steward(0, &mems), Some(nominal.as_slice()));

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,7 +42,9 @@ pub use error::CoreError;
 pub use events::{CallbackError, GroupEventHandler};
 
 // ── Group state ──
-pub use group::{Group, PendingUpdate, ProposalId, target_identity_of};
+pub use group::{
+    DEFAULT_MAX_REELECTION_RETRIES, Group, PendingUpdate, ProposalId, target_identity_of,
+};
 
 // ── Proposal classification ──
 pub use proposal_kind::ProposalKind;

--- a/src/core/steward_list.rs
+++ b/src/core/steward_list.rs
@@ -72,6 +72,11 @@ pub struct StewardList {
     config: ProtocolConfig,
     /// The epoch at which this steward list became active.
     start_epoch: u64,
+    /// The retry-round seed fed into the SHA256 sort that produced this list.
+    /// Historical tag — frozen once the list is accepted. Distinct from
+    /// `Group::reelection_round`, which is the dynamic counter for the
+    /// *next* election attempt.
+    retry_round: u32,
 }
 
 impl StewardList {
@@ -97,6 +102,7 @@ impl StewardList {
             members,
             config,
             start_epoch: election_epoch,
+            retry_round,
         })
     }
 
@@ -228,6 +234,13 @@ impl StewardList {
 
     pub fn start_epoch(&self) -> u64 {
         self.start_epoch
+    }
+
+    /// Historical tag — the retry-round seed that was fed into the SHA256
+    /// sort when this list was accepted. Joiners carry this value in
+    /// `GroupSync` so they can re-derive the same ordering.
+    pub fn retry_round(&self) -> u32 {
+        self.retry_round
     }
 }
 

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -116,6 +116,10 @@ message GroupSync {
   // Retry round the accepted steward list was generated with. Joiners
   // need this to reproduce the deterministic sort when validating.
   uint32 retry_round = 8;
+  // Group's configured ceiling on election retries. Joiners apply this
+  // value so the stuck-election error path triggers consistently across
+  // the group.
+  uint32 max_reelection_retries = 9;
 }
 
 message PeerScore {

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -364,7 +364,7 @@ fn test_auto_fill_steward_list_triggers_below_sn_min() {
     let sn = members_2.len().min(config.sn_max);
     assert!(
         steward_handle
-            .generate_and_set_steward_list(epoch, &members_2, sn)
+            .generate_and_set_steward_list(epoch, &members_2, sn, 0)
             .is_ok()
     );
 
@@ -458,6 +458,7 @@ fn test_group_sync_roundtrip() {
         peer_scores: vec![],
         timing: None,
         retry_round: 0,
+        max_reelection_retries: 1,
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
@@ -515,7 +516,12 @@ fn test_group_sync_roundtrip() {
         let sn = sync.steward_members.len();
         assert!(
             joiner_handle
-                .generate_and_set_steward_list(sync.start_epoch, &sync.steward_members, sn,)
+                .generate_and_set_steward_list(
+                    sync.start_epoch,
+                    &sync.steward_members,
+                    sn,
+                    sync.retry_round,
+                )
                 .is_ok()
         );
     }
@@ -560,7 +566,7 @@ fn test_group_sync_idempotent_for_existing_members() {
     let members = group_members(&joiner_handle, &joiner_mls).unwrap();
     assert!(
         joiner_handle
-            .generate_and_set_steward_list(0, &members, 1)
+            .generate_and_set_steward_list(0, &members, 1, 0)
             .is_ok()
     );
     assert!(joiner_handle.steward_list().is_some());
@@ -576,6 +582,7 @@ fn test_group_sync_idempotent_for_existing_members() {
         peer_scores: vec![],
         timing: None,
         retry_round: 0,
+        max_reelection_retries: 1,
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet =
@@ -600,5 +607,110 @@ fn test_group_sync_idempotent_for_existing_members() {
         joiner_handle.steward_list().unwrap().len(),
         1,
         "Existing list should be preserved (1 member), not overwritten by sync"
+    );
+}
+
+/// A list accepted at `retry_round > 0` must ship its generation seed
+/// on `GroupSync` so the joiner re-derives the same ordering. The seed
+/// lives on `StewardList` as a frozen tag, distinct from
+/// `Group::reelection_round` (the dynamic counter, which resets to 0
+/// on accept). Sourcing the wire `retry_round` from the list keeps the
+/// two values from diverging after an accept.
+#[test]
+fn test_group_sync_carries_list_retry_round_not_group_counter() {
+    let group_name = "sync-retry-tag-group";
+    let steward_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let joiner_hex = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+    let extra1_hex = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
+    let extra2_hex = "0x90F79bf6EB2c4f870365E785982E1f101E93b906";
+
+    // sn=4 over 4 members: retry_round affects ordering, not membership.
+    let config = ProtocolConfig::new(2, 4).unwrap();
+    let (steward_mls, mut steward_handle) =
+        setup_steward_with_config(group_name, steward_hex, config.clone());
+
+    // Pull three joiners into the MLS group so we have a four-member set
+    // for a meaningful hash-sorted list.
+    for hex in [joiner_hex, extra1_hex, extra2_hex] {
+        let (_, _, kp) = setup_joiner_with_config(group_name, hex, config.clone());
+        steward_add_joiner(&steward_mls, &mut steward_handle, &kp);
+    }
+    let members = group_members(&steward_handle, &steward_mls).unwrap();
+    assert_eq!(members.len(), 4);
+
+    // Simulate an election accepted after two rejections: the resulting
+    // list is generated at retry_round=2 and stored with that tag.
+    let epoch = steward_mls.current_epoch(group_name).unwrap();
+    let accepted_round: u32 = 2;
+    steward_handle
+        .generate_and_set_steward_list(epoch, &members, 4, accepted_round)
+        .unwrap();
+    // Accept-side bookkeeping: the dynamic counter clears; the list's
+    // seed is unaffected.
+    steward_handle.reset_reelection_round();
+
+    let list = steward_handle.steward_list().expect("list set above");
+    assert_eq!(list.retry_round(), accepted_round, "list keeps its seed");
+    assert_eq!(
+        steward_handle.reelection_round(),
+        0,
+        "counter was reset on accept — distinct from the list tag"
+    );
+
+    // The round-2 ordering must differ from round 0 for the assertion
+    // below to be meaningful — if they happened to match, the seed
+    // wouldn't be load-bearing.
+    let round0 =
+        StewardList::generate(epoch, group_name.as_bytes(), &members, 4, config.clone(), 0)
+            .unwrap();
+    assert_ne!(
+        list.members(),
+        round0.members(),
+        "test assumption: retry_round must shuffle the ordering"
+    );
+
+    // Build a GroupSync the way `send_group_sync` does — seed sourced
+    // from the list's `retry_round`.
+    use de_mls::protos::de_mls::messages::v1::GroupSync;
+    let sync = GroupSync {
+        steward_members: list.members().to_vec(),
+        start_epoch: list.start_epoch(),
+        sn_min: list.config().sn_min as u32,
+        sn_max: list.config().sn_max as u32,
+        allow_subset_candidates: false,
+        peer_scores: vec![],
+        timing: None,
+        retry_round: list.retry_round(),
+        max_reelection_retries: steward_handle.max_reelection_retries(),
+    };
+
+    // Joiner re-derives the ordering using the wire seed — should match.
+    assert!(
+        StewardList::validate(
+            &sync.steward_members,
+            sync.start_epoch,
+            group_name.as_bytes(),
+            &sync.steward_members,
+            &config,
+            sync.retry_round,
+        )
+        .unwrap(),
+        "joiner validates when the wire retry_round matches the list's seed"
+    );
+
+    // The counter's current value (0) regenerates a different ordering —
+    // confirms `retry_round`-on-list is load-bearing, not redundant with
+    // the counter.
+    assert!(
+        !StewardList::validate(
+            &sync.steward_members,
+            sync.start_epoch,
+            group_name.as_bytes(),
+            &sync.steward_members,
+            &config,
+            steward_handle.reelection_round(),
+        )
+        .unwrap(),
+        "the post-accept counter value (0) regenerates a different ordering"
     );
 }

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -457,10 +457,10 @@ fn test_backup_commit_scores_absent_steward() {
     let epoch = alice_mls.current_epoch(group_name).unwrap();
     let members = vec![alice_id.clone(), bob_id.clone()];
     alice_group
-        .generate_and_set_steward_list(epoch, &members, 2)
+        .generate_and_set_steward_list(epoch, &members, 2, 0)
         .unwrap();
     bob_group
-        .generate_and_set_steward_list(epoch, &members, 2)
+        .generate_and_set_steward_list(epoch, &members, 2, 0)
         .unwrap();
 
     // Produce an approved proposal (invite Charlie) on both sides.


### PR DESCRIPTION
StewardList now stores the retry_round it was generated under; send_group_sync reads the seed from the list instead of Group::reelection_round, which resets to 0 on accept and leaves the wire value mismatched with the list. Also adds max_reelection_retries to GroupSync so joiners honor the group-configured retry ceiling, and collapses the duplicate DEFAULT_MAX_REELECTION_RETRIES onto core.