### PR TITLE
fix(consensus): close self-leave consensus-scope asymmetry

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -203,9 +203,6 @@ impl Gateway<WakuDeliveryService> {
                 }
 
                 // Push refreshed approved queue + epoch history + members.
-                // Members refresh keeps the pending-leave badge visible
-                // without waiting for an explicit poll when a peer receives
-                // a LeaveRequest (or a commit that changes membership).
                 push_consensus_state(&user, &evt_tx, &group_id).await;
                 push_member_scores(&user, &evt_tx, &group_id).await;
             }

--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -4,18 +4,25 @@
 
 use alloy::signers::Signer;
 use prost::Message;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::info;
 
 use hashgraph_like_consensus::{
+    error::ConsensusError,
     protos::consensus::v1::{Proposal, Vote},
     session::ConsensusConfig,
     types::CreateProposalRequest,
+    utils::build_vote,
 };
 
 use crate::app::error::UserError;
-use crate::core::{CoreError, DeMlsProvider, Group, GroupEventHandler, ProviderConsensus};
-use crate::protos::de_mls::messages::v1::{AppMessage, GroupUpdateRequest, VotePayload};
+use crate::core::{
+    CoreError, DeMlsProvider, Group, GroupEventHandler, ProviderConsensus,
+    auto_approved_leave_proposal_id,
+};
+use crate::protos::de_mls::messages::v1::{
+    AppMessage, GroupUpdateRequest, RemoveMember, VotePayload, group_update_request,
+};
 
 /// Consensus-session parameters that come from `GroupConfig`. Grouped so
 /// [`submit_proposal`]'s argument list stays readable.
@@ -159,8 +166,6 @@ pub async fn forward_incoming_vote<P: DeMlsProvider>(
     vote: Vote,
     consensus: &ProviderConsensus<P>,
 ) -> Result<(), CoreError> {
-    use hashgraph_like_consensus::error::ConsensusError;
-
     let proposal_id = vote.proposal_id;
     let scope = P::Scope::from(group_name.to_string());
     match consensus.process_incoming_vote(&scope, vote).await {
@@ -190,5 +195,89 @@ pub async fn forward_incoming_vote<P: DeMlsProvider>(
             Ok(())
         }
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Open a self-leave consensus session with the leaver's YES vote bundled
+/// and `expected_voters_count = 1`.
+///
+/// Unlike [`submit_proposal`], this hand-crafts the `Proposal` so it carries
+/// the deterministic `auto_approved_leave_proposal_id(identity)`. Every node
+/// derives the same id from the MLS-authenticated sender, so a
+/// retransmitted self-leave dedupes natively via `ProposalAlreadyExist` and
+/// every node's `approved_proposals` entry ends up under the same key.
+///
+/// On the leaver's side the bundled YES vote (+ `expected_voters=1`) makes
+/// `from_proposal` fire `ConsensusReached(true)` synchronously, so the
+/// normal `apply_consensus_outcome` path can place `RemoveMember(self)` in
+/// `approved_proposals` with the deterministic id.
+///
+/// Returns `Ok(Some(...))` if the proposal was newly opened (caller must
+/// broadcast the `AppMessage`). Returns `Ok(None)` if the session already
+/// exists (e.g. the user double-clicked Leave and the dedup fired) — no
+/// broadcast needed. Other consensus errors propagate.
+pub async fn submit_self_leave_proposal<P, SN>(
+    group_name: &str,
+    self_identity: &[u8],
+    consensus: &ProviderConsensus<P>,
+    signer: SN,
+    params: ProposalParams,
+) -> Result<Option<(u32, AppMessage)>, UserError>
+where
+    P: DeMlsProvider,
+    SN: Signer + Send + Sync,
+{
+    let request = GroupUpdateRequest {
+        payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+            identity: self_identity.to_vec(),
+        })),
+    };
+    let payload = request.encode_to_vec();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(CoreError::from)?
+        .as_secs();
+    let expiration = now.saturating_add(params.proposal_expiration.as_secs());
+
+    let proposal_id = auto_approved_leave_proposal_id(self_identity);
+    let mut proposal = Proposal {
+        name: format!("self-leave:{proposal_id}"),
+        payload,
+        proposal_id,
+        proposal_owner: self_identity.to_vec(),
+        votes: Vec::new(),
+        expected_voters_count: params.expected_voters,
+        round: 1,
+        timestamp: now,
+        expiration_timestamp: expiration,
+        liveness_criteria_yes: params.liveness_criteria_yes,
+    };
+
+    let yes_vote = build_vote(&proposal, true, signer)
+        .await
+        .map_err(CoreError::from)?;
+    proposal.votes.push(yes_vote);
+
+    let scope = P::Scope::from(group_name.to_string());
+    match consensus
+        .process_incoming_proposal(&scope, proposal.clone())
+        .await
+    {
+        Ok(()) => {
+            info!(
+                group = group_name,
+                proposal_id, "self-leave proposal opened (expected_voters=1, bundled YES)"
+            );
+            Ok(Some((proposal_id, proposal.into())))
+        }
+        Err(ConsensusError::ProposalAlreadyExist) => {
+            info!(
+                group = group_name,
+                proposal_id, "self-leave already in flight, skipping retransmit"
+            );
+            Ok(None)
+        }
+        Err(e) => Err(CoreError::from(e).into()),
     }
 }

