### PR TITLE
feat(core): leaver-aware steward selection

### DIFF
--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -330,12 +330,18 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     as u64,
             };
 
+            // Filter ghosts and queued-removal targets so joiners don't
+            // inherit stewards they would have to walk past on the very
+            // first epoch.
+            let mls_members = group_members(&entry.group, &self.mls_service)?;
+            let steward_members = entry.group.live_steward_members(&mls_members);
+
             // `retry_round` is the seed that produced the *stored* list —
             // a frozen tag on `StewardList`, not `Group::reelection_round`
             // (the dynamic counter for the next attempt, which resets to 0
             // on accept). Joiners re-derive the ordering from this seed.
             let sync = GroupSync {
-                steward_members: list.members().to_vec(),
+                steward_members,
                 start_epoch: list.start_epoch(),
                 sn_min: list.config().sn_min as u32,
                 sn_max: list.config().sn_max as u32,

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -276,8 +276,15 @@ fn rank_applicable_candidates(
 
 /// Result of trying to apply one candidate. `Terminal` ends the round;
 /// `Drop` records a local score penalty and the caller tries the next.
+///
+/// `committer` is the MLS-verified sender (incoming) or our own identity
+/// (local). Scoring keys off this so a forged wire claim cannot redirect
+/// the `SuccessfulCommit` reward.
 enum CandidateOutcome {
-    Terminal(FreezeOutcome),
+    Terminal {
+        outcome: FreezeOutcome,
+        committer: Vec<u8>,
+    },
     Drop(ScoreOp),
 }
 
@@ -305,7 +312,6 @@ where
 
     let mut remaining = sorted.into_iter();
     while let Some(chosen) = remaining.next() {
-        let author_id = chosen.candidate_msg.steward_identity.clone();
         let apply_result = if chosen.is_local_candidate {
             if own_commit_discarded {
                 tracing::debug!(
@@ -327,17 +333,20 @@ where
         };
 
         match apply_result {
-            CandidateOutcome::Terminal(outcome) => {
+            CandidateOutcome::Terminal { outcome, committer } => {
                 score_ops.push(ScoreOp {
-                    member_id: author_id.clone(),
+                    member_id: committer.clone(),
                     event: ScoreEvent::SuccessfulCommit,
                 });
                 // If a backup committed in place of the epoch steward,
                 // penalise the absent steward (RFC §Steward violation
                 // list: censorship/inactivity). Skip self-accusation —
-                // we know our own liveness directly.
+                // we know our own liveness directly. The walk in
+                // `live_epoch_steward_id` already filters out
+                // queued-removal targets, so a draining named steward
+                // never appears here as `expected`.
                 if let Some(expected) = ctx.live_epoch_steward_id.as_deref() {
-                    if expected != author_id.as_slice() && expected != ctx.self_identity.as_slice()
+                    if expected != committer.as_slice() && expected != ctx.self_identity.as_slice()
                     {
                         score_ops.push(ScoreOp {
                             member_id: expected.to_vec(),
@@ -348,12 +357,23 @@ where
                 // Unpicked candidates that passed the count filter are
                 // honest competitors under Δ-synchrony (same approved set,
                 // different MLS entropy). RFC §Commit Validation: "MUST
-                // NOT be classified as misbehaviour."
+                // NOT be classified as misbehaviour." Score only when the
+                // wire-claimed identity sits on the steward list — a forged
+                // claim from a non-steward earns no credit.
                 for loser in remaining {
-                    score_ops.push(ScoreOp {
-                        member_id: loser.candidate_msg.steward_identity,
-                        event: ScoreEvent::HonestCommitAttempt,
-                    });
+                    let claimed = loser.candidate_msg.steward_identity;
+                    let on_list = group.steward_list().is_some_and(|l| l.contains(&claimed));
+                    if on_list {
+                        score_ops.push(ScoreOp {
+                            member_id: claimed,
+                            event: ScoreEvent::HonestCommitAttempt,
+                        });
+                    } else {
+                        tracing::debug!(
+                            group = %group_name,
+                            "dropping HonestCommitAttempt: claimed identity not on steward list"
+                        );
+                    }
                 }
                 return Ok(FreezeFinalizeResult { outcome, score_ops });
             }
@@ -432,6 +452,10 @@ fn apply_local_candidate<S>(
 where
     S: DeMlsStorage<MlsStorage = MemoryStorage>,
 {
+    // Local candidate: we wrote the message, so the wire-claimed identity
+    // is our own and is trusted by definition.
+    let committer = chosen.candidate_msg.steward_identity.clone();
+
     mls.merge_own_commit(group.group_name())?;
 
     // Welcomes go out only after our merge — joiners must not race ahead of the steward's epoch.
@@ -446,10 +470,13 @@ where
     } else {
         ProcessResult::GroupUpdated
     };
-    Ok(CandidateOutcome::Terminal(FreezeOutcome::Applied {
-        result: Box::new(result),
-        outbound,
-    }))
+    Ok(CandidateOutcome::Terminal {
+        outcome: FreezeOutcome::Applied {
+            result: Box::new(result),
+            outbound,
+        },
+        committer,
+    })
 }
 
 /// Stage, validate, and merge a candidate authored by another steward.
@@ -520,10 +547,13 @@ where
     } else {
         ProcessResult::GroupUpdated
     };
-    Ok(CandidateOutcome::Terminal(FreezeOutcome::Applied {
-        result: Box::new(result),
-        outbound: None,
-    }))
+    Ok(CandidateOutcome::Terminal {
+        outcome: FreezeOutcome::Applied {
+            result: Box::new(result),
+            outbound: None,
+        },
+        committer: commit_sender,
+    })
 }
 
 // ─────────────────────────── MLS Staging ───────────────────────────

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -59,6 +59,32 @@ fn removal_request_for(evidence: &ViolationEvidence) -> GroupUpdateRequest {
     }
 }
 
+/// Identity this approval would queue for removal in `approved_proposals`,
+/// if any. Covers a direct `RemoveMember` request and a score-below-threshold
+/// ECP that transforms into one. Returns `None` for elections, non-removal
+/// emergencies, non-removal regular proposals, and rejections.
+fn pending_removal_target(
+    request: &GroupUpdateRequest,
+    evidence: Option<&ViolationEvidence>,
+    approved: bool,
+    is_emergency: bool,
+    transforms_to_removal: bool,
+) -> Option<Vec<u8>> {
+    if !approved {
+        return None;
+    }
+    if transforms_to_removal {
+        return evidence.map(|ev| ev.target_member_id.clone());
+    }
+    if is_emergency {
+        return None;
+    }
+    match request.payload.as_ref() {
+        Some(group_update_request::Payload::RemoveMember(r)) => Some(r.identity.clone()),
+        _ => None,
+    }
+}
+
 /// Apply a consensus result to the group's proposal queues.
 ///
 /// Routes by proposal kind:
@@ -118,6 +144,29 @@ pub fn apply_consensus_result(
     // Should the approved ECP transform into a RemoveMember?
     let transforms_to_removal =
         approved && is_emergency && evidence.as_ref().is_some_and(is_score_below_threshold);
+
+    // Target-keyed dedup. Two approvals from independent paths (self-leave +
+    // ban, ECP + ban, …) can each carry `RemoveMember(target)` under
+    // different proposal ids. MLS rejects a duplicate removal at commit
+    // time, so keep the first entry and drop the second.
+    if let Some(target) = pending_removal_target(
+        &request,
+        evidence.as_ref(),
+        approved,
+        is_emergency,
+        transforms_to_removal,
+    ) && group.is_pending_removal(&target)
+    {
+        if is_owner {
+            group.mark_proposal_as_rejected(proposal_id);
+        }
+        info!(
+            proposal_id,
+            target = %ShortId(&target),
+            "removal proposal deduped — target already queued for removal"
+        );
+        return Ok(ConsensusApplyResult::default());
+    }
 
     if approved {
         if is_owner {
@@ -251,5 +300,74 @@ mod tests {
         assert_eq!(outcome.election_epoch, 5);
         assert_eq!(outcome.proposed_stewards.len(), 3);
         assert_eq!(group.approved_proposals_count(), 0);
+    }
+
+    fn remove_request(target: Vec<u8>) -> GroupUpdateRequest {
+        GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(
+                crate::protos::de_mls::messages::v1::RemoveMember { identity: target },
+            )),
+        }
+    }
+
+    /// A second `RemoveMember(target)` arriving via consensus is dropped
+    /// when an entry for the same target is already in `approved_proposals`.
+    #[test]
+    fn removal_deduped_when_target_already_pending() {
+        let config = ProtocolConfig::new(2, 5).unwrap();
+        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
+        let target = member(7);
+
+        // First removal — non-owner path inserts straight into approved.
+        let first_id = 10;
+        let request = remove_request(target.clone());
+        apply_consensus_result(&mut group, first_id, true, &request.encode_to_vec()).unwrap();
+        assert_eq!(group.approved_proposals_count(), 1);
+
+        // Second removal for the same target arrives under a different id.
+        let second_id = 11;
+        let request = remove_request(target.clone());
+        let result =
+            apply_consensus_result(&mut group, second_id, true, &request.encode_to_vec()).unwrap();
+
+        assert!(result.election.is_none());
+        assert_eq!(
+            group.approved_proposals_count(),
+            1,
+            "duplicate removal must not stack a second entry"
+        );
+        assert!(group.approved_proposals().contains_key(&first_id));
+        assert!(!group.approved_proposals().contains_key(&second_id));
+    }
+
+    /// Owner-side dedup: the duplicate clears its voting-queue entry so the
+    /// queue does not retain an outcome we deliberately discarded.
+    #[test]
+    fn removal_dedup_clears_owner_voting_entry() {
+        let config = ProtocolConfig::new(2, 5).unwrap();
+        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
+        let target = member(7);
+
+        // Pre-existing approved removal from an unrelated path.
+        let pending_id = 20;
+        let pending = remove_request(target.clone());
+        group.insert_approved_proposal(pending_id, pending);
+
+        // This user submits their own removal and it passes consensus.
+        let owner_id = 21;
+        let owner_request = remove_request(target.clone());
+        group.store_voting_proposal(owner_id, owner_request.clone());
+
+        let result =
+            apply_consensus_result(&mut group, owner_id, true, &owner_request.encode_to_vec())
+                .unwrap();
+
+        assert!(result.election.is_none());
+        assert_eq!(group.approved_proposals_count(), 1);
+        assert!(group.approved_proposals().contains_key(&pending_id));
+        assert!(
+            !group.is_owner_of_proposal(owner_id),
+            "duplicate must be cleared from voting queue"
+        );
     }
 }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -319,7 +319,23 @@ impl Group {
     }
 
     fn is_steward_eligible(&self, candidate: &[u8], members: &[Vec<u8>]) -> bool {
-        !self.is_pending_self_leave(candidate) && members.iter().any(|m| m == candidate)
+        !self.is_pending_removal(candidate) && members.iter().any(|m| m == candidate)
+    }
+
+    /// True iff `approved_proposals` carries any `RemoveMember(identity)` —
+    /// regardless of source (self-leave, ban, ECP-derived). Used by the
+    /// steward-eligibility predicate to skip a member whose removal is queued
+    /// for the next commit: MLS forbids them from committing it themselves,
+    /// so the rotation walk would have to fall back anyway. Broader than
+    /// [`Self::is_pending_self_leave`] (which only matches the deterministic
+    /// self-leave id).
+    pub fn is_pending_removal(&self, identity: &[u8]) -> bool {
+        self.approved_proposals.values().any(|req| {
+            matches!(
+                req.payload.as_ref(),
+                Some(group_update_request::Payload::RemoveMember(r)) if r.identity == identity
+            )
+        })
     }
 
     // ─────────────────────────── Proposal Queues ───────────────────────────
@@ -455,6 +471,22 @@ impl Group {
         self.steward_list
             .as_ref()
             .and_then(|l| l.epoch_steward(epoch))
+    }
+
+    /// Steward identities filtered by the steward-eligibility predicate
+    /// (MLS-present and not queued for removal). Joiners receive this view
+    /// via `GroupSync` so they don't inherit ghosts or members whose
+    /// removal is queued. Order is preserved from the canonical list.
+    /// Returns an empty `Vec` if no list is set.
+    pub fn live_steward_members(&self, members: &[Vec<u8>]) -> Vec<Vec<u8>> {
+        let Some(list) = self.steward_list.as_ref() else {
+            return Vec::new();
+        };
+        list.members()
+            .iter()
+            .filter(|m| self.is_steward_eligible(m, members))
+            .cloned()
+            .collect()
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election
@@ -976,5 +1008,69 @@ mod tests {
         let live = group.live_epoch_steward(0, &mems).unwrap();
         assert_ne!(live, nominal.as_slice());
         assert!(mems.iter().any(|m| m == live));
+    }
+
+    fn insert_remove_member(group: &mut Group, target: &[u8], proposal_id: ProposalId) {
+        let remove = GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(
+                crate::protos::de_mls::messages::v1::RemoveMember {
+                    identity: target.to_vec(),
+                },
+            )),
+        };
+        group.insert_approved_proposal(proposal_id, remove);
+    }
+
+    /// Live rotation skips a nominal steward whose removal is queued under a
+    /// non-self-leave proposal id (ban / ECP-derived).
+    #[test]
+    fn test_live_rotation_skips_ban_pending_removal() {
+        let config = ProtocolConfig::new(3, 3).unwrap();
+        let mems = members(&[1, 2, 3]);
+        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 3, 0).unwrap();
+
+        let nominal = group.epoch_steward(0).unwrap().to_vec();
+        assert_eq!(group.live_epoch_steward(0, &mems), Some(nominal.as_slice()));
+
+        // Removal under an arbitrary proposal id (not the deterministic
+        // self-leave id) — the narrower self-leave predicate would miss it.
+        insert_remove_member(&mut group, &nominal, 0xdead_beef);
+        assert!(!group.is_pending_self_leave(&nominal));
+        assert!(group.is_pending_removal(&nominal));
+
+        let live = group.live_epoch_steward(0, &mems).unwrap();
+        assert_ne!(live, nominal.as_slice());
+        assert!(mems.iter().any(|m| m == live));
+    }
+
+    /// `live_epoch_and_backup` skips a draining nominal *and* a draining
+    /// backup, returning the next two eligible distinct stewards.
+    #[test]
+    fn test_live_epoch_and_backup_skips_draining_pair() {
+        let config = ProtocolConfig::new(4, 4).unwrap();
+        let mems = members(&[1, 2, 3, 4]);
+        let mut group = Group::new_as_creator("test-group", member(1), config).unwrap();
+        group.generate_and_set_steward_list(0, &mems, 4, 0).unwrap();
+
+        let nominal = group.epoch_steward(0).unwrap().to_vec();
+        let backup = group
+            .steward_list()
+            .unwrap()
+            .backup_steward(0)
+            .unwrap()
+            .to_vec();
+
+        insert_remove_member(&mut group, &nominal, 1);
+        insert_remove_member(&mut group, &backup, 2);
+
+        let (live_epoch, live_backup) = group.live_epoch_and_backup(0, &mems);
+        let live_epoch = live_epoch.expect("eligible epoch steward").to_vec();
+        let live_backup = live_backup.expect("eligible backup steward").to_vec();
+        assert_ne!(live_epoch, nominal);
+        assert_ne!(live_epoch, backup);
+        assert_ne!(live_backup, nominal);
+        assert_ne!(live_backup, backup);
+        assert_ne!(live_epoch, live_backup);
     }
 }


### PR DESCRIPTION
Ban or self-leave of the epoch steward used to deadlock freeze. Widen the eligibility predicate so the rotation walk skips any member with a queued RemoveMember; dedup RemoveMember at consensus-result insertion; and key freeze scoring off the MLS-verified committer.