--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -143,24 +143,50 @@ pub async fn forward_incoming_proposal<P: DeMlsProvider>(
 
 /// Forward a peer's vote into the local consensus service.
 ///
-/// A late vote may arrive after our local session has been timeout-reaped
-/// (`SessionNotActive`). That's a benign race — consensus concluded locally —
-/// and we downgrade it to a debug log. Other consensus errors propagate.
+/// Late-arrival classification uses the `Group::is_consensus_outcome_applied`
+/// cache to tell benign late packets from suspicious unknowns:
+/// - `SessionNotActive` — session exists but already resolved. Benign, debug.
+/// - `SessionNotFound` with id in the resolved-proposals cache — session
+///   was trimmed after local resolution. Benign, debug.
+/// - `SessionNotFound` with id NOT in the cache — we never saw this
+///   proposal. Suspicious (spurious packet or lost proposal). Warn-log,
+///   swallow the error so inbound dispatch keeps draining.
+///
+/// Other consensus errors propagate.
 pub async fn forward_incoming_vote<P: DeMlsProvider>(
     group_name: &str,
+    group: &Group,
     vote: Vote,
     consensus: &ProviderConsensus<P>,
 ) -> Result<(), CoreError> {
     use hashgraph_like_consensus::error::ConsensusError;
 
+    let proposal_id = vote.proposal_id;
     let scope = P::Scope::from(group_name.to_string());
     match consensus.process_incoming_vote(&scope, vote).await {
         Ok(()) => Ok(()),
         Err(ConsensusError::SessionNotActive) => {
             tracing::debug!(
                 group = group_name,
+                proposal_id,
                 "late vote dropped: consensus session already resolved"
             );
+            Ok(())
+        }
+        Err(ConsensusError::SessionNotFound) => {
+            if group.is_consensus_outcome_applied(proposal_id) {
+                tracing::debug!(
+                    group = group_name,
+                    proposal_id,
+                    "late vote dropped: session trimmed after local resolution"
+                );
+            } else {
+                tracing::warn!(
+                    group = group_name,
+                    proposal_id,
+                    "vote for unknown proposal id dropped: no local session and not in resolved cache"
+                );
+            }
             Ok(())
         }
         Err(e) => Err(e.into()),

--- a/src/app/display.rs
+++ b/src/app/display.rs
@@ -44,7 +44,6 @@ pub mod message_types {
     pub const PROPOSAL_ADDED: &str = "ProposalAdded";
     pub const COMMIT_CANDIDATE: &str = "CommitCandidate";
     pub const GROUP_SYNC: &str = "GroupSync";
-    pub const LEAVE_REQUEST: &str = "LeaveRequest";
     pub const UNKNOWN: &str = "Unknown";
 }
 
@@ -66,7 +65,6 @@ impl MessageType for app_message::Payload {
             app_message::Payload::ProposalAdded(_) => PROPOSAL_ADDED,
             app_message::Payload::CommitCandidate(_) => COMMIT_CANDIDATE,
             app_message::Payload::GroupSync(_) => GROUP_SYNC,
-            app_message::Payload::LeaveRequest(_) => LEAVE_REQUEST,
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28,6 +28,7 @@ pub use config::{
 };
 pub use consensus_bridge::{
     ProposalParams, cast_vote, forward_incoming_proposal, forward_incoming_vote, submit_proposal,
+    submit_self_leave_proposal,
 };
 pub use display::{
     MemberRole, MessageType, format_group_request, format_group_request_target, message_types,

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -141,9 +141,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
         };
 
-        let scope = P::Scope::from(group_name.clone());
         tokio::time::sleep(self.default_group_config.consensus_timeout).await;
-        self.resolve_on_timeout(proposal_id, &scope).await;
+        self.resolve_on_timeout(&group_name, proposal_id).await;
     }
 
     /// Open the consensus session, record ownership, then either bundle
@@ -251,23 +250,58 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
     /// Resolve the proposal via the consensus library's timeout path if it's
     /// still in the active set.
-    async fn resolve_on_timeout(&self, proposal_id: u32, scope: &P::Scope) {
+    ///
+    /// The `still_active` guard eliminates the normal case where the session
+    /// has already resolved by the time the timer fires. A race can still slip
+    /// through (session resolved between the guard and the call); a
+    /// `SessionNotFound`/`SessionNotActive` in that window is benign as long
+    /// as the proposal is in our resolved-proposals cache — we downgrade the
+    /// log accordingly and warn only for truly unknown IDs (indicates a logic
+    /// bug, not a race).
+    async fn resolve_on_timeout(&self, group_name: &str, proposal_id: u32) {
+        use hashgraph_like_consensus::error::ConsensusError;
+
+        let scope = P::Scope::from(group_name.to_string());
         let still_active = self
             .consensus_service
             .storage()
-            .get_active_proposals(scope)
+            .get_active_proposals(&scope)
             .await
             .map(|active| active.iter().any(|p| p.proposal_id == proposal_id))
             .unwrap_or(false);
         if !still_active {
             return;
         }
-        if let Err(e) = self
+        match self
             .consensus_service
-            .handle_consensus_timeout(scope, proposal_id)
+            .handle_consensus_timeout(&scope, proposal_id)
             .await
         {
-            info!(proposal_id, error = %e, "timeout resolution skipped");
+            Ok(_) => {}
+            Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
+                let resolved_locally = {
+                    let groups = self.groups.read().await;
+                    groups
+                        .get(group_name)
+                        .is_some_and(|entry| entry.group.is_consensus_outcome_applied(proposal_id))
+                };
+                if resolved_locally {
+                    tracing::debug!(
+                        group = group_name,
+                        proposal_id,
+                        "timeout fired for already-resolved proposal: ignoring"
+                    );
+                } else {
+                    tracing::warn!(
+                        group = group_name,
+                        proposal_id,
+                        "timeout fired for unknown proposal id: no session and not in resolved cache"
+                    );
+                }
+            }
+            Err(e) => {
+                info!(proposal_id, error = %e, "timeout resolution skipped");
+            }
         }
     }
 

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -39,7 +39,16 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.on_incoming_proposal(group_name, proposal).await
             }
             ProcessResult::Vote(vote) => {
-                forward_incoming_vote::<P>(group_name, vote, &*self.consensus_service).await?;
+                let group = {
+                    let groups = self.groups.read().await;
+                    groups
+                        .get(group_name)
+                        .ok_or(UserError::GroupNotFound)?
+                        .group
+                        .clone()
+                };
+                forward_incoming_vote::<P>(group_name, &group, vote, &*self.consensus_service)
+                    .await?;
                 Ok(())
             }
             ProcessResult::MembershipChangeReceived(request) => {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -14,10 +14,8 @@ use crate::{
         build_message, create_commit_candidate, group_members, process_inbound,
     },
     ds::InboundPacket,
-    mls_crypto::ShortId,
     protos::de_mls::messages::v1::{
-        AppMessage, ConversationMessage, GroupSync, GroupUpdateRequest, LeaveRequest,
-        group_update_request,
+        AppMessage, ConversationMessage, GroupSync, GroupUpdateRequest, group_update_request,
     },
 };
 
@@ -62,9 +60,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.on_commit_candidate_received(group_name).await
             }
             ProcessResult::GroupSyncReceived(sync) => self.on_group_sync(group_name, sync).await,
-            ProcessResult::LeaveRequestReceived(leave) => {
-                self.on_leave_request(group_name, leave).await
-            }
             ProcessResult::Noop => Ok(()),
         }
     }
@@ -353,43 +348,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             timing = sync.timing.is_some(),
             "group sync applied"
         );
-        Ok(())
-    }
-
-    /// Signer/identity match has already been verified at the MLS decrypt
-    /// layer (see `process_app_subtopic`). We just need to confirm the
-    /// identity is a current group member before accepting the auto-removal.
-    async fn on_leave_request(
-        &self,
-        group_name: &str,
-        leave: LeaveRequest,
-    ) -> Result<(), UserError> {
-        let accepted = {
-            let mut groups = self.groups.write().await;
-            let Some(entry) = groups.get_mut(group_name) else {
-                return Ok(());
-            };
-            let members = group_members(&entry.group, &self.mls_service)?;
-            if !members.iter().any(|m| m == &leave.identity) {
-                tracing::warn!(
-                    group = group_name,
-                    sender = %ShortId(&leave.identity),
-                    "leave request ignored: sender not a current member"
-                );
-                false
-            } else {
-                entry
-                    .group
-                    .accept_auto_approved_leave(leave.identity.clone())
-            }
-        };
-        if accepted {
-            info!(
-                group = group_name,
-                identity = %ShortId(&leave.identity),
-                "leave accepted (auto-approved)"
-            );
-        }
         Ok(())
     }
 

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -4,12 +4,12 @@ use tracing::info;
 
 use crate::{
     app::{
-        GroupConfig, GroupState, GroupStateMachine, StateChangeHandler, User, UserError,
-        user::GroupEntry,
+        GroupConfig, GroupState, GroupStateMachine, ProposalParams, StateChangeHandler, User,
+        UserError, submit_self_leave_proposal, user::GroupEntry,
     },
     core::{DeMlsProvider, GroupEventHandler, build_message, create_group, prepare_to_join},
     mls_crypto::parse_wallet_to_bytes,
-    protos::de_mls::messages::v1::{AppMessage, LeaveRequest},
+    protos::de_mls::messages::v1::GroupUpdateRequest,
 };
 
 impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
@@ -84,16 +84,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         Ok(())
     }
 
-    /// Broadcast a signed `LeaveRequest` and locally accept it (deterministic
-    /// proposal id → approved queue, no consensus round). The next live
-    /// steward's commit includes the self-remove.
-    ///
-    /// The leaver stays fully active until that commit actually merges; at
-    /// that point `ProcessResult::LeaveGroup` fires and the UI closes the
-    /// view. This avoids a half-leave state — if the commit fails we just
-    /// stay a member and a later commit picks the leave up.
-    ///
-    /// `PendingJoin` short-circuits: nothing to leave, just tear down local state.
+    /// Submit `RemoveMember(self)` as an `expected_voters = 1` proposal with
+    /// the leaver's YES bundled, so the session resolves on submit. We stay
+    /// active until the next steward commit merges the removal; on that
+    /// commit `ProcessResult::LeaveGroup` fires. A failed commit leaves us
+    /// a member and a later one picks the leave up.
+    /// `PendingJoin` short-circuits to local teardown.
     pub async fn leave_group(&mut self, group_name: &str) -> Result<(), UserError> {
         info!(group = group_name, "leaving group");
 
@@ -113,7 +109,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         let self_identity = parse_wallet_to_bytes(&self.identity_string())?;
 
-        // Idempotent: second click after a broadcast is a no-op.
+        // Idempotent: a second click after a successful submit finds the
+        // approved entry and short-circuits.
         {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
@@ -126,25 +123,52 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
         }
 
-        // Build + MLS-encrypt + broadcast on the app subtopic.
+        let request = {
+            use crate::protos::de_mls::messages::v1::{RemoveMember, group_update_request};
+            GroupUpdateRequest {
+                payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                    identity: self_identity.clone(),
+                })),
+            }
+        };
+
+        // Register ownership BEFORE the session opens — the bundled YES
+        // fires `ConsensusReached` on submit, and `apply_consensus_result`
+        // needs `is_owner_of_proposal` to be true by then.
+        let proposal_id = crate::core::auto_approved_leave_proposal_id(&self_identity);
+        {
+            let mut groups = self.groups.write().await;
+            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            entry.group.store_voting_proposal(proposal_id, request);
+        }
+
+        let config = &self.default_group_config;
+        let submitted = submit_self_leave_proposal::<P, _>(
+            group_name,
+            &self_identity,
+            &self.consensus_service,
+            self.eth_signer.clone(),
+            ProposalParams {
+                expected_voters: 1,
+                proposal_expiration: config.proposal_expiration,
+                consensus_timeout: config.consensus_timeout,
+                liveness_criteria_yes: true,
+            },
+        )
+        .await?;
+
+        // Dedup (`ProposalAlreadyExist`) — another submit is already driving
+        // this proposal_id. Our voting entry resolves on that session.
+        let Some((_proposal_id, app_msg)) = submitted else {
+            return Ok(());
+        };
+
         let packet = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-            let app_msg: AppMessage = LeaveRequest {
-                identity: self_identity.clone(),
-            }
-            .into();
             build_message(&entry.group, &self.mls_service, &app_msg, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
-
-        // The inactivity timer self-starts on the next `check_steward_inactivity` poll.
-        {
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
-                entry.group.accept_auto_approved_leave(self_identity);
-            }
-        }
 
         Ok(())
     }

--- a/src/core/api/inbound.rs
+++ b/src/core/api/inbound.rs
@@ -15,6 +15,30 @@ use crate::protos::de_mls::messages::v1::{
     AppMessage, GroupUpdateRequest, InviteMember, WelcomeMessage, app_message,
     group_update_request, welcome_message,
 };
+use hashgraph_like_consensus::protos::consensus::v1::Proposal;
+
+/// Fast-path proposals (`expected_voters_count == 1`) bypass peer voting, so
+/// we restrict them to self-removal. Enforcing that the MLS-authenticated
+/// sender matches the `RemoveMember` target closes the unilateral-removal
+/// vector that an otherwise-free `expected_voters == 1` opens.
+///
+/// Returns `true` when the proposal is allowed. A mismatch (different
+/// target, wrong payload variant, or undecodable) produces `false`.
+fn authorize_fast_path_proposal(proposal: &Proposal, mls_sender: &[u8]) -> bool {
+    if proposal.expected_voters_count != 1 {
+        return true;
+    }
+    if proposal.proposal_owner != mls_sender {
+        return false;
+    }
+    let Ok(request) = GroupUpdateRequest::decode(proposal.payload.as_slice()) else {
+        return false;
+    };
+    matches!(
+        request.payload,
+        Some(group_update_request::Payload::RemoveMember(ref r)) if r.identity == mls_sender
+    )
+}
 
 /// Process an inbound packet and determine what action is needed.
 pub fn process_inbound<S>(
@@ -114,20 +138,17 @@ where
     match res {
         DecryptResult::Application(app_bytes, sender) => {
             let app_msg = AppMessage::decode(app_bytes.as_ref())?;
-            // LeaveRequest is auto-approved — the MLS-authenticated sender
-            // MUST equal the identity being removed. Reject mismatches here
-            // so the app layer can trust the pair downstream.
-            if let Some(app_message::Payload::LeaveRequest(leave)) = &app_msg.payload {
-                if leave.identity != sender {
-                    warn!(
-                        group = group.group_name(),
-                        claimed = %ShortId(&leave.identity),
-                        sender = %ShortId(&sender),
-                        "leave request signer mismatch"
-                    );
-                    return Ok(ProcessResult::Noop);
-                }
-                return Ok(ProcessResult::LeaveRequestReceived(leave.clone()));
+            if let Some(app_message::Payload::Proposal(proposal)) = &app_msg.payload
+                && !authorize_fast_path_proposal(proposal, &sender)
+            {
+                warn!(
+                    group = group.group_name(),
+                    proposal_id = proposal.proposal_id,
+                    sender = %ShortId(&sender),
+                    owner = %ShortId(&proposal.proposal_owner),
+                    "fast-path proposal rejected: sender is not the self-removal target"
+                );
+                return Ok(ProcessResult::Noop);
             }
             // Drop BanRequests whose target isn't in the group — saves a
             // useless consensus round. Mirrors the already-a-member check
@@ -160,5 +181,84 @@ where
             );
             Ok(ProcessResult::Noop)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::group::auto_approved_leave_proposal_id;
+    use crate::protos::de_mls::messages::v1::RemoveMember;
+
+    fn member(id: u8) -> Vec<u8> {
+        vec![id; 20]
+    }
+
+    fn remove_payload(identity: &[u8]) -> Vec<u8> {
+        GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: identity.to_vec(),
+            })),
+        }
+        .encode_to_vec()
+    }
+
+    fn proposal_for_self_remove(sender: &[u8], expected_voters: u32) -> Proposal {
+        Proposal {
+            name: "test".into(),
+            payload: remove_payload(sender),
+            proposal_id: auto_approved_leave_proposal_id(sender),
+            proposal_owner: sender.to_vec(),
+            votes: Vec::new(),
+            expected_voters_count: expected_voters,
+            round: 1,
+            timestamp: 0,
+            expiration_timestamp: u64::MAX,
+            liveness_criteria_yes: true,
+        }
+    }
+
+    #[test]
+    fn fast_path_allows_self_removal_matching_sender() {
+        let sender = member(1);
+        let proposal = proposal_for_self_remove(&sender, 1);
+        assert!(authorize_fast_path_proposal(&proposal, &sender));
+    }
+
+    #[test]
+    fn fast_path_rejects_target_other_than_sender() {
+        let sender = member(1);
+        let victim = member(2);
+        let mut proposal = proposal_for_self_remove(&victim, 1);
+        proposal.proposal_owner = sender.clone();
+        assert!(!authorize_fast_path_proposal(&proposal, &sender));
+    }
+
+    #[test]
+    fn fast_path_rejects_owner_mismatch() {
+        let sender = member(1);
+        let imposter = member(3);
+        let mut proposal = proposal_for_self_remove(&sender, 1);
+        proposal.proposal_owner = imposter;
+        assert!(!authorize_fast_path_proposal(&proposal, &sender));
+    }
+
+    #[test]
+    fn fast_path_rejects_non_remove_payload() {
+        let sender = member(1);
+        let mut proposal = proposal_for_self_remove(&sender, 1);
+        proposal.payload = vec![0xff; 8]; // garbage
+        assert!(!authorize_fast_path_proposal(&proposal, &sender));
+    }
+
+    #[test]
+    fn expected_voters_gt_one_bypasses_authz() {
+        let sender = member(1);
+        let victim = member(2);
+        let mut proposal = proposal_for_self_remove(&victim, 5);
+        proposal.proposal_owner = sender.clone();
+        // Regular proposals (voters > 1) aren't gated by this check — peer
+        // voting provides the authorization instead.
+        assert!(authorize_fast_path_proposal(&proposal, &sender));
     }
 }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -59,6 +59,54 @@ pub fn target_identity_of(request: &GroupUpdateRequest) -> Option<&[u8]> {
     }
 }
 
+/// Bounded FIFO of proposal IDs for which a local consensus outcome has been
+/// observed (`ConsensusReached` or timeout-path resolution). Oldest entries
+/// are evicted once `capacity` is reached.
+///
+/// Serves two callers: (a) duplicate-drop guard in `apply_consensus_outcome`
+/// against consensus-library re-emissions, and (b) late-packet classifier in
+/// `forward_incoming_vote` — a `SessionNotFound` for an id in this cache is
+/// a benign late vote (session was trimmed after we resolved it), while the
+/// same error for an id we never saw is suspicious and warrants a warn-log.
+///
+/// `CAPACITY` is sized well above the consensus library's
+/// `max_sessions_per_scope` (default 10) so a late vote arriving within any
+/// plausible peer-lag window still finds its id cached.
+#[derive(Clone, Debug)]
+struct ResolvedProposalCache {
+    ids: HashSet<ProposalId>,
+    order: VecDeque<ProposalId>,
+    capacity: usize,
+}
+
+const RESOLVED_PROPOSAL_CACHE_CAPACITY: usize = 256;
+
+impl ResolvedProposalCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            ids: HashSet::new(),
+            order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn contains(&self, id: ProposalId) -> bool {
+        self.ids.contains(&id)
+    }
+
+    fn record(&mut self, id: ProposalId) {
+        if !self.ids.insert(id) {
+            return;
+        }
+        self.order.push_back(id);
+        while self.order.len() > self.capacity
+            && let Some(old) = self.order.pop_front()
+        {
+            self.ids.remove(&old);
+        }
+    }
+}
+
 /// A membership update that has been observed but may not yet have been committed.
 ///
 /// Every member buffers these so that, if the epoch steward fails to commit the
@@ -138,10 +186,11 @@ pub struct Group {
     /// triggers consistently across the group. Overridden at group
     /// creation from `GroupConfig`; defaults to [`DEFAULT_MAX_REELECTION_RETRIES`].
     max_reelection_retries: u32,
-    /// Proposal IDs already dispatched through `apply_consensus_outcome`.
-    /// The consensus library can re-emit `ConsensusReached` (timeout-path
-    /// race); this guards against re-applying state and double-firing events.
-    consensus_outcomes_applied: HashSet<ProposalId>,
+    /// Bounded FIFO of proposal IDs with a locally-observed consensus outcome.
+    /// Used by `apply_consensus_outcome` to drop library re-emissions and by
+    /// `forward_incoming_vote` to distinguish benign late peer votes (session
+    /// was trimmed after resolution) from votes for unknown proposal IDs.
+    resolved_proposals: ResolvedProposalCache,
 }
 
 /// Fallback ceiling on steward-election retries. One retry gives the
@@ -166,16 +215,16 @@ impl Group {
             pending_updates: HashMap::new(),
             reelection_round: 0,
             max_reelection_retries: DEFAULT_MAX_REELECTION_RETRIES,
-            consensus_outcomes_applied: HashSet::new(),
+            resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
         }
     }
 
     pub fn is_consensus_outcome_applied(&self, proposal_id: ProposalId) -> bool {
-        self.consensus_outcomes_applied.contains(&proposal_id)
+        self.resolved_proposals.contains(proposal_id)
     }
 
     pub fn mark_consensus_outcome_applied(&mut self, proposal_id: ProposalId) {
-        self.consensus_outcomes_applied.insert(proposal_id);
+        self.resolved_proposals.record(proposal_id);
     }
 
     /// Create a new group handle for a joining member (not yet steward).
@@ -977,6 +1026,50 @@ mod tests {
         assert!(!group.accept_auto_approved_leave(target.clone()));
         assert_eq!(group.approved_proposals_count(), 0);
         assert!(!group.is_pending_self_leave(&target));
+    }
+
+    #[test]
+    fn resolved_cache_records_and_evicts_fifo() {
+        let mut cache = ResolvedProposalCache::new(3);
+        cache.record(1);
+        cache.record(2);
+        cache.record(3);
+        assert!(cache.contains(1));
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+
+        cache.record(4);
+        assert!(!cache.contains(1), "oldest entry must be evicted");
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+        assert!(cache.contains(4));
+    }
+
+    #[test]
+    fn resolved_cache_dedupes_and_does_not_bump_position() {
+        let mut cache = ResolvedProposalCache::new(3);
+        cache.record(1);
+        cache.record(2);
+        cache.record(1); // no-op: 1 stays in its original slot
+        cache.record(3);
+        assert!(cache.contains(1));
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+
+        // Fourth distinct id evicts the oldest (1), not a later entry.
+        cache.record(4);
+        assert!(!cache.contains(1));
+        assert!(cache.contains(2));
+        assert!(cache.contains(3));
+        assert!(cache.contains(4));
+    }
+
+    #[test]
+    fn mark_consensus_outcome_persists_in_resolved_cache() {
+        let mut group = Group::new_as_creator("g", member(1), default_config()).unwrap();
+        assert!(!group.is_consensus_outcome_applied(42));
+        group.mark_consensus_outcome_applied(42);
+        assert!(group.is_consensus_outcome_applied(42));
     }
 
     /// Live rotation skips a nominal steward who has submitted a self-leave.

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -21,14 +21,12 @@ pub type ProposalId = u32;
 /// that becomes a first-class config value (see `docs/ROADMAP.md`).
 const MAX_EPOCH_HISTORY: usize = 10;
 
-/// Derive a deterministic proposal ID for an auto-approved self-leave,
-/// keyed on the leaver's identity. Every node computes the same ID, so
-/// `approved_proposals` stays consistent across the group without
-/// running a consensus round.
-///
-/// This ID doubles as the "auto-approved" signature — an approved entry
-/// whose ID matches this formula for its own target is known to be a
-/// self-leave (not a consensus-approved Remove).
+/// Deterministic proposal ID for a self-leave, derived from the leaver's
+/// identity. Pinning the ID is what makes a leaver's crash-retry dedupe
+/// against an in-flight session (`ProposalAlreadyExist`) instead of opening
+/// a second session that would land a duplicate `RemoveMember` in the next
+/// commit batch. It also doubles as the self-leave signature used by
+/// `is_auto_approved_entry` and `reject_all_approved_proposals`.
 pub fn auto_approved_leave_proposal_id(identity: &[u8]) -> u32 {
     use sha2::{Digest, Sha256};
     let hash = Sha256::digest(identity);
@@ -634,11 +632,6 @@ impl Group {
     /// Keyed by target identity — a second insertion for the same identity
     /// keeps the original `first_seen_epoch` so it can still expire on schedule.
     /// Returns `true` if this is a new entry, `false` if already buffered.
-    ///
-    /// For auto-approved updates (self-leave) use
-    /// [`Self::accept_auto_approved_leave`] instead — those have a known
-    /// result and go straight to `approved_proposals`, never through
-    /// `pending_updates`.
     pub fn buffer_pending_update(
         &mut self,
         request: GroupUpdateRequest,
@@ -661,65 +654,14 @@ impl Group {
         true
     }
 
-    /// Whether the identity has an auto-approved self-leave currently in
-    /// `approved_proposals`. Used by live rotation to skip the leaver.
+    /// True if `identity` has a self-leave waiting for the next commit —
+    /// an approved `RemoveMember(identity)` under the deterministic
+    /// self-leave ID. Used by live rotation to skip the leaver.
     pub fn is_pending_self_leave(&self, identity: &[u8]) -> bool {
         let pid = auto_approved_leave_proposal_id(identity);
         self.approved_proposals
             .get(&pid)
             .is_some_and(|req| is_auto_approved_entry(pid, req))
-    }
-
-    /// Accept an auto-approved self-leave.
-    ///
-    /// Inserts `RemoveMember(identity)` directly into `approved_proposals`
-    /// with a deterministic proposal ID so every node's approved set agrees
-    /// without running a consensus round. The deterministic ID doubles as
-    /// the "auto-approved" signature — [`Self::reject_all_approved_proposals`]
-    /// uses it to preserve the entry across a freeze failure, and
-    /// [`Self::is_pending_self_leave`] uses it for rotation skip.
-    ///
-    /// Caller must have verified that the originator of the request matches
-    /// `identity` (e.g., via the MLS-authenticated sender on the app subtopic).
-    ///
-    /// Returns `true` if this is a new leave, `false` if already recorded or
-    /// a `RemoveMember` for this identity is already pending via another
-    /// path (ban, ECP). Dedup prevents duplicate Remove entries from landing
-    /// in the same commit batch.
-    pub fn accept_auto_approved_leave(&mut self, identity: Vec<u8>) -> bool {
-        // Dedup against any existing Remove for this identity — approved
-        // queue (ban that already passed consensus), pending_updates (ban or
-        // ECP still in flight), or a prior self-leave.
-        if self.has_any_remove_for(&identity) {
-            return false;
-        }
-        let remove = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember {
-                    identity: identity.clone(),
-                },
-            )),
-        };
-        let proposal_id = auto_approved_leave_proposal_id(&identity);
-        self.approved_proposals.insert(proposal_id, remove);
-        true
-    }
-
-    /// True if any Remove targeting `identity` is in flight — approved queue
-    /// (consensus-approved ban or prior self-leave) or pending_updates (ban
-    /// still voting, ECP-derived). Used to dedup before an auto-approved
-    /// insertion.
-    fn has_any_remove_for(&self, identity: &[u8]) -> bool {
-        self.has_pending_remove(identity) || self.has_approved_remove(identity)
-    }
-
-    fn has_approved_remove(&self, identity: &[u8]) -> bool {
-        self.approved_proposals.values().any(|req| {
-            matches!(
-                req.payload.as_ref(),
-                Some(group_update_request::Payload::RemoveMember(r)) if r.identity == identity
-            )
-        })
     }
 
     /// Current steward-election retry round (0 for fresh elections).
@@ -749,18 +691,6 @@ impl Group {
     /// `GroupConfig`) and on joiner sync (from `GroupSync.max_reelection_retries`).
     pub fn set_max_reelection_retries(&mut self, max: u32) {
         self.max_reelection_retries = max;
-    }
-
-    fn has_pending_remove(&self, identity: &[u8]) -> bool {
-        self.pending_updates
-            .get(identity)
-            .map(|p| {
-                matches!(
-                    p.request.payload.as_ref(),
-                    Some(group_update_request::Payload::RemoveMember(_))
-                )
-            })
-            .unwrap_or(false)
     }
 
     /// Drop a buffered update by target identity.
@@ -925,43 +855,26 @@ mod tests {
         assert!(!outsider.is_steward());
     }
 
-    #[test]
-    fn test_accept_auto_approved_leave_goes_directly_to_approved() {
-        let config = ProtocolConfig::new(1, 3).unwrap();
-        let mems = members(&[1, 2, 3]);
-        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
-
-        let leaver = member(2);
-        assert_eq!(group.approved_proposals_count(), 0);
-        assert_eq!(group.pending_update_count(), 0);
-        assert!(!group.is_pending_self_leave(&leaver));
-
-        assert!(group.accept_auto_approved_leave(leaver.clone()));
-
-        // Auto-approved leaves land in `approved_proposals` directly,
-        // keyed by the deterministic proposal id, and don't touch pending_updates.
-        assert_eq!(group.pending_update_count(), 0);
-        assert_eq!(group.approved_proposals_count(), 1);
-        assert!(group.is_pending_self_leave(&leaver));
-        let expected_id = auto_approved_leave_proposal_id(&leaver);
-        assert!(group.approved_proposals().contains_key(&expected_id));
-
-        // Idempotent: second accept for the same identity is a no-op.
-        assert!(!group.accept_auto_approved_leave(leaver.clone()));
-        assert_eq!(group.approved_proposals_count(), 1);
+    fn insert_self_leave(group: &mut Group, identity: &[u8]) {
+        let remove = GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(
+                crate::protos::de_mls::messages::v1::RemoveMember {
+                    identity: identity.to_vec(),
+                },
+            )),
+        };
+        group.insert_approved_proposal(auto_approved_leave_proposal_id(identity), remove);
     }
 
     #[test]
-    fn test_reject_all_approved_preserves_auto_approved_leaves() {
+    fn test_reject_all_approved_preserves_self_leave_entry() {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
         group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
-        // One auto-approved leave + one consensus-approved proposal.
         let leaver = member(2);
-        group.accept_auto_approved_leave(leaver.clone());
+        insert_self_leave(&mut group, &leaver);
         let ban_id: ProposalId = 0xdead_beef;
         let ban = GroupUpdateRequest {
             payload: Some(group_update_request::Payload::InviteMember(
@@ -977,7 +890,7 @@ mod tests {
         // Simulate freeze failure.
         group.reject_all_approved_proposals();
 
-        // Auto-approved leave survives; the consensus-approved ban is gone.
+        // Self-leave entry (deterministic id) survives; unrelated approvals drop.
         assert_eq!(group.approved_proposals_count(), 1);
         let leave_id = auto_approved_leave_proposal_id(&leaver);
         assert!(group.approved_proposals().contains_key(&leave_id));
@@ -985,14 +898,14 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_clears_auto_approved_leave_when_member_gone() {
+    fn test_prune_clears_self_leave_entry_when_member_gone() {
         let config = ProtocolConfig::new(1, 3).unwrap();
         let mems = members(&[1, 2, 3]);
         let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
         group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
 
         let leaver = member(2);
-        group.accept_auto_approved_leave(leaver.clone());
+        insert_self_leave(&mut group, &leaver);
         assert_eq!(group.approved_proposals_count(), 1);
         assert!(group.is_pending_self_leave(&leaver));
 
@@ -1002,30 +915,6 @@ mod tests {
 
         assert_eq!(group.approved_proposals_count(), 0);
         assert!(!group.is_pending_self_leave(&leaver));
-    }
-
-    /// A pending ban on the target dedupes a subsequent self-leave —
-    /// avoids two `RemoveMember` entries for the same identity in one batch.
-    #[test]
-    fn test_accept_auto_approved_leave_deduped_when_ban_pending() {
-        let config = ProtocolConfig::new(1, 3).unwrap();
-        let mems = members(&[1, 2, 3]);
-        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
-        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
-
-        let target = member(2);
-        let ban_remove = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember {
-                    identity: target.clone(),
-                },
-            )),
-        };
-        assert!(group.buffer_pending_update(ban_remove, 0));
-
-        assert!(!group.accept_auto_approved_leave(target.clone()));
-        assert_eq!(group.approved_proposals_count(), 0);
-        assert!(!group.is_pending_self_leave(&target));
     }
 
     #[test]
@@ -1083,7 +972,7 @@ mod tests {
         let nominal = group.epoch_steward(0).unwrap().to_vec();
         assert_eq!(group.live_epoch_steward(0, &mems), Some(nominal.as_slice()));
 
-        group.accept_auto_approved_leave(nominal.clone());
+        insert_self_leave(&mut group, &nominal);
         let live = group.live_epoch_steward(0, &mems).unwrap();
         assert_ne!(live, nominal.as_slice());
         assert!(mems.iter().any(|m| m == live));

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,7 +43,8 @@ pub use events::{CallbackError, GroupEventHandler};
 
 // ── Group state ──
 pub use group::{
-    DEFAULT_MAX_REELECTION_RETRIES, Group, PendingUpdate, ProposalId, target_identity_of,
+    DEFAULT_MAX_REELECTION_RETRIES, Group, PendingUpdate, ProposalId,
+    auto_approved_leave_proposal_id, target_identity_of,
 };
 
 // ── Proposal classification ──

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -11,9 +11,9 @@ use crate::{
     mls_crypto::parse_wallet_to_bytes,
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, CommitCandidate, ConversationMessage, EmergencyCriteriaProposal,
-        GroupSync, GroupUpdateRequest, InvitationToJoin, LeaveRequest, Outcome, ProposalAdded,
-        RemoveMember, UserKeyPackage, UserVote, ViolationEvidence, ViolationType, VotePayload,
-        WelcomeMessage, app_message, group_update_request, welcome_message,
+        GroupSync, GroupUpdateRequest, InvitationToJoin, Outcome, ProposalAdded, RemoveMember,
+        UserKeyPackage, UserVote, ViolationEvidence, ViolationType, VotePayload, WelcomeMessage,
+        app_message, group_update_request, welcome_message,
     },
 };
 
@@ -48,11 +48,6 @@ pub enum ProcessResult {
     /// Group-sync message from the steward (steward list, scores, timing,
     /// protocol flags). Meaningful only for joiners with no steward list yet.
     GroupSyncReceived(GroupSync),
-
-    /// Authenticated self-leave from a member. Auto-approved — the app layer
-    /// verifies the signer matches `identity` and inserts `RemoveMember`
-    /// directly into the approved queue.
-    LeaveRequestReceived(LeaveRequest),
 
     /// Nothing to do (not for us, duplicate, or already handled).
     Noop,
@@ -178,7 +173,6 @@ impl_payload_from!(
     ConversationMessage => app_message::Payload::ConversationMessage,
     CommitCandidate     => app_message::Payload::CommitCandidate,
     BanRequest          => app_message::Payload::BanRequest,
-    LeaveRequest        => app_message::Payload::LeaveRequest,
     Proposal            => app_message::Payload::Proposal,
     Vote                => app_message::Payload::Vote,
     GroupSync           => app_message::Payload::GroupSync,
@@ -216,12 +210,6 @@ impl TryFrom<AppMessage> for ProcessResult {
             Some(app_message::Payload::GroupSync(sync)) => {
                 Ok(ProcessResult::GroupSyncReceived(sync.clone()))
             }
-            // LeaveRequest is NOT handled here: the authenticated path
-            // (`process_app_subtopic`) is the sole producer of
-            // `LeaveRequestReceived` — it verifies the MLS sender matches
-            // `leave.identity` before emitting the variant. Treating it as
-            // Noop here prevents any caller from bypassing that check via
-            // a generic `AppMessage::try_into()`.
             _ => Ok(ProcessResult::Noop),
         }
     }

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -17,14 +17,7 @@ message AppMessage {
     ProposalAdded proposal_added = 7;
     CommitCandidate commit_candidate = 8;
     GroupSync group_sync = 9;
-    LeaveRequest leave_request = 10;
   }
-}
-
-// Self-leave intent. Auto-approved — no consensus vote.
-// Signer must equal `identity`.
-message LeaveRequest {
-  bytes identity = 1;
 }
 
 message BanRequest {


### PR DESCRIPTION
Self-leave used to bypass the consensus service entirely (`LeaveRequest` + `accept_auto_approved_leave` inserting straight into `approved_proposals`), which broke the `approved_proposals` ↔ consensus-session
invariant. Lookups against the deterministic self-leave id returned `SessionNotFound` and surfaced as hard errors on any adjacent late packet.

- `forward_incoming_vote` and `resolve_on_timeout` now classify `SessionNotFound` through a bounded resolved-proposals cache on `Group`: ids in the cache are benign late packets (debug-log); ids absent are
unknown (warn-log). No more hard error on late peer votes.

- Self-leave runs as a real consensus round with `expected_voters = 1` and the leaver's YES bundled at submit. A hand-crafted `Proposal` carries `auto_approved_leave_proposal_id(self)` so every node agrees on the
 key and crash/retry collapses via `ProposalAlreadyExist`.

- Inbound authorization gate on the fast path: a proposal with `expected_voters_count == 1` is only accepted when its MLS-authenticated sender matches both `proposal_owner` and the `RemoveMember` target. Closes
the unilateral-removal vector that `expected_voters = 1` otherwise opens.

Known gaps: a self-leave concurrent with a consensus-approved ban for the same identity could land two `RemoveMember` entries in the next commit batch — old `accept_auto_approved_leave` dedup'd this, the
consensus path doesn't yet. Not seen in practice; tracked separately.