### PR TITLE
feat(group_sync): propagate full per-group setup to joiners

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -2,7 +2,10 @@
 
 use std::time::Duration;
 
-pub use crate::core::DEFAULT_MAX_REELECTION_ATTEMPTS;
+pub use crate::core::{
+    DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_MAX_REELECTION_ATTEMPTS,
+    DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_THRESHOLD_PEER_SCORE,
+};
 use crate::core::{ProposalKind, ProtocolConfig};
 
 /// Wall-clock window the steward waits before batching approved proposals
@@ -17,10 +20,6 @@ pub const DEFAULT_PROPOSAL_EXPIRATION: Duration = Duration::from_secs(3600);
 /// vote can stay open. MUST be `> voting_delay`.
 pub const DEFAULT_CONSENSUS_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Drop a buffered membership update if the steward fails to commit it
-/// for this many consecutive epochs.
-pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
-
 /// Inactivity window during recovery. Reset to `epoch_duration` after a
 /// successful commit.
 pub const DEFAULT_RETRY_INACTIVITY_DURATION: Duration = Duration::from_secs(5);
@@ -33,16 +32,8 @@ pub const DEFAULT_VOTING_DELAY: Duration = Duration::from_secs(10);
 /// `DEFAULT_VOTING_DELAY` so recovery elections converge fast.
 pub const DEFAULT_ELECTION_VOTING_DELAY: Duration = Duration::from_secs(5);
 
-/// Whether silent voters count as YES at `consensus_timeout`
-/// (RFC §Creating Voting Proposal). Also used as the auto-vote value.
-pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
-
 /// RFC §Peer Scoring `default_peer_score`: starting score for a new member.
 pub const DEFAULT_PEER_SCORE: i64 = 100;
-
-/// RFC §Peer Scoring `threshold_peer_score`: at or below this, a member
-/// becomes eligible for `SCORE_BELOW_THRESHOLD` ECP removal.
-pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
 /// Fallback [`ProtocolConfig`] for a group created without explicit bounds —
 /// tiny groups with `sn ∈ [1, 2]`.

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -98,10 +98,8 @@ impl ScoringProvider for FixedScoringProvider {
 
 // ── Service ─────────────────────────────────────────────────────────
 
-/// Per-member score tracker, parameterised over a [`PeerScoreStorage`] and
-/// a [`ScoringProvider`]. The removal threshold lives per-group on
-/// `Group::threshold_peer_score` and is supplied by callers to
-/// [`Self::is_below_threshold`] / [`Self::members_below_threshold`].
+/// Per-member score tracker. Threshold is supplied per-call by the caller
+/// (held on `Group::threshold_peer_score`).
 pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
     storage: S,
     provider: P,
@@ -154,8 +152,6 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
         self.storage.set(group_id, member_id, score);
     }
 
-    /// Members at or below `threshold`. Caller supplies the per-group
-    /// `threshold_peer_score` (held on `Group` core, synced via `GroupSync`).
     pub fn members_below_threshold(&self, group_id: &str, threshold: i64) -> Vec<Vec<u8>> {
         self.storage
             .all_scores(group_id)
@@ -185,8 +181,6 @@ mod tests {
     use super::*;
 
     const GROUP: &str = "test-group";
-    /// Test threshold value, used wherever the old `ScoringConfig.removal_threshold`
-    /// was. Real callers pass `Group::threshold_peer_score()`.
     const REMOVAL_THRESHOLD: i64 = 0;
 
     fn default_config() -> ScoringConfig {

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -99,7 +99,9 @@ impl ScoringProvider for FixedScoringProvider {
 // ── Service ─────────────────────────────────────────────────────────
 
 /// Per-member score tracker, parameterised over a [`PeerScoreStorage`] and
-/// a [`ScoringProvider`]. Detects members at/below `removal_threshold`.
+/// a [`ScoringProvider`]. The removal threshold lives per-group on
+/// `Group::threshold_peer_score` and is supplied by callers to
+/// [`Self::is_below_threshold`] / [`Self::members_below_threshold`].
 pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
     storage: S,
     provider: P,
@@ -185,7 +187,7 @@ mod tests {
     const GROUP: &str = "test-group";
     /// Test threshold value, used wherever the old `ScoringConfig.removal_threshold`
     /// was. Real callers pass `Group::threshold_peer_score()`.
-    const THRESHOLD: i64 = 0;
+    const REMOVAL_THRESHOLD: i64 = 0;
 
     fn default_config() -> ScoringConfig {
         ScoringConfig { default_score: 100 }
@@ -345,7 +347,7 @@ mod tests {
             },
         );
 
-        let below = svc.members_below_threshold(GROUP, THRESHOLD);
+        let below = svc.members_below_threshold(GROUP, REMOVAL_THRESHOLD);
         assert_eq!(below.len(), 2);
         assert!(below.contains(&b"alice".to_vec()));
         assert!(below.contains(&b"charlie".to_vec()));
@@ -357,7 +359,7 @@ mod tests {
         let mut svc = make_service();
         svc.add_member(GROUP, b"alice");
 
-        assert!(!svc.is_below_threshold(GROUP, b"alice", THRESHOLD));
+        assert!(!svc.is_below_threshold(GROUP, b"alice", REMOVAL_THRESHOLD));
 
         svc.apply_op(
             GROUP,
@@ -374,14 +376,14 @@ mod tests {
             },
         );
 
-        assert!(svc.is_below_threshold(GROUP, b"alice", THRESHOLD));
+        assert!(svc.is_below_threshold(GROUP, b"alice", REMOVAL_THRESHOLD));
     }
 
     #[test]
     fn test_is_below_threshold_unknown_member() {
         let svc = make_service();
 
-        assert!(!svc.is_below_threshold(GROUP, b"unknown", THRESHOLD));
+        assert!(!svc.is_below_threshold(GROUP, b"unknown", REMOVAL_THRESHOLD));
     }
 
     #[test]
@@ -466,8 +468,8 @@ mod tests {
         );
         assert_eq!(svc1.score_for(GROUP, b"bob"), svc2.score_for(GROUP, b"bob"));
         assert_eq!(
-            svc1.members_below_threshold(GROUP, THRESHOLD).len(),
-            svc2.members_below_threshold(GROUP, THRESHOLD).len()
+            svc1.members_below_threshold(GROUP, REMOVAL_THRESHOLD).len(),
+            svc2.members_below_threshold(GROUP, REMOVAL_THRESHOLD).len()
         );
     }
 
@@ -549,8 +551,8 @@ mod tests {
             },
         );
 
-        let below_a = svc.members_below_threshold(group_a, THRESHOLD);
-        let below_b = svc.members_below_threshold(group_b, THRESHOLD);
+        let below_a = svc.members_below_threshold(group_a, REMOVAL_THRESHOLD);
+        let below_b = svc.members_below_threshold(group_b, REMOVAL_THRESHOLD);
 
         assert_eq!(below_a, vec![b"alice".to_vec()]);
         assert_eq!(below_b, vec![b"bob".to_vec()]);

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -152,19 +152,21 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
         self.storage.set(group_id, member_id, score);
     }
 
-    pub fn members_below_threshold(&self, group_id: &str) -> Vec<Vec<u8>> {
+    /// Members at or below `threshold`. Caller supplies the per-group
+    /// `threshold_peer_score` (held on `Group` core, synced via `GroupSync`).
+    pub fn members_below_threshold(&self, group_id: &str, threshold: i64) -> Vec<Vec<u8>> {
         self.storage
             .all_scores(group_id)
             .into_iter()
-            .filter(|(_, score)| *score <= self.config.removal_threshold)
+            .filter(|(_, score)| *score <= threshold)
             .map(|(id, _)| id)
             .collect()
     }
 
-    pub fn is_below_threshold(&self, group_id: &str, member_id: &[u8]) -> bool {
+    pub fn is_below_threshold(&self, group_id: &str, member_id: &[u8], threshold: i64) -> bool {
         self.storage
             .get(group_id, member_id)
-            .is_some_and(|s| s <= self.config.removal_threshold)
+            .is_some_and(|s| s <= threshold)
     }
 
     pub fn all_members_with_scores(&self, group_id: &str) -> Vec<(Vec<u8>, i64)> {
@@ -181,12 +183,12 @@ mod tests {
     use super::*;
 
     const GROUP: &str = "test-group";
+    /// Test threshold value, used wherever the old `ScoringConfig.removal_threshold`
+    /// was. Real callers pass `Group::threshold_peer_score()`.
+    const THRESHOLD: i64 = 0;
 
     fn default_config() -> ScoringConfig {
-        ScoringConfig {
-            default_score: 100,
-            removal_threshold: 0,
-        }
+        ScoringConfig { default_score: 100 }
     }
 
     fn make_service() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
@@ -343,7 +345,7 @@ mod tests {
             },
         );
 
-        let below = svc.members_below_threshold(GROUP);
+        let below = svc.members_below_threshold(GROUP, THRESHOLD);
         assert_eq!(below.len(), 2);
         assert!(below.contains(&b"alice".to_vec()));
         assert!(below.contains(&b"charlie".to_vec()));
@@ -355,7 +357,7 @@ mod tests {
         let mut svc = make_service();
         svc.add_member(GROUP, b"alice");
 
-        assert!(!svc.is_below_threshold(GROUP, b"alice"));
+        assert!(!svc.is_below_threshold(GROUP, b"alice", THRESHOLD));
 
         svc.apply_op(
             GROUP,
@@ -372,14 +374,14 @@ mod tests {
             },
         );
 
-        assert!(svc.is_below_threshold(GROUP, b"alice"));
+        assert!(svc.is_below_threshold(GROUP, b"alice", THRESHOLD));
     }
 
     #[test]
     fn test_is_below_threshold_unknown_member() {
         let svc = make_service();
 
-        assert!(!svc.is_below_threshold(GROUP, b"unknown"));
+        assert!(!svc.is_below_threshold(GROUP, b"unknown", THRESHOLD));
     }
 
     #[test]
@@ -389,7 +391,6 @@ mod tests {
             FixedScoringProvider::new(HashMap::from([(ScoreEvent::SuccessfulCommit, i64::MAX)])),
             ScoringConfig {
                 default_score: i64::MAX,
-                removal_threshold: 0,
             },
         );
         svc.add_member(GROUP, b"alice");
@@ -465,8 +466,8 @@ mod tests {
         );
         assert_eq!(svc1.score_for(GROUP, b"bob"), svc2.score_for(GROUP, b"bob"));
         assert_eq!(
-            svc1.members_below_threshold(GROUP).len(),
-            svc2.members_below_threshold(GROUP).len()
+            svc1.members_below_threshold(GROUP, THRESHOLD).len(),
+            svc2.members_below_threshold(GROUP, THRESHOLD).len()
         );
     }
 
@@ -548,8 +549,8 @@ mod tests {
             },
         );
 
-        let below_a = svc.members_below_threshold(group_a);
-        let below_b = svc.members_below_threshold(group_b);
+        let below_a = svc.members_below_threshold(group_a, THRESHOLD);
+        let below_b = svc.members_below_threshold(group_b, THRESHOLD);
 
         assert_eq!(below_a, vec![b"alice".to_vec()]);
         assert_eq!(below_b, vec![b"bob".to_vec()]);

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -439,11 +439,11 @@ mod tests {
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
     }
 
-    /// `voting_delay` and `election_voting_delay` are threaded per-group
-    /// from `GroupConfig` at construction. They aren't synced via
-    /// `GroupSync` — each node tunes them locally.
+    /// `voting_delay_for` dispatches on proposal kind: steward-election
+    /// proposals get the shorter `election_voting_delay`, others get
+    /// `voting_delay`.
     #[test]
-    fn test_voting_delay_threaded() {
+    fn test_voting_delay_dispatch_on_proposal_kind() {
         use crate::core::ProposalKind;
 
         let config = GroupConfig {
@@ -460,26 +460,6 @@ mod tests {
             sm.voting_delay_for(ProposalKind::StewardElection),
             Duration::from_secs(3)
         );
-    }
-
-    /// `proposal_expiration` and `consensus_timeout` carry their own
-    /// per-group values from `GroupConfig` and respond to per-field
-    /// setters (the joiner's path when applying a `GroupSync`).
-    #[test]
-    fn test_proposal_expiration_and_consensus_timeout_threaded_and_updated() {
-        let config = GroupConfig {
-            proposal_expiration: Duration::from_secs(7),
-            consensus_timeout: Duration::from_secs(11),
-            ..GroupConfig::default()
-        };
-        let mut sm = GroupStateMachine::new_as_member_with_config(config);
-        assert_eq!(sm.proposal_expiration(), Duration::from_secs(7));
-        assert_eq!(sm.consensus_timeout(), Duration::from_secs(11));
-
-        sm.set_proposal_expiration(Duration::from_secs(99));
-        sm.set_consensus_timeout(Duration::from_secs(123));
-        assert_eq!(sm.proposal_expiration(), Duration::from_secs(99));
-        assert_eq!(sm.consensus_timeout(), Duration::from_secs(123));
     }
 
     #[test]

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -7,6 +7,7 @@ use std::{
 use tracing::info;
 
 use crate::app::config::GroupConfig;
+use crate::core::ProposalKind;
 
 /// Notifies the integrator when a group transitions between [`GroupState`]
 /// variants. Fires from the app layer only — core never calls it.
@@ -89,6 +90,18 @@ pub struct GroupStateMachine {
     /// as the library's tie-break rule. Per-group so a joiner picks up
     /// the steward's value rather than diverging on its local default.
     liveness_criteria_yes: bool,
+    /// Per-member window to cast a manual vote before the auto-vote
+    /// fires. Held per-group (seeded from `GroupConfig` at creation)
+    /// for consistency with the other temporal config — not synced via
+    /// `GroupSync` since each node may tolerate a different window.
+    voting_delay: Duration,
+    /// Auto-vote delay for steward-election proposals; same per-group
+    /// rationale as `voting_delay`.
+    election_voting_delay: Duration,
+    /// Max age (in epochs) of a buffered membership update before it
+    /// gets dropped. Per-group so the policy can be tuned per group;
+    /// not synced via `GroupSync`.
+    pending_update_max_epochs: u32,
 }
 
 impl Default for GroupStateMachine {
@@ -112,6 +125,9 @@ impl GroupStateMachine {
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
             liveness_criteria_yes: config.liveness_criteria_yes,
+            voting_delay: config.voting_delay,
+            election_voting_delay: config.election_voting_delay,
+            pending_update_max_epochs: config.pending_update_max_epochs,
         }
     }
 
@@ -125,6 +141,9 @@ impl GroupStateMachine {
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
             liveness_criteria_yes: config.liveness_criteria_yes,
+            voting_delay: config.voting_delay,
+            election_voting_delay: config.election_voting_delay,
+            pending_update_max_epochs: config.pending_update_max_epochs,
         }
     }
 
@@ -159,6 +178,21 @@ impl GroupStateMachine {
     /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn set_liveness_criteria_yes(&mut self, value: bool) {
         self.liveness_criteria_yes = value;
+    }
+
+    pub fn pending_update_max_epochs(&self) -> u32 {
+        self.pending_update_max_epochs
+    }
+
+    /// Auto-vote delay for the given proposal kind. Steward-election
+    /// proposals use the shorter `election_voting_delay` so recovery
+    /// elections converge fast.
+    pub fn voting_delay_for(&self, kind: ProposalKind) -> Duration {
+        if kind.is_steward_election() {
+            self.election_voting_delay
+        } else {
+            self.voting_delay
+        }
     }
 
     /// Overwritten when the handle receives a `GroupSync` from the steward.
@@ -429,6 +463,32 @@ mod tests {
         let sm = GroupStateMachine::new_as_member_with_config(config);
         assert_eq!(sm.epoch_duration(), long_inactivity());
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
+    }
+
+    /// `voting_delay`, `election_voting_delay`, and
+    /// `pending_update_max_epochs` are threaded per-group from `GroupConfig`
+    /// at construction. They aren't synced via `GroupSync`, so no setter
+    /// is exposed — each node tunes them locally.
+    #[test]
+    fn test_voting_delay_and_pending_update_max_epochs_threaded() {
+        use crate::core::ProposalKind;
+
+        let config = GroupConfig {
+            voting_delay: Duration::from_secs(7),
+            election_voting_delay: Duration::from_secs(3),
+            pending_update_max_epochs: 9,
+            ..GroupConfig::default()
+        };
+        let sm = GroupStateMachine::new_as_member_with_config(config);
+        assert_eq!(
+            sm.voting_delay_for(ProposalKind::Commit),
+            Duration::from_secs(7)
+        );
+        assert_eq!(
+            sm.voting_delay_for(ProposalKind::StewardElection),
+            Duration::from_secs(3)
+        );
+        assert_eq!(sm.pending_update_max_epochs(), 9);
     }
 
     /// `liveness_criteria_yes` is threaded from `GroupConfig` and updated

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -196,19 +196,28 @@ impl GroupStateMachine {
     }
 
     /// Overwritten when the handle receives a `GroupSync` from the steward.
-    pub fn update_timing(
-        &mut self,
-        epoch_duration: Duration,
-        freeze_duration: Duration,
-        retry_inactivity_duration: Duration,
-        proposal_expiration: Duration,
-        consensus_timeout: Duration,
-    ) {
-        self.epoch_duration = epoch_duration;
-        self.freeze_duration = freeze_duration;
-        self.retry_inactivity_duration = retry_inactivity_duration;
-        self.proposal_expiration = proposal_expiration;
-        self.consensus_timeout = consensus_timeout;
+    pub fn set_epoch_duration(&mut self, value: Duration) {
+        self.epoch_duration = value;
+    }
+
+    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    pub fn set_freeze_duration(&mut self, value: Duration) {
+        self.freeze_duration = value;
+    }
+
+    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    pub fn set_retry_inactivity_duration(&mut self, value: Duration) {
+        self.retry_inactivity_duration = value;
+    }
+
+    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    pub fn set_proposal_expiration(&mut self, value: Duration) {
+        self.proposal_expiration = value;
+    }
+
+    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    pub fn set_consensus_timeout(&mut self, value: Duration) {
+        self.consensus_timeout = value;
     }
 
     pub fn start_working(&mut self) {
@@ -508,8 +517,8 @@ mod tests {
     }
 
     /// `proposal_expiration` and `consensus_timeout` carry their own
-    /// per-group values from `GroupConfig` and survive an `update_timing`
-    /// call (the joiner's path when applying a `GroupSync`).
+    /// per-group values from `GroupConfig` and respond to per-field
+    /// setters (the joiner's path when applying a `GroupSync`).
     #[test]
     fn test_proposal_expiration_and_consensus_timeout_threaded_and_updated() {
         let config = GroupConfig {
@@ -521,13 +530,8 @@ mod tests {
         assert_eq!(sm.proposal_expiration(), Duration::from_secs(7));
         assert_eq!(sm.consensus_timeout(), Duration::from_secs(11));
 
-        sm.update_timing(
-            long_inactivity(),
-            long_inactivity(),
-            short_inactivity(),
-            Duration::from_secs(99),
-            Duration::from_secs(123),
-        );
+        sm.set_proposal_expiration(Duration::from_secs(99));
+        sm.set_consensus_timeout(Duration::from_secs(123));
         assert_eq!(sm.proposal_expiration(), Duration::from_secs(99));
         assert_eq!(sm.consensus_timeout(), Duration::from_secs(123));
     }

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -85,11 +85,6 @@ pub struct GroupStateMachine {
     /// across nodes cause split outcomes (see consensus-timeout-divergence
     /// follow-up), so this is per-group and synced via `GroupSync`.
     consensus_timeout: Duration,
-    /// Whether silent voters count as YES at `consensus_timeout` (RFC
-    /// §Creating Voting Proposal). Used both as the auto-vote value and
-    /// as the library's tie-break rule. Per-group so a joiner picks up
-    /// the steward's value rather than diverging on its local default.
-    liveness_criteria_yes: bool,
     /// Per-member window to cast a manual vote before the auto-vote
     /// fires. Held per-group (seeded from `GroupConfig` at creation)
     /// for consistency with the other temporal config — not synced via
@@ -98,10 +93,6 @@ pub struct GroupStateMachine {
     /// Auto-vote delay for steward-election proposals; same per-group
     /// rationale as `voting_delay`.
     election_voting_delay: Duration,
-    /// Max age (in epochs) of a buffered membership update before it
-    /// gets dropped. Per-group so the policy can be tuned per group;
-    /// not synced via `GroupSync`.
-    pending_update_max_epochs: u32,
 }
 
 impl Default for GroupStateMachine {
@@ -124,10 +115,8 @@ impl GroupStateMachine {
             retry_inactivity_duration: config.retry_inactivity_duration,
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
-            liveness_criteria_yes: config.liveness_criteria_yes,
             voting_delay: config.voting_delay,
             election_voting_delay: config.election_voting_delay,
-            pending_update_max_epochs: config.pending_update_max_epochs,
         }
     }
 
@@ -140,10 +129,8 @@ impl GroupStateMachine {
             retry_inactivity_duration: config.retry_inactivity_duration,
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
-            liveness_criteria_yes: config.liveness_criteria_yes,
             voting_delay: config.voting_delay,
             election_voting_delay: config.election_voting_delay,
-            pending_update_max_epochs: config.pending_update_max_epochs,
         }
     }
 
@@ -169,19 +156,6 @@ impl GroupStateMachine {
 
     pub fn consensus_timeout(&self) -> Duration {
         self.consensus_timeout
-    }
-
-    pub fn liveness_criteria_yes(&self) -> bool {
-        self.liveness_criteria_yes
-    }
-
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
-    pub fn set_liveness_criteria_yes(&mut self, value: bool) {
-        self.liveness_criteria_yes = value;
-    }
-
-    pub fn pending_update_max_epochs(&self) -> u32 {
-        self.pending_update_max_epochs
     }
 
     /// Auto-vote delay for the given proposal kind. Steward-election
@@ -474,18 +448,16 @@ mod tests {
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
     }
 
-    /// `voting_delay`, `election_voting_delay`, and
-    /// `pending_update_max_epochs` are threaded per-group from `GroupConfig`
-    /// at construction. They aren't synced via `GroupSync`, so no setter
-    /// is exposed — each node tunes them locally.
+    /// `voting_delay` and `election_voting_delay` are threaded per-group
+    /// from `GroupConfig` at construction. They aren't synced via
+    /// `GroupSync` — each node tunes them locally.
     #[test]
-    fn test_voting_delay_and_pending_update_max_epochs_threaded() {
+    fn test_voting_delay_threaded() {
         use crate::core::ProposalKind;
 
         let config = GroupConfig {
             voting_delay: Duration::from_secs(7),
             election_voting_delay: Duration::from_secs(3),
-            pending_update_max_epochs: 9,
             ..GroupConfig::default()
         };
         let sm = GroupStateMachine::new_as_member_with_config(config);
@@ -497,23 +469,6 @@ mod tests {
             sm.voting_delay_for(ProposalKind::StewardElection),
             Duration::from_secs(3)
         );
-        assert_eq!(sm.pending_update_max_epochs(), 9);
-    }
-
-    /// `liveness_criteria_yes` is threaded from `GroupConfig` and updated
-    /// independently of the timing block (joiner's `GroupSync` path
-    /// applies it via a separate setter).
-    #[test]
-    fn test_liveness_criteria_yes_threaded_and_updated() {
-        let config = GroupConfig {
-            liveness_criteria_yes: false,
-            ..GroupConfig::default()
-        };
-        let mut sm = GroupStateMachine::new_as_member_with_config(config);
-        assert!(!sm.liveness_criteria_yes());
-
-        sm.set_liveness_criteria_yes(true);
-        assert!(sm.liveness_criteria_yes());
     }
 
     /// `proposal_expiration` and `consensus_timeout` carry their own

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -77,21 +77,15 @@ pub struct GroupStateMachine {
     /// Short inactivity window used during recovery; caller of
     /// `check_steward_inactivity` picks which duration to apply.
     retry_inactivity_duration: Duration,
-    /// How long a voting proposal stays valid before expiring (RFC §Creating
-    /// Voting Proposal). Per-group so a joiner picks up the steward's value
-    /// from `GroupSync` rather than diverging on its local default.
+    /// Voting-proposal lifetime (RFC §Creating Voting Proposal). Synced
+    /// via `GroupSync`.
     proposal_expiration: Duration,
-    /// Library deadline for a single consensus session. Mismatched values
-    /// across nodes cause split outcomes (see consensus-timeout-divergence
-    /// follow-up), so this is per-group and synced via `GroupSync`.
+    /// Library deadline per consensus session. Synced via `GroupSync` —
+    /// mismatched values across nodes split outcomes.
     consensus_timeout: Duration,
-    /// Per-member window to cast a manual vote before the auto-vote
-    /// fires. Held per-group (seeded from `GroupConfig` at creation)
-    /// for consistency with the other temporal config — not synced via
-    /// `GroupSync` since each node may tolerate a different window.
+    /// Per-member window before auto-vote fires. Local-only; not synced.
     voting_delay: Duration,
-    /// Auto-vote delay for steward-election proposals; same per-group
-    /// rationale as `voting_delay`.
+    /// Auto-vote delay for steward-election proposals. Local-only.
     election_voting_delay: Duration,
 }
 
@@ -158,9 +152,8 @@ impl GroupStateMachine {
         self.consensus_timeout
     }
 
-    /// Auto-vote delay for the given proposal kind. Steward-election
-    /// proposals use the shorter `election_voting_delay` so recovery
-    /// elections converge fast.
+    /// Steward-election proposals use the shorter `election_voting_delay`
+    /// for fast recovery convergence.
     pub fn voting_delay_for(&self, kind: ProposalKind) -> Duration {
         if kind.is_steward_election() {
             self.election_voting_delay
@@ -169,27 +162,25 @@ impl GroupStateMachine {
         }
     }
 
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    // Setters below are called by `User::on_group_sync` to apply the
+    // steward's `TimingConfig`.
+
     pub fn set_epoch_duration(&mut self, value: Duration) {
         self.epoch_duration = value;
     }
 
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn set_freeze_duration(&mut self, value: Duration) {
         self.freeze_duration = value;
     }
 
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn set_retry_inactivity_duration(&mut self, value: Duration) {
         self.retry_inactivity_duration = value;
     }
 
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn set_proposal_expiration(&mut self, value: Duration) {
         self.proposal_expiration = value;
     }
 
-    /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn set_consensus_timeout(&mut self, value: Duration) {
         self.consensus_timeout = value;
     }

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -77,13 +77,12 @@ pub struct GroupStateMachine {
     /// Short inactivity window used during recovery; caller of
     /// `check_steward_inactivity` picks which duration to apply.
     retry_inactivity_duration: Duration,
-    /// Voting-proposal lifetime (RFC §Creating Voting Proposal). Synced
-    /// via `GroupSync`.
+    /// Voting-proposal lifetime (RFC §Creating Voting Proposal).
     proposal_expiration: Duration,
-    /// Library deadline per consensus session. Synced via `GroupSync` —
-    /// mismatched values across nodes split outcomes.
+    /// Library deadline per consensus session. Mismatched values across
+    /// nodes split outcomes.
     consensus_timeout: Duration,
-    /// Per-member window before auto-vote fires. Local-only; not synced.
+    /// Per-member window before auto-vote fires. Local-only.
     voting_delay: Duration,
     /// Auto-vote delay for steward-election proposals. Local-only.
     election_voting_delay: Duration,

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -84,6 +84,11 @@ pub struct GroupStateMachine {
     /// across nodes cause split outcomes (see consensus-timeout-divergence
     /// follow-up), so this is per-group and synced via `GroupSync`.
     consensus_timeout: Duration,
+    /// Whether silent voters count as YES at `consensus_timeout` (RFC
+    /// §Creating Voting Proposal). Used both as the auto-vote value and
+    /// as the library's tie-break rule. Per-group so a joiner picks up
+    /// the steward's value rather than diverging on its local default.
+    liveness_criteria_yes: bool,
 }
 
 impl Default for GroupStateMachine {
@@ -106,6 +111,7 @@ impl GroupStateMachine {
             retry_inactivity_duration: config.retry_inactivity_duration,
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
+            liveness_criteria_yes: config.liveness_criteria_yes,
         }
     }
 
@@ -118,6 +124,7 @@ impl GroupStateMachine {
             retry_inactivity_duration: config.retry_inactivity_duration,
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
+            liveness_criteria_yes: config.liveness_criteria_yes,
         }
     }
 
@@ -143,6 +150,15 @@ impl GroupStateMachine {
 
     pub fn consensus_timeout(&self) -> Duration {
         self.consensus_timeout
+    }
+
+    pub fn liveness_criteria_yes(&self) -> bool {
+        self.liveness_criteria_yes
+    }
+
+    /// Overwritten when the handle receives a `GroupSync` from the steward.
+    pub fn set_liveness_criteria_yes(&mut self, value: bool) {
+        self.liveness_criteria_yes = value;
     }
 
     /// Overwritten when the handle receives a `GroupSync` from the steward.
@@ -413,6 +429,22 @@ mod tests {
         let sm = GroupStateMachine::new_as_member_with_config(config);
         assert_eq!(sm.epoch_duration(), long_inactivity());
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
+    }
+
+    /// `liveness_criteria_yes` is threaded from `GroupConfig` and updated
+    /// independently of the timing block (joiner's `GroupSync` path
+    /// applies it via a separate setter).
+    #[test]
+    fn test_liveness_criteria_yes_threaded_and_updated() {
+        let config = GroupConfig {
+            liveness_criteria_yes: false,
+            ..GroupConfig::default()
+        };
+        let mut sm = GroupStateMachine::new_as_member_with_config(config);
+        assert!(!sm.liveness_criteria_yes());
+
+        sm.set_liveness_criteria_yes(true);
+        assert!(sm.liveness_criteria_yes());
     }
 
     /// `proposal_expiration` and `consensus_timeout` carry their own

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -76,6 +76,14 @@ pub struct GroupStateMachine {
     /// Short inactivity window used during recovery; caller of
     /// `check_steward_inactivity` picks which duration to apply.
     retry_inactivity_duration: Duration,
+    /// How long a voting proposal stays valid before expiring (RFC §Creating
+    /// Voting Proposal). Per-group so a joiner picks up the steward's value
+    /// from `GroupSync` rather than diverging on its local default.
+    proposal_expiration: Duration,
+    /// Library deadline for a single consensus session. Mismatched values
+    /// across nodes cause split outcomes (see consensus-timeout-divergence
+    /// follow-up), so this is per-group and synced via `GroupSync`.
+    consensus_timeout: Duration,
 }
 
 impl Default for GroupStateMachine {
@@ -96,6 +104,8 @@ impl GroupStateMachine {
             epoch_duration: config.epoch_duration,
             freeze_duration: config.freeze_duration,
             retry_inactivity_duration: config.retry_inactivity_duration,
+            proposal_expiration: config.proposal_expiration,
+            consensus_timeout: config.consensus_timeout,
         }
     }
 
@@ -106,6 +116,8 @@ impl GroupStateMachine {
             epoch_duration: config.epoch_duration,
             freeze_duration: config.freeze_duration,
             retry_inactivity_duration: config.retry_inactivity_duration,
+            proposal_expiration: config.proposal_expiration,
+            consensus_timeout: config.consensus_timeout,
         }
     }
 
@@ -125,16 +137,28 @@ impl GroupStateMachine {
         self.retry_inactivity_duration
     }
 
+    pub fn proposal_expiration(&self) -> Duration {
+        self.proposal_expiration
+    }
+
+    pub fn consensus_timeout(&self) -> Duration {
+        self.consensus_timeout
+    }
+
     /// Overwritten when the handle receives a `GroupSync` from the steward.
     pub fn update_timing(
         &mut self,
         epoch_duration: Duration,
         freeze_duration: Duration,
         retry_inactivity_duration: Duration,
+        proposal_expiration: Duration,
+        consensus_timeout: Duration,
     ) {
         self.epoch_duration = epoch_duration;
         self.freeze_duration = freeze_duration;
         self.retry_inactivity_duration = retry_inactivity_duration;
+        self.proposal_expiration = proposal_expiration;
+        self.consensus_timeout = consensus_timeout;
     }
 
     pub fn start_working(&mut self) {
@@ -389,6 +413,31 @@ mod tests {
         let sm = GroupStateMachine::new_as_member_with_config(config);
         assert_eq!(sm.epoch_duration(), long_inactivity());
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
+    }
+
+    /// `proposal_expiration` and `consensus_timeout` carry their own
+    /// per-group values from `GroupConfig` and survive an `update_timing`
+    /// call (the joiner's path when applying a `GroupSync`).
+    #[test]
+    fn test_proposal_expiration_and_consensus_timeout_threaded_and_updated() {
+        let config = GroupConfig {
+            proposal_expiration: Duration::from_secs(7),
+            consensus_timeout: Duration::from_secs(11),
+            ..GroupConfig::default()
+        };
+        let mut sm = GroupStateMachine::new_as_member_with_config(config);
+        assert_eq!(sm.proposal_expiration(), Duration::from_secs(7));
+        assert_eq!(sm.consensus_timeout(), Duration::from_secs(11));
+
+        sm.update_timing(
+            long_inactivity(),
+            long_inactivity(),
+            short_inactivity(),
+            Duration::from_secs(99),
+            Duration::from_secs(123),
+        );
+        assert_eq!(sm.proposal_expiration(), Duration::from_secs(99));
+        assert_eq!(sm.consensus_timeout(), Duration::from_secs(123));
     }
 
     #[test]

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -146,7 +146,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
         };
 
-        tokio::time::sleep(self.default_group_config.consensus_timeout).await;
+        let consensus_timeout = {
+            let groups = self.groups.read().await;
+            groups
+                .get(&group_name)
+                .map(|e| e.state_machine.consensus_timeout())
+                .unwrap_or(self.default_group_config.consensus_timeout)
+        };
+        tokio::time::sleep(consensus_timeout).await;
         self.resolve_on_timeout(&group_name, proposal_id).await;
     }
 
@@ -168,6 +175,15 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
+        let (proposal_expiration, consensus_timeout) = {
+            let groups = self.groups.read().await;
+            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            (
+                entry.state_machine.proposal_expiration(),
+                entry.state_machine.consensus_timeout(),
+            )
+        };
+
         let (proposal_id, unbundled) = submit_proposal::<P>(
             group_name,
             &request,
@@ -175,8 +191,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             &self.consensus_service,
             ProposalParams {
                 expected_voters,
-                proposal_expiration: self.default_group_config.proposal_expiration,
-                consensus_timeout: self.default_group_config.consensus_timeout,
+                proposal_expiration,
+                consensus_timeout,
                 liveness_criteria_yes: self.default_group_config.liveness_criteria_yes,
             },
         )

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -148,10 +148,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         let consensus_timeout = {
             let groups = self.groups.read().await;
-            groups
-                .get(&group_name)
-                .map(|e| e.state_machine.consensus_timeout())
-                .unwrap_or(self.default_group_config.consensus_timeout)
+            let Some(entry) = groups.get(&group_name) else {
+                return;
+            };
+            entry.state_machine.consensus_timeout()
         };
         tokio::time::sleep(consensus_timeout).await;
         self.resolve_on_timeout(&group_name, proposal_id).await;
@@ -175,13 +175,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
-        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = {
+        let (proposal_expiration, consensus_timeout, liveness_criteria_yes, voting_delay) = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
             (
                 entry.state_machine.proposal_expiration(),
                 entry.state_machine.consensus_timeout(),
                 entry.state_machine.liveness_criteria_yes(),
+                entry.state_machine.voting_delay_for(kind),
             )
         };
 
@@ -263,8 +264,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.handler
                     .on_app_message(group_name, vote_notification)
                     .await?;
-                let delay = self.default_group_config.voting_delay_for(kind);
-                self.spawn_auto_vote(group_name.to_string(), proposal_id, delay);
+                self.spawn_auto_vote(group_name.to_string(), proposal_id, voting_delay);
             }
         }
 

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -175,14 +175,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
-        let (proposal_expiration, consensus_timeout, liveness_criteria_yes, voting_delay) = {
+        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
             (
                 entry.state_machine.proposal_expiration(),
                 entry.state_machine.consensus_timeout(),
                 entry.state_machine.liveness_criteria_yes(),
-                entry.state_machine.voting_delay_for(kind),
             )
         };
 
@@ -264,7 +263,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.handler
                     .on_app_message(group_name, vote_notification)
                     .await?;
-                self.spawn_auto_vote(group_name.to_string(), proposal_id, voting_delay);
+                let voting_delay = {
+                    let groups = self.groups.read().await;
+                    let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+                    entry.state_machine.voting_delay_for(kind)
+                };
+                self.spawn_auto_vote(
+                    group_name.to_string(),
+                    proposal_id,
+                    voting_delay,
+                    liveness_criteria_yes,
+                );
             }
         }
 
@@ -448,14 +457,23 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     }
 
     /// Spawn an auto-vote timer for `(group_name, proposal_id)`. After
-    /// `delay`, the timer casts the local member's vote using
-    /// `liveness_criteria_yes` and broadcasts it. Idempotent — an existing
-    /// handle for the same key is aborted and replaced.
+    /// `delay`, the timer casts `vote` for the local member and broadcasts
+    /// it. Idempotent — an existing handle for the same key is aborted
+    /// and replaced.
     ///
+    /// `vote` is captured at the caller's read of per-group
+    /// `liveness_criteria_yes` so the value is frozen at session start;
+    /// a `GroupSync` arriving during the sleep can't flip the cast.
     /// If the member has already voted or the session has resolved by the
     /// time the timer fires, `cast_vote` returns a benign error
     /// (`UserAlreadyVoted` / `SessionNotActive`); we log at debug and exit.
-    pub(crate) fn spawn_auto_vote(&self, group_name: String, proposal_id: u32, delay: Duration) {
+    pub(crate) fn spawn_auto_vote(
+        &self,
+        group_name: String,
+        proposal_id: u32,
+        delay: Duration,
+        vote: bool,
+    ) {
         self.cancel_auto_vote(&group_name, proposal_id);
 
         let user = self.clone();
@@ -463,13 +481,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         let handle = tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            let vote = {
-                let groups = user.groups.read().await;
-                let Some(entry) = groups.get(&group_name) else {
-                    return;
-                };
-                entry.state_machine.liveness_criteria_yes()
-            };
             if let Err(e) = user.cast_auto_vote(&group_name, proposal_id, vote).await {
                 tracing::debug!(
                     group = %group_name,

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -179,7 +179,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 (
                     e.state_machine.proposal_expiration(),
                     e.state_machine.consensus_timeout(),
-                    e.state_machine.liveness_criteria_yes(),
+                    e.group.liveness_criteria_yes(),
                 )
             })
             .await

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -146,12 +146,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
         };
 
-        let consensus_timeout = {
-            let groups = self.groups.read().await;
-            let Some(entry) = groups.get(&group_name) else {
-                return;
-            };
-            entry.state_machine.consensus_timeout()
+        let Some(consensus_timeout) = self
+            .with_entry(&group_name, |e| e.state_machine.consensus_timeout())
+            .await
+        else {
+            return;
         };
         tokio::time::sleep(consensus_timeout).await;
         self.resolve_on_timeout(&group_name, proposal_id).await;
@@ -175,15 +174,16 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
-        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-            (
-                entry.state_machine.proposal_expiration(),
-                entry.state_machine.consensus_timeout(),
-                entry.state_machine.liveness_criteria_yes(),
-            )
-        };
+        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = self
+            .with_entry(group_name, |e| {
+                (
+                    e.state_machine.proposal_expiration(),
+                    e.state_machine.consensus_timeout(),
+                    e.state_machine.liveness_criteria_yes(),
+                )
+            })
+            .await
+            .ok_or(UserError::GroupNotFound)?;
 
         let (proposal_id, unbundled) = submit_proposal::<P>(
             group_name,
@@ -263,11 +263,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.handler
                     .on_app_message(group_name, vote_notification)
                     .await?;
-                let voting_delay = {
-                    let groups = self.groups.read().await;
-                    let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-                    entry.state_machine.voting_delay_for(kind)
-                };
+                let voting_delay = self
+                    .with_entry(group_name, |e| e.state_machine.voting_delay_for(kind))
+                    .await
+                    .ok_or(UserError::GroupNotFound)?;
                 self.spawn_auto_vote(
                     group_name.to_string(),
                     proposal_id,

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -455,17 +455,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         Ok(())
     }
 
-    /// Spawn an auto-vote timer for `(group_name, proposal_id)`. After
-    /// `delay`, the timer casts `vote` for the local member and broadcasts
-    /// it. Idempotent — an existing handle for the same key is aborted
-    /// and replaced.
-    ///
-    /// `vote` is captured at the caller's read of per-group
-    /// `liveness_criteria_yes` so the value is frozen at session start;
-    /// a `GroupSync` arriving during the sleep can't flip the cast.
-    /// If the member has already voted or the session has resolved by the
-    /// time the timer fires, `cast_vote` returns a benign error
-    /// (`UserAlreadyVoted` / `SessionNotActive`); we log at debug and exit.
+    /// Spawn an auto-vote timer for `(group_name, proposal_id)`. Idempotent
+    /// — an existing handle for the same key is aborted and replaced.
+    /// `vote` is captured before the sleep so a `GroupSync` during the
+    /// delay can't change it.
     pub(crate) fn spawn_auto_vote(
         &self,
         group_name: String,

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -175,12 +175,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
-        let (proposal_expiration, consensus_timeout) = {
+        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
             (
                 entry.state_machine.proposal_expiration(),
                 entry.state_machine.consensus_timeout(),
+                entry.state_machine.liveness_criteria_yes(),
             )
         };
 
@@ -193,7 +194,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 expected_voters,
                 proposal_expiration,
                 consensus_timeout,
-                liveness_criteria_yes: self.default_group_config.liveness_criteria_yes,
+                liveness_criteria_yes,
             },
         )
         .await?;
@@ -458,11 +459,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         self.cancel_auto_vote(&group_name, proposal_id);
 
         let user = self.clone();
-        let vote = self.default_group_config.liveness_criteria_yes;
         let key = (group_name.clone(), proposal_id);
 
         let handle = tokio::spawn(async move {
             tokio::time::sleep(delay).await;
+            let vote = {
+                let groups = user.groups.read().await;
+                let Some(entry) = groups.get(&group_name) else {
+                    return;
+                };
+                entry.state_machine.liveness_criteria_yes()
+            };
             if let Err(e) = user.cast_auto_vote(&group_name, proposal_id, vote).await {
                 tracing::debug!(
                     group = %group_name,

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -349,6 +349,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
         sync: &GroupSync,
     ) -> Result<(), UserError> {
+        let mut protocol_config = ProtocolConfig::new(sync.sn_min as usize, sync.sn_max as usize)?;
+        protocol_config.allow_subset_candidates = sync.allow_subset_candidates;
+
         let mut groups = self.groups.write().await;
         let Some(entry) = groups.get_mut(group_name) else {
             return Ok(());
@@ -360,9 +363,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             sn,
             sync.retry_round,
         )?;
-        entry
-            .group
-            .set_allow_subset_candidates(sync.allow_subset_candidates);
+        entry.group.set_protocol_config(protocol_config);
         entry
             .group
             .set_max_reelection_attempts(sync.max_reelection_attempts);

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -116,15 +116,16 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // YES already resolved the session, so the timer would hit a
         // closed session.
         if expected_voters > 1 {
-            let (delay, vote) = {
-                let groups = self.groups.read().await;
-                let Some(entry) = groups.get(group_name) else {
-                    return Ok(());
-                };
-                (
-                    entry.state_machine.voting_delay_for(kind),
-                    entry.state_machine.liveness_criteria_yes(),
-                )
+            let Some((delay, vote)) = self
+                .with_entry(group_name, |e| {
+                    (
+                        e.state_machine.voting_delay_for(kind),
+                        e.state_machine.liveness_criteria_yes(),
+                    )
+                })
+                .await
+            else {
+                return Ok(());
             };
             self.spawn_auto_vote(group_name.to_string(), proposal_id, delay, vote);
         }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -120,7 +120,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 .with_entry(group_name, |e| {
                     (
                         e.state_machine.voting_delay_for(kind),
-                        e.state_machine.liveness_criteria_yes(),
+                        e.group.liveness_criteria_yes(),
                     )
                 })
                 .await
@@ -373,8 +373,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     .group
                     .set_threshold_peer_score(sync.threshold_peer_score);
                 entry
-                    .state_machine
+                    .group
                     .set_liveness_criteria_yes(sync.liveness_criteria_yes);
+                entry
+                    .group
+                    .set_pending_update_max_epochs(sync.pending_update_max_epochs);
                 if let Some(timing) = &sync.timing {
                     let sm = &mut entry.state_machine;
                     sm.set_epoch_duration(std::time::Duration::from_millis(

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -375,21 +375,22 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     .state_machine
                     .set_liveness_criteria_yes(sync.liveness_criteria_yes);
                 if let Some(timing) = &sync.timing {
-                    let epoch_dur = std::time::Duration::from_millis(timing.epoch_duration_ms);
-                    let freeze_dur = std::time::Duration::from_millis(timing.freeze_duration_ms);
-                    let retry_dur =
-                        std::time::Duration::from_millis(timing.retry_inactivity_duration_ms);
-                    let proposal_exp =
-                        std::time::Duration::from_millis(timing.proposal_expiration_ms);
-                    let consensus_to =
-                        std::time::Duration::from_millis(timing.consensus_timeout_ms);
-                    entry.state_machine.update_timing(
-                        epoch_dur,
-                        freeze_dur,
-                        retry_dur,
-                        proposal_exp,
-                        consensus_to,
-                    );
+                    let sm = &mut entry.state_machine;
+                    sm.set_epoch_duration(std::time::Duration::from_millis(
+                        timing.epoch_duration_ms,
+                    ));
+                    sm.set_freeze_duration(std::time::Duration::from_millis(
+                        timing.freeze_duration_ms,
+                    ));
+                    sm.set_retry_inactivity_duration(std::time::Duration::from_millis(
+                        timing.retry_inactivity_duration_ms,
+                    ));
+                    sm.set_proposal_expiration(std::time::Duration::from_millis(
+                        timing.proposal_expiration_ms,
+                    ));
+                    sm.set_consensus_timeout(std::time::Duration::from_millis(
+                        timing.consensus_timeout_ms,
+                    ));
                 }
             }
         }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -116,13 +116,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // YES already resolved the session, so the timer would hit a
         // closed session.
         if expected_voters > 1 {
-            let groups = self.groups.read().await;
-            let Some(entry) = groups.get(group_name) else {
-                return Ok(());
+            let (delay, vote) = {
+                let groups = self.groups.read().await;
+                let Some(entry) = groups.get(group_name) else {
+                    return Ok(());
+                };
+                (
+                    entry.state_machine.voting_delay_for(kind),
+                    entry.state_machine.liveness_criteria_yes(),
+                )
             };
-            let delay = entry.state_machine.voting_delay_for(kind);
-            drop(groups);
-            self.spawn_auto_vote(group_name.to_string(), proposal_id, delay);
+            self.spawn_auto_vote(group_name.to_string(), proposal_id, delay, vote);
         }
         Ok(())
     }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -319,85 +319,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         };
 
         let current_epoch = self.mls_service.current_epoch(group_name)?;
-        if sync.election_epoch > current_epoch {
-            info!(
-                group = group_name,
-                election_epoch = sync.election_epoch,
-                current_epoch,
-                "group sync rejected: election_epoch > current_epoch"
-            );
-            return Ok(());
-        }
-
-        // Ghost stewards (removed since the list was elected) are skipped at
-        // query time by the `live_*` rotation helpers, so we tolerate them
-        // here rather than rejecting the whole sync. A sync with zero live
-        // stewards is useless and still rejected. Full list pruning on
-        // member removal is tracked in the roadmap.
-        let any_present = sync.steward_members.iter().any(|s| members.contains(s));
-        let ordering_valid = StewardList::validate(
-            &sync.steward_members,
-            sync.election_epoch,
-            group_name.as_bytes(),
-            &sync.steward_members,
-            &ProtocolConfig::new(sync.sn_min as usize, sync.sn_max as usize)?,
-            sync.retry_round,
-        )?;
-        if !(any_present && ordering_valid) {
-            info!(
-                group = group_name,
-                any_present,
-                ordering = ordering_valid,
-                "group sync rejected: invalid"
-            );
+        if !validate_group_sync(group_name, &sync, current_epoch, &members)? {
             return Ok(());
         }
 
         let sn = sync.steward_members.len();
-        {
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
-                entry.group.generate_and_set_steward_list(
-                    sync.election_epoch,
-                    &sync.steward_members,
-                    sn,
-                    sync.retry_round,
-                )?;
-                entry
-                    .group
-                    .set_allow_subset_candidates(sync.allow_subset_candidates);
-                entry
-                    .group
-                    .set_max_reelection_attempts(sync.max_reelection_attempts);
-                entry
-                    .group
-                    .set_threshold_peer_score(sync.threshold_peer_score);
-                entry
-                    .group
-                    .set_liveness_criteria_yes(sync.liveness_criteria_yes);
-                entry
-                    .group
-                    .set_pending_update_max_epochs(sync.pending_update_max_epochs);
-                if let Some(timing) = &sync.timing {
-                    let sm = &mut entry.state_machine;
-                    sm.set_epoch_duration(std::time::Duration::from_millis(
-                        timing.epoch_duration_ms,
-                    ));
-                    sm.set_freeze_duration(std::time::Duration::from_millis(
-                        timing.freeze_duration_ms,
-                    ));
-                    sm.set_retry_inactivity_duration(std::time::Duration::from_millis(
-                        timing.retry_inactivity_duration_ms,
-                    ));
-                    sm.set_proposal_expiration(std::time::Duration::from_millis(
-                        timing.proposal_expiration_ms,
-                    ));
-                    sm.set_consensus_timeout(std::time::Duration::from_millis(
-                        timing.consensus_timeout_ms,
-                    ));
-                }
-            }
-        }
+        self.apply_group_sync_to_entry(group_name, &sync).await?;
 
         if !sync.peer_scores.is_empty() {
             let mut scoring = self.scoring();
@@ -414,6 +341,54 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             timing = sync.timing.is_some(),
             "group sync applied"
         );
+        Ok(())
+    }
+
+    async fn apply_group_sync_to_entry(
+        &self,
+        group_name: &str,
+        sync: &GroupSync,
+    ) -> Result<(), UserError> {
+        let mut groups = self.groups.write().await;
+        let Some(entry) = groups.get_mut(group_name) else {
+            return Ok(());
+        };
+        let sn = sync.steward_members.len();
+        entry.group.generate_and_set_steward_list(
+            sync.election_epoch,
+            &sync.steward_members,
+            sn,
+            sync.retry_round,
+        )?;
+        entry
+            .group
+            .set_allow_subset_candidates(sync.allow_subset_candidates);
+        entry
+            .group
+            .set_max_reelection_attempts(sync.max_reelection_attempts);
+        entry
+            .group
+            .set_threshold_peer_score(sync.threshold_peer_score);
+        entry
+            .group
+            .set_liveness_criteria_yes(sync.liveness_criteria_yes);
+        entry
+            .group
+            .set_pending_update_max_epochs(sync.pending_update_max_epochs);
+        if let Some(timing) = &sync.timing {
+            let sm = &mut entry.state_machine;
+            sm.set_epoch_duration(std::time::Duration::from_millis(timing.epoch_duration_ms));
+            sm.set_freeze_duration(std::time::Duration::from_millis(timing.freeze_duration_ms));
+            sm.set_retry_inactivity_duration(std::time::Duration::from_millis(
+                timing.retry_inactivity_duration_ms,
+            ));
+            sm.set_proposal_expiration(std::time::Duration::from_millis(
+                timing.proposal_expiration_ms,
+            ));
+            sm.set_consensus_timeout(std::time::Duration::from_millis(
+                timing.consensus_timeout_ms,
+            ));
+        }
         Ok(())
     }
 
@@ -451,4 +426,47 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         self.dispatch_inbound_result(&group_name, result).await
     }
+}
+
+/// Returns `true` when the sync is acceptable for application. Logs the
+/// rejection reason on `false`.
+///
+/// `members` is the joiner's current MLS member set; ghost stewards
+/// (removed since the list was elected) are tolerated as long as at
+/// least one listed steward is still present.
+fn validate_group_sync(
+    group_name: &str,
+    sync: &GroupSync,
+    current_epoch: u64,
+    members: &[Vec<u8>],
+) -> Result<bool, UserError> {
+    if sync.election_epoch > current_epoch {
+        info!(
+            group = group_name,
+            election_epoch = sync.election_epoch,
+            current_epoch,
+            "group sync rejected: election_epoch > current_epoch"
+        );
+        return Ok(false);
+    }
+
+    let any_present = sync.steward_members.iter().any(|s| members.contains(s));
+    let ordering_valid = StewardList::validate(
+        &sync.steward_members,
+        sync.election_epoch,
+        group_name.as_bytes(),
+        &sync.steward_members,
+        &ProtocolConfig::new(sync.sn_min as usize, sync.sn_max as usize)?,
+        sync.retry_round,
+    )?;
+    if !(any_present && ordering_valid) {
+        info!(
+            group = group_name,
+            any_present,
+            ordering = ordering_valid,
+            "group sync rejected: invalid"
+        );
+        return Ok(false);
+    }
+    Ok(true)
 }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -359,6 +359,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 entry
                     .group
                     .set_max_reelection_attempts(sync.max_reelection_attempts);
+                entry
+                    .state_machine
+                    .set_liveness_criteria_yes(sync.liveness_criteria_yes);
                 if let Some(timing) = &sync.timing {
                     let epoch_dur = std::time::Duration::from_millis(timing.epoch_duration_ms);
                     let freeze_dur = std::time::Duration::from_millis(timing.freeze_duration_ms);

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -360,6 +360,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     .group
                     .set_max_reelection_attempts(sync.max_reelection_attempts);
                 entry
+                    .group
+                    .set_threshold_peer_score(sync.threshold_peer_score);
+                entry
                     .state_machine
                     .set_liveness_criteria_yes(sync.liveness_criteria_yes);
                 if let Some(timing) = &sync.timing {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -116,7 +116,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // YES already resolved the session, so the timer would hit a
         // closed session.
         if expected_voters > 1 {
-            let delay = self.default_group_config.voting_delay_for(kind);
+            let groups = self.groups.read().await;
+            let Some(entry) = groups.get(group_name) else {
+                return Ok(());
+            };
+            let delay = entry.state_machine.voting_delay_for(kind);
+            drop(groups);
             self.spawn_auto_vote(group_name.to_string(), proposal_id, delay);
         }
         Ok(())

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -364,9 +364,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                     let freeze_dur = std::time::Duration::from_millis(timing.freeze_duration_ms);
                     let retry_dur =
                         std::time::Duration::from_millis(timing.retry_inactivity_duration_ms);
-                    entry
-                        .state_machine
-                        .update_timing(epoch_dur, freeze_dur, retry_dur);
+                    let proposal_exp =
+                        std::time::Duration::from_millis(timing.proposal_expiration_ms);
+                    let consensus_to =
+                        std::time::Duration::from_millis(timing.consensus_timeout_ms);
+                    entry.state_machine.update_timing(
+                        epoch_dur,
+                        freeze_dur,
+                        retry_dur,
+                        proposal_exp,
+                        consensus_to,
+                    );
                 }
             }
         }

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -136,13 +136,16 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // fires `ConsensusReached` on submit, and `apply_consensus_result`
         // needs `is_owner_of_proposal` to be true by then.
         let proposal_id = crate::core::auto_approved_leave_proposal_id(&self_identity);
-        {
+        let (proposal_expiration, consensus_timeout) = {
             let mut groups = self.groups.write().await;
             let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
             entry.group.store_voting_proposal(proposal_id, request);
-        }
+            (
+                entry.state_machine.proposal_expiration(),
+                entry.state_machine.consensus_timeout(),
+            )
+        };
 
-        let config = &self.default_group_config;
         let submitted = submit_self_leave_proposal::<P, _>(
             group_name,
             &self_identity,
@@ -150,8 +153,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             self.eth_signer.clone(),
             ProposalParams {
                 expected_voters: 1,
-                proposal_expiration: config.proposal_expiration,
-                consensus_timeout: config.consensus_timeout,
+                proposal_expiration,
+                consensus_timeout,
                 liveness_criteria_yes: true,
             },
         )

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -40,6 +40,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         let max_reelection_attempts = config.max_reelection_attempts;
         let threshold_peer_score = config.threshold_peer_score;
+        let liveness_criteria_yes = config.liveness_criteria_yes;
+        let pending_update_max_epochs = config.pending_update_max_epochs;
         let (mut group, state_machine) = if is_creation {
             let group = create_group(group_name, &self.mls_service, config.protocol.clone())?;
             let state_machine = GroupStateMachine::new_as_member_with_config(config);
@@ -55,6 +57,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         };
         group.set_max_reelection_attempts(max_reelection_attempts);
         group.set_threshold_peer_score(threshold_peer_score);
+        group.set_liveness_criteria_yes(liveness_criteria_yes);
+        group.set_pending_update_max_epochs(pending_update_max_epochs);
 
         let initial_state = state_machine.current_state();
         if initial_state == GroupState::PendingJoin {

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -39,6 +39,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         }
 
         let max_reelection_attempts = config.max_reelection_attempts;
+        let threshold_peer_score = config.threshold_peer_score;
         let (mut group, state_machine) = if is_creation {
             let group = create_group(group_name, &self.mls_service, config.protocol.clone())?;
             let state_machine = GroupStateMachine::new_as_member_with_config(config);
@@ -53,6 +54,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             (group, state_machine)
         };
         group.set_max_reelection_attempts(max_reelection_attempts);
+        group.set_threshold_peer_score(threshold_peer_score);
 
         let initial_state = state_machine.current_state();
         if initial_state == GroupState::PendingJoin {

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -126,14 +126,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .unwrap_or_else(|e| e.into_inner())
     }
 
-    /// Read-locked snapshot of one group's entry. Returns `None` when the
-    /// entry isn't present — caller chooses between bailing
-    /// (`let Some(x) = ... else { return; }`) or escalating
-    /// (`.ok_or(UserError::GroupNotFound)?`).
-    ///
-    /// `f` runs while the read lock is held, so its return type must own
-    /// any data taken out of the entry — typical use is a tuple of `Copy`
-    /// state-machine fields.
+    /// Run `f` under the groups read lock. Returns `None` if the entry
+    /// isn't present.
     pub(crate) async fn with_entry<R>(
         &self,
         group_name: &str,

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -97,7 +97,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     ) -> Self {
         let scoring_config = ScoringConfig {
             default_score: default_group_config.default_peer_score,
-            removal_threshold: default_group_config.threshold_peer_score,
         };
         Self {
             mls_service: Arc::new(mls_service),

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -39,7 +39,7 @@ mod messaging;
 mod query;
 mod steward;
 
-struct GroupEntry {
+pub(crate) struct GroupEntry {
     group: Group,
     state_machine: GroupStateMachine,
 }
@@ -124,6 +124,23 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         self.scoring_service
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Read-locked snapshot of one group's entry. Returns `None` when the
+    /// entry isn't present — caller chooses between bailing
+    /// (`let Some(x) = ... else { return; }`) or escalating
+    /// (`.ok_or(UserError::GroupNotFound)?`).
+    ///
+    /// `f` runs while the read lock is held, so its return type must own
+    /// any data taken out of the entry — typical use is a tuple of `Copy`
+    /// state-machine fields.
+    pub(crate) async fn with_entry<R>(
+        &self,
+        group_name: &str,
+        f: impl FnOnce(&GroupEntry) -> R,
+    ) -> Option<R> {
+        let groups = self.groups.read().await;
+        groups.get(group_name).map(f)
     }
 
     /// Wallet address as checksummed hex.

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -266,15 +266,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
     ) -> Result<(), UserError> {
         let current_epoch = self.mls_service.current_epoch(group_name)?;
-        let max_age = self.default_group_config.pending_update_max_epochs;
 
-        let members = {
+        let (members, max_age) = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
             if !self.mls_service.has_group(entry.group.group_name()) {
                 return Ok(());
             }
-            group_members(&entry.group, &self.mls_service)?
+            (
+                group_members(&entry.group, &self.mls_service)?,
+                entry.state_machine.pending_update_max_epochs(),
+            )
         };
 
         let mut groups = self.groups.write().await;
@@ -395,10 +397,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             let timing = TimingConfig {
                 epoch_duration_ms: entry.state_machine.epoch_duration().as_millis() as u64,
                 freeze_duration_ms: entry.state_machine.freeze_duration().as_millis() as u64,
-                proposal_expiration_ms: self.default_group_config.proposal_expiration.as_millis()
+                proposal_expiration_ms: entry.state_machine.proposal_expiration().as_millis()
                     as u64,
-                consensus_timeout_ms: self.default_group_config.consensus_timeout.as_millis()
-                    as u64,
+                consensus_timeout_ms: entry.state_machine.consensus_timeout().as_millis() as u64,
                 retry_inactivity_duration_ms: entry
                     .state_machine
                     .retry_inactivity_duration()

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -446,16 +446,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<(), UserError> {
-        let (is_steward, epoch, self_id, threshold) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-            (
-                entry.group.is_steward(),
-                self.mls_service.current_epoch(group_name)?,
-                self.mls_service.wallet_bytes(),
-                entry.group.threshold_peer_score(),
-            )
-        };
+        let epoch = self.mls_service.current_epoch(group_name)?;
+        let self_id = self.mls_service.wallet_bytes();
+        let (is_steward, threshold) = self
+            .with_entry(group_name, |e| {
+                (e.group.is_steward(), e.group.threshold_peer_score())
+            })
+            .await
+            .ok_or(UserError::GroupNotFound)?;
 
         if !is_steward {
             return Ok(());

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -426,6 +426,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.group.max_reelection_attempts(),
                 liveness_criteria_yes: entry.state_machine.liveness_criteria_yes(),
+                threshold_peer_score: entry.group.threshold_peer_score(),
             };
 
             let app_msg: AppMessage = sync.into();
@@ -444,13 +445,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<(), UserError> {
-        let (is_steward, epoch, self_id) = {
+        let (is_steward, epoch, self_id, threshold) = {
             let groups = self.groups.read().await;
             let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
             (
                 entry.group.is_steward(),
                 self.mls_service.current_epoch(group_name)?,
                 self.mls_service.wallet_bytes(),
+                entry.group.threshold_peer_score(),
             )
         };
 
@@ -461,7 +463,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let targets: Vec<(Vec<u8>, i64)> = {
             let scoring = self.scoring();
             scoring
-                .members_below_threshold(group_name)
+                .members_below_threshold(group_name, threshold)
                 .into_iter()
                 .filter(|id| *id != self_id) // self-removal handled separately
                 .map(|id| {

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -425,6 +425,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 timing: Some(timing),
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.group.max_reelection_attempts(),
+                liveness_criteria_yes: entry.state_machine.liveness_criteria_yes(),
             };
 
             let app_msg: AppMessage = sync.into();

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -275,7 +275,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
             (
                 group_members(&entry.group, &self.mls_service)?,
-                entry.state_machine.pending_update_max_epochs(),
+                entry.group.pending_update_max_epochs(),
             )
         };
 
@@ -426,8 +426,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 timing: Some(timing),
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.group.max_reelection_attempts(),
-                liveness_criteria_yes: entry.state_machine.liveness_criteria_yes(),
+                liveness_criteria_yes: entry.group.liveness_criteria_yes(),
                 threshold_peer_score: entry.group.threshold_peer_score(),
+                pending_update_max_epochs: entry.group.pending_update_max_epochs(),
             };
 
             let app_msg: AppMessage = sync.into();

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -204,6 +204,14 @@ pub struct Group {
     /// removal. Joiners pick up the steward's value via `GroupSync` so
     /// every node raises ECPs at the same trigger.
     threshold_peer_score: i64,
+    /// Whether silent voters count as YES at `consensus_timeout` (RFC
+    /// §Creating Voting Proposal). Drives both the auto-vote default and
+    /// the consensus library's tie-break rule. Synced via `GroupSync`.
+    liveness_criteria_yes: bool,
+    /// Max age (in epochs) of a buffered membership update before the
+    /// epoch steward drops it. Synced via `GroupSync` so every node
+    /// expires entries at the same point.
+    pending_update_max_epochs: u32,
 }
 
 /// Fallback ceiling on steward-election retries. One retry gives the
@@ -214,6 +222,14 @@ pub const DEFAULT_MAX_REELECTION_ATTEMPTS: u32 = 1;
 /// Fallback `threshold_peer_score` used until the group creator (or a
 /// `GroupSync` for joiners) overrides it.
 pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
+
+/// Fallback `liveness_criteria_yes` (auto-vote default + tie-break rule)
+/// used until the group creator (or a `GroupSync` for joiners) overrides it.
+pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
+
+/// Fallback `pending_update_max_epochs` used until the group creator (or a
+/// `GroupSync` for joiners) overrides it.
+pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
 
 impl Group {
     fn new_base(group_name: &str, self_identity: Vec<u8>, protocol_config: ProtocolConfig) -> Self {
@@ -237,6 +253,8 @@ impl Group {
             urgent_commit_target: None,
             recovery_mode: false,
             threshold_peer_score: DEFAULT_THRESHOLD_PEER_SCORE,
+            liveness_criteria_yes: DEFAULT_LIVENESS_CRITERIA_YES,
+            pending_update_max_epochs: DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
         }
     }
 
@@ -830,6 +848,28 @@ impl Group {
         self.threshold_peer_score = threshold;
     }
 
+    pub fn liveness_criteria_yes(&self) -> bool {
+        self.liveness_criteria_yes
+    }
+
+    /// Overwrite the per-group auto-vote default. Called from
+    /// group-creation (from `GroupConfig`) and on joiner sync (from
+    /// `GroupSync.liveness_criteria_yes`).
+    pub fn set_liveness_criteria_yes(&mut self, value: bool) {
+        self.liveness_criteria_yes = value;
+    }
+
+    pub fn pending_update_max_epochs(&self) -> u32 {
+        self.pending_update_max_epochs
+    }
+
+    /// Overwrite the per-group buffered-update max age. Called from
+    /// group-creation (from `GroupConfig`) and on joiner sync (from
+    /// `GroupSync.pending_update_max_epochs`).
+    pub fn set_pending_update_max_epochs(&mut self, value: u32) {
+        self.pending_update_max_epochs = value;
+    }
+
     /// Drop a buffered update by target identity.
     ///
     /// Returns `true` if an entry was removed.
@@ -949,6 +989,25 @@ mod tests {
 
         group.set_threshold_peer_score(-25);
         assert_eq!(group.threshold_peer_score(), -25);
+    }
+
+    /// `liveness_criteria_yes` and `pending_update_max_epochs` default to
+    /// their core constants and are overwritten by setters (lifecycle at
+    /// creation, `on_group_sync` for joiners).
+    #[test]
+    fn test_liveness_and_pending_update_max_epochs_default_and_setter() {
+        let config = ProtocolConfig::new(1, 3).unwrap();
+        let mut group = Group::new_as_joiner("test-group", member(1), config);
+        assert_eq!(group.liveness_criteria_yes(), DEFAULT_LIVENESS_CRITERIA_YES);
+        assert_eq!(
+            group.pending_update_max_epochs(),
+            DEFAULT_PENDING_UPDATE_MAX_EPOCHS
+        );
+
+        group.set_liveness_criteria_yes(false);
+        group.set_pending_update_max_epochs(7);
+        assert!(!group.liveness_criteria_yes());
+        assert_eq!(group.pending_update_max_epochs(), 7);
     }
 
     #[test]

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -200,13 +200,13 @@ pub struct Group {
     /// gate so any member can produce the recovery commit.
     recovery_mode: bool,
     /// At or below this score, a member is eligible for
-    /// `SCORE_BELOW_THRESHOLD` ECP removal (RFC §Peer Scoring). Synced.
+    /// `SCORE_BELOW_THRESHOLD` ECP removal (RFC §Peer Scoring).
     threshold_peer_score: i64,
     /// Auto-vote default and consensus tie-break rule (RFC §Creating
-    /// Voting Proposal). Synced.
+    /// Voting Proposal).
     liveness_criteria_yes: bool,
     /// Max age (in epochs) of a buffered membership update before the
-    /// epoch steward drops it. Synced.
+    /// epoch steward drops it.
     pending_update_max_epochs: u32,
 }
 

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -199,12 +199,21 @@ pub struct Group {
     /// While `true`, `create_commit_candidate` bypasses the `is_steward()`
     /// gate so any member can produce the recovery commit.
     recovery_mode: bool,
+    /// Per-group `threshold_peer_score` (RFC §Peer Scoring). A member at
+    /// or below this score is eligible for `SCORE_BELOW_THRESHOLD` ECP
+    /// removal. Joiners pick up the steward's value via `GroupSync` so
+    /// every node raises ECPs at the same trigger.
+    threshold_peer_score: i64,
 }
 
 /// Fallback ceiling on steward-election retries. One retry gives the
 /// responsible proposer a second shot with a different list composition;
 /// beyond that human/policy intervention is expected.
 pub const DEFAULT_MAX_REELECTION_ATTEMPTS: u32 = 1;
+
+/// Fallback `threshold_peer_score` used until the group creator (or a
+/// `GroupSync` for joiners) overrides it.
+pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
 impl Group {
     fn new_base(group_name: &str, self_identity: Vec<u8>, protocol_config: ProtocolConfig) -> Self {
@@ -227,6 +236,7 @@ impl Group {
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
             recovery_mode: false,
+            threshold_peer_score: DEFAULT_THRESHOLD_PEER_SCORE,
         }
     }
 
@@ -807,6 +817,19 @@ impl Group {
         self.max_reelection_attempts = max;
     }
 
+    /// Per-group `threshold_peer_score` (RFC §Peer Scoring). Below or equal
+    /// triggers a `SCORE_BELOW_THRESHOLD` ECP.
+    pub fn threshold_peer_score(&self) -> i64 {
+        self.threshold_peer_score
+    }
+
+    /// Overwrite the per-group threshold. Called from group-creation
+    /// (from `GroupConfig`) and on joiner sync (from
+    /// `GroupSync.threshold_peer_score`).
+    pub fn set_threshold_peer_score(&mut self, threshold: i64) {
+        self.threshold_peer_score = threshold;
+    }
+
     /// Drop a buffered update by target identity.
     ///
     /// Returns `true` if an entry was removed.
@@ -913,6 +936,19 @@ mod tests {
         let list = group.steward_list().unwrap();
         assert_eq!(list.len(), 1);
         assert!(list.contains(&creator));
+    }
+
+    /// `threshold_peer_score` defaults to `DEFAULT_THRESHOLD_PEER_SCORE`
+    /// and is overwritten by the setter (used by `lifecycle::create_group`
+    /// at creation and by `on_group_sync` for joiners).
+    #[test]
+    fn test_threshold_peer_score_default_and_setter() {
+        let config = ProtocolConfig::new(1, 3).unwrap();
+        let mut group = Group::new_as_joiner("test-group", member(1), config);
+        assert_eq!(group.threshold_peer_score(), DEFAULT_THRESHOLD_PEER_SCORE);
+
+        group.set_threshold_peer_score(-25);
+        assert_eq!(group.threshold_peer_score(), -25);
     }
 
     #[test]

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -199,18 +199,14 @@ pub struct Group {
     /// While `true`, `create_commit_candidate` bypasses the `is_steward()`
     /// gate so any member can produce the recovery commit.
     recovery_mode: bool,
-    /// Per-group `threshold_peer_score` (RFC §Peer Scoring). A member at
-    /// or below this score is eligible for `SCORE_BELOW_THRESHOLD` ECP
-    /// removal. Joiners pick up the steward's value via `GroupSync` so
-    /// every node raises ECPs at the same trigger.
+    /// At or below this score, a member is eligible for
+    /// `SCORE_BELOW_THRESHOLD` ECP removal (RFC §Peer Scoring). Synced.
     threshold_peer_score: i64,
-    /// Whether silent voters count as YES at `consensus_timeout` (RFC
-    /// §Creating Voting Proposal). Drives both the auto-vote default and
-    /// the consensus library's tie-break rule. Synced via `GroupSync`.
+    /// Auto-vote default and consensus tie-break rule (RFC §Creating
+    /// Voting Proposal). Synced.
     liveness_criteria_yes: bool,
     /// Max age (in epochs) of a buffered membership update before the
-    /// epoch steward drops it. Synced via `GroupSync` so every node
-    /// expires entries at the same point.
+    /// epoch steward drops it. Synced.
     pending_update_max_epochs: u32,
 }
 
@@ -219,16 +215,10 @@ pub struct Group {
 /// beyond that human/policy intervention is expected.
 pub const DEFAULT_MAX_REELECTION_ATTEMPTS: u32 = 1;
 
-/// Fallback `threshold_peer_score` used until the group creator (or a
-/// `GroupSync` for joiners) overrides it.
 pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
-/// Fallback `liveness_criteria_yes` (auto-vote default + tie-break rule)
-/// used until the group creator (or a `GroupSync` for joiners) overrides it.
 pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
 
-/// Fallback `pending_update_max_epochs` used until the group creator (or a
-/// `GroupSync` for joiners) overrides it.
 pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
 
 impl Group {
@@ -823,27 +813,18 @@ impl Group {
         self.reelection_round = 0;
     }
 
-    /// Group-configured ceiling on retries before the stuck-election error
-    /// surfaces. Shared across the group via `GroupSync`.
     pub fn max_reelection_attempts(&self) -> u32 {
         self.max_reelection_attempts
     }
 
-    /// Overwrite the retry ceiling. Called from group-creation (from
-    /// `GroupConfig`) and on joiner sync (from `GroupSync.max_reelection_attempts`).
     pub fn set_max_reelection_attempts(&mut self, max: u32) {
         self.max_reelection_attempts = max;
     }
 
-    /// Per-group `threshold_peer_score` (RFC §Peer Scoring). Below or equal
-    /// triggers a `SCORE_BELOW_THRESHOLD` ECP.
     pub fn threshold_peer_score(&self) -> i64 {
         self.threshold_peer_score
     }
 
-    /// Overwrite the per-group threshold. Called from group-creation
-    /// (from `GroupConfig`) and on joiner sync (from
-    /// `GroupSync.threshold_peer_score`).
     pub fn set_threshold_peer_score(&mut self, threshold: i64) {
         self.threshold_peer_score = threshold;
     }
@@ -852,9 +833,6 @@ impl Group {
         self.liveness_criteria_yes
     }
 
-    /// Overwrite the per-group auto-vote default. Called from
-    /// group-creation (from `GroupConfig`) and on joiner sync (from
-    /// `GroupSync.liveness_criteria_yes`).
     pub fn set_liveness_criteria_yes(&mut self, value: bool) {
         self.liveness_criteria_yes = value;
     }
@@ -863,9 +841,6 @@ impl Group {
         self.pending_update_max_epochs
     }
 
-    /// Overwrite the per-group buffered-update max age. Called from
-    /// group-creation (from `GroupConfig`) and on joiner sync (from
-    /// `GroupSync.pending_update_max_epochs`).
     pub fn set_pending_update_max_epochs(&mut self, value: u32) {
         self.pending_update_max_epochs = value;
     }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -567,6 +567,10 @@ impl Group {
         &self.protocol_config
     }
 
+    pub fn set_protocol_config(&mut self, config: ProtocolConfig) {
+        self.protocol_config = config;
+    }
+
     pub fn epoch_steward(&self, epoch: u64) -> Option<&[u8]> {
         self.steward_list
             .as_ref()

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -953,38 +953,6 @@ mod tests {
         assert!(list.contains(&creator));
     }
 
-    /// `threshold_peer_score` defaults to `DEFAULT_THRESHOLD_PEER_SCORE`
-    /// and is overwritten by the setter (used by `lifecycle::create_group`
-    /// at creation and by `on_group_sync` for joiners).
-    #[test]
-    fn test_threshold_peer_score_default_and_setter() {
-        let config = ProtocolConfig::new(1, 3).unwrap();
-        let mut group = Group::new_as_joiner("test-group", member(1), config);
-        assert_eq!(group.threshold_peer_score(), DEFAULT_THRESHOLD_PEER_SCORE);
-
-        group.set_threshold_peer_score(-25);
-        assert_eq!(group.threshold_peer_score(), -25);
-    }
-
-    /// `liveness_criteria_yes` and `pending_update_max_epochs` default to
-    /// their core constants and are overwritten by setters (lifecycle at
-    /// creation, `on_group_sync` for joiners).
-    #[test]
-    fn test_liveness_and_pending_update_max_epochs_default_and_setter() {
-        let config = ProtocolConfig::new(1, 3).unwrap();
-        let mut group = Group::new_as_joiner("test-group", member(1), config);
-        assert_eq!(group.liveness_criteria_yes(), DEFAULT_LIVENESS_CRITERIA_YES);
-        assert_eq!(
-            group.pending_update_max_epochs(),
-            DEFAULT_PENDING_UPDATE_MAX_EPOCHS
-        );
-
-        group.set_liveness_criteria_yes(false);
-        group.set_pending_update_max_epochs(7);
-        assert!(!group.liveness_criteria_yes());
-        assert_eq!(group.pending_update_max_epochs(), 7);
-    }
-
     #[test]
     fn test_set_steward_list_on_joiner() {
         let config = ProtocolConfig::new(2, 5).unwrap();

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -1282,4 +1282,55 @@ mod tests {
         assert!(!group.approved_proposals().contains_key(&100));
         assert!(!group.approved_proposals().contains_key(&101));
     }
+
+    fn buffer_remove_at(group: &mut Group, target: &[u8], epoch: u64) {
+        let request = GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(
+                crate::protos::de_mls::messages::v1::RemoveMember {
+                    identity: target.to_vec(),
+                },
+            )),
+        };
+        assert!(group.buffer_pending_update(request, epoch));
+    }
+
+    /// Reducing `pending_update_max_epochs` (e.g. via a tightened
+    /// `GroupSync`) must expire entries whose age now exceeds the new max.
+    /// Cutoff math: `current_epoch - max_age`; entries with
+    /// `first_seen_epoch < cutoff` are dropped.
+    #[test]
+    fn test_expire_pending_updates_drops_entries_older_than_max_age() {
+        let mut group = Group::new_as_creator("g", member(1), default_config()).unwrap();
+        let stale = member(7);
+        let fresh = member(9);
+
+        buffer_remove_at(&mut group, &stale, 0);
+        buffer_remove_at(&mut group, &fresh, 4);
+        assert_eq!(group.pending_update_count(), 2);
+
+        let expired = group.expire_pending_updates(5, 1);
+
+        assert_eq!(expired, vec![stale.clone()]);
+        assert_eq!(group.pending_update_count(), 1);
+        assert!(group.has_pending_update(&fresh));
+        assert!(!group.has_pending_update(&stale));
+    }
+
+    /// `max_age = 0` keeps only entries from the current epoch — the
+    /// boundary case a tightened sync hits when shrinking the window.
+    #[test]
+    fn test_expire_pending_updates_max_age_zero_keeps_only_current_epoch() {
+        let mut group = Group::new_as_creator("g", member(1), default_config()).unwrap();
+        let prior = member(7);
+        let current = member(9);
+
+        buffer_remove_at(&mut group, &prior, 4);
+        buffer_remove_at(&mut group, &current, 5);
+
+        let expired = group.expire_pending_updates(5, 0);
+
+        assert_eq!(expired, vec![prior.clone()]);
+        assert!(group.has_pending_update(&current));
+        assert!(!group.has_pending_update(&prior));
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,8 +43,9 @@ pub use events::{CallbackError, GroupEventHandler};
 
 // ── Group state ──
 pub use group::{
-    DEFAULT_MAX_REELECTION_ATTEMPTS, Group, PendingUpdate, ProposalId,
-    auto_approved_leave_proposal_id, target_identity_of,
+    DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_MAX_REELECTION_ATTEMPTS,
+    DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_THRESHOLD_PEER_SCORE, Group, PendingUpdate,
+    ProposalId, auto_approved_leave_proposal_id, target_identity_of,
 };
 
 // ── Proposal classification ──

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -72,8 +72,6 @@ pub trait ScoringProvider {
 pub struct ScoringConfig {
     /// Score assigned to newly added members.
     pub default_score: i64,
-    /// Members at or below this score are candidates for removal.
-    pub removal_threshold: i64,
 }
 
 /// Per-(group, member) score persistence. Default impl:

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -107,24 +107,20 @@ message GroupSync {
   bool allow_subset_candidates = 5;
   repeated PeerScore peer_scores = 6;
   TimingConfig timing = 7;
-  // Retry round the accepted steward list was generated with. Joiners
-  // need this to reproduce the deterministic sort when validating.
+  // Seed for the deterministic steward-list sort; joiners reproduce the
+  // ordering when validating.
   uint32 retry_round = 8;
-  // Group's configured ceiling on election retries. Joiners apply this
-  // value so the stuck-election error path triggers consistently across
-  // the group.
+  // Ceiling on steward-election retries before the stuck-election error
+  // surfaces.
   uint32 max_reelection_attempts = 9;
-  // Whether silent voters count as YES at consensus_timeout (RFC §Creating
-  // Voting Proposal). Joiners adopt this so auto-votes and tie-breaks
-  // match the rest of the group.
+  // Auto-vote default and consensus tie-break rule
+  // (RFC §Creating Voting Proposal).
   bool liveness_criteria_yes = 10;
-  // Score at or below which a member becomes eligible for SCORE_BELOW_THRESHOLD
-  // ECP removal (RFC §Peer Scoring). Joiners adopt this so removal ECPs
-  // are raised at a consistent trigger across the group.
+  // At or below this score, a member is eligible for SCORE_BELOW_THRESHOLD
+  // ECP removal (RFC §Peer Scoring).
   int64 threshold_peer_score = 11;
   // Max age (in epochs) of a buffered membership update before the epoch
-  // steward drops it. Joiners adopt this so every node expires entries at
-  // the same point.
+  // steward drops it.
   uint32 pending_update_max_epochs = 12;
 }
 

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -114,6 +114,10 @@ message GroupSync {
   // value so the stuck-election error path triggers consistently across
   // the group.
   uint32 max_reelection_attempts = 9;
+  // Whether silent voters count as YES at consensus_timeout (RFC §Creating
+  // Voting Proposal). Joiners adopt this so auto-votes and tie-breaks
+  // match the rest of the group.
+  bool liveness_criteria_yes = 10;
 }
 
 message PeerScore {

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -118,6 +118,10 @@ message GroupSync {
   // Voting Proposal). Joiners adopt this so auto-votes and tie-breaks
   // match the rest of the group.
   bool liveness_criteria_yes = 10;
+  // Score at or below which a member becomes eligible for SCORE_BELOW_THRESHOLD
+  // ECP removal (RFC §Peer Scoring). Joiners adopt this so removal ECPs
+  // are raised at a consistent trigger across the group.
+  int64 threshold_peer_score = 11;
 }
 
 message PeerScore {

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -122,6 +122,10 @@ message GroupSync {
   // ECP removal (RFC §Peer Scoring). Joiners adopt this so removal ECPs
   // are raised at a consistent trigger across the group.
   int64 threshold_peer_score = 11;
+  // Max age (in epochs) of a buffered membership update before the epoch
+  // steward drops it. Joiners adopt this so every node expires entries at
+  // the same point.
+  uint32 pending_update_max_epochs = 12;
 }
 
 message PeerScore {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -229,7 +229,6 @@ pub fn make_scoring() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScori
         FixedScoringProvider::with_default_deltas(),
         ScoringConfig {
             default_score: DEFAULT_SCORE,
-            removal_threshold: REMOVAL_THRESHOLD,
         },
     )
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,7 +24,6 @@ use de_mls::mls_crypto::{MemoryDeMlsStorage, MlsService, parse_wallet_address};
 use de_mls::protos::de_mls::messages::v1::AppMessage;
 
 pub const DEFAULT_SCORE: i64 = 100;
-pub const REMOVAL_THRESHOLD: i64 = 0;
 
 // ─────────────────────────── Mock handler ───────────────────────────
 

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -460,6 +460,7 @@ fn test_group_sync_roundtrip() {
         retry_round: 0,
         max_reelection_attempts: 1,
         liveness_criteria_yes: true,
+        threshold_peer_score: 0,
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
@@ -585,6 +586,7 @@ fn test_group_sync_idempotent_for_existing_members() {
         retry_round: 0,
         max_reelection_attempts: 1,
         liveness_criteria_yes: true,
+        threshold_peer_score: 0,
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet =
@@ -685,6 +687,7 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
         retry_round: list.retry_round(),
         max_reelection_attempts: steward_handle.max_reelection_attempts(),
         liveness_criteria_yes: true,
+        threshold_peer_score: 0,
     };
 
     // Joiner re-derives the ordering using the wire seed — should match.

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -540,6 +540,154 @@ fn test_group_sync_roundtrip() {
     assert_eq!(joiner_list.election_epoch(), steward_list.election_epoch());
 }
 
+/// `GroupSync` propagates the per-group config that lives on `Group`
+/// (threshold, liveness flag, pending-update max age) end-to-end across
+/// the wire. Steward sets non-default values; joiner receives the sync
+/// and reads the steward's values back via the same getters production
+/// code uses. Also exercises a behaviour assertion: the synced
+/// threshold drives `members_below_threshold` selection.
+#[test]
+fn test_group_sync_propagates_divergent_per_group_config() {
+    use de_mls::app::{InMemoryPeerScoreStorage, PeerScoringService};
+    use de_mls::core::{ScoreEvent, ScoreOp, ScoringConfig};
+    use de_mls::protos::de_mls::messages::v1::{GroupSync, PeerScore};
+
+    const STEWARD_THRESHOLD: i64 = -50;
+    const STEWARD_LIVENESS_YES: bool = false;
+    const STEWARD_PENDING_MAX_EPOCHS: u32 = 11;
+
+    let group_name = "sync-divergent-config";
+    let steward_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let joiner_hex = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+    let (steward_mls, mut steward_handle) = setup_steward(group_name, steward_hex);
+    let (joiner_mls, mut joiner_handle, kp_packet) = setup_joiner(group_name, joiner_hex);
+
+    // Steward configures the group with non-default per-group state.
+    steward_handle.set_threshold_peer_score(STEWARD_THRESHOLD);
+    steward_handle.set_liveness_criteria_yes(STEWARD_LIVENESS_YES);
+    steward_handle.set_pending_update_max_epochs(STEWARD_PENDING_MAX_EPOCHS);
+
+    // Joiner starts with the core defaults — different from the steward's.
+    assert_ne!(joiner_handle.threshold_peer_score(), STEWARD_THRESHOLD);
+    assert_ne!(joiner_handle.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
+    assert_ne!(
+        joiner_handle.pending_update_max_epochs(),
+        STEWARD_PENDING_MAX_EPOCHS
+    );
+
+    // Steward adds joiner so a Welcome path exists.
+    let (welcome_packet, _) = steward_add_joiner(&steward_mls, &mut steward_handle, &kp_packet);
+    process_inbound(
+        &mut joiner_handle,
+        &welcome_packet.payload,
+        WELCOME_SUBTOPIC,
+        &joiner_mls,
+    )
+    .unwrap();
+
+    // Steward builds a GroupSync from per-group state. Two members are
+    // included with peer scores below STEWARD_THRESHOLD so the synced
+    // threshold has something to assert on.
+    let alice = b"alice".to_vec();
+    let bob = b"bob".to_vec();
+    let steward_list = steward_handle.steward_list().unwrap();
+    let sync = GroupSync {
+        steward_members: steward_list.members().to_vec(),
+        election_epoch: steward_list.election_epoch(),
+        sn_min: steward_list.config().sn_min as u32,
+        sn_max: steward_list.config().sn_max as u32,
+        allow_subset_candidates: steward_handle.allow_subset_candidates(),
+        peer_scores: vec![
+            PeerScore {
+                member_id: alice.clone(),
+                score: STEWARD_THRESHOLD - 10,
+            },
+            PeerScore {
+                member_id: bob.clone(),
+                score: STEWARD_THRESHOLD + 10,
+            },
+        ],
+        timing: None,
+        retry_round: steward_list.retry_round(),
+        max_reelection_attempts: steward_handle.max_reelection_attempts(),
+        liveness_criteria_yes: steward_handle.liveness_criteria_yes(),
+        threshold_peer_score: steward_handle.threshold_peer_score(),
+        pending_update_max_epochs: steward_handle.pending_update_max_epochs(),
+    };
+    let app_msg: AppMessage = sync.clone().into();
+    let sync_packet =
+        build_message(&steward_handle, &steward_mls, &app_msg, b"test-app-id").unwrap();
+
+    // Joiner processes the encrypted sync.
+    let result = process_inbound(
+        &mut joiner_handle,
+        &sync_packet.payload,
+        APP_MSG_SUBTOPIC,
+        &joiner_mls,
+    )
+    .unwrap();
+    let received = match result {
+        ProcessResult::GroupSyncReceived(s) => s,
+        other => panic!("Expected GroupSyncReceived, got {:?}", other),
+    };
+
+    // The new fields survive the wire.
+    assert_eq!(received.threshold_peer_score, STEWARD_THRESHOLD);
+    assert_eq!(received.liveness_criteria_yes, STEWARD_LIVENESS_YES);
+    assert_eq!(
+        received.pending_update_max_epochs,
+        STEWARD_PENDING_MAX_EPOCHS
+    );
+
+    // App-layer application — same setters `User::on_group_sync` uses.
+    joiner_handle.set_threshold_peer_score(received.threshold_peer_score);
+    joiner_handle.set_liveness_criteria_yes(received.liveness_criteria_yes);
+    joiner_handle.set_pending_update_max_epochs(received.pending_update_max_epochs);
+
+    // Joiner now reads the steward's values via the same getters
+    // production code uses (steward.rs::check_and_initiate_score_removals,
+    // consensus.rs::register_new_proposal, steward.rs::prune_pending_updates_after_commit).
+    assert_eq!(joiner_handle.threshold_peer_score(), STEWARD_THRESHOLD);
+    assert_eq!(joiner_handle.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
+    assert_eq!(
+        joiner_handle.pending_update_max_epochs(),
+        STEWARD_PENDING_MAX_EPOCHS
+    );
+
+    // Behaviour assertion: a scoring lookup at the synced threshold
+    // returns members at or below it.
+    let mut scoring = PeerScoringService::new(
+        InMemoryPeerScoreStorage::new(),
+        de_mls::app::FixedScoringProvider::with_default_deltas(),
+        ScoringConfig { default_score: 100 },
+    );
+    for ps in &received.peer_scores {
+        scoring.set_score(group_name, &ps.member_id, ps.score);
+    }
+    // Apply a single op so the score-mutation path is also exercised.
+    scoring.apply_op(
+        group_name,
+        &ScoreOp {
+            member_id: alice.clone(),
+            event: ScoreEvent::SuccessfulCommit,
+        },
+    );
+    let below = scoring.members_below_threshold(group_name, joiner_handle.threshold_peer_score());
+    assert!(
+        below.contains(&alice),
+        "alice (score {}) is below the synced threshold {}",
+        STEWARD_THRESHOLD - 10 + 10,
+        joiner_handle.threshold_peer_score()
+    );
+    assert!(
+        !below.contains(&bob),
+        "bob (score {}) is above the synced threshold {}",
+        STEWARD_THRESHOLD + 10,
+        joiner_handle.threshold_peer_score()
+    );
+}
+
 /// If a member already has a steward list, receiving a sync message is a no-op.
 #[test]
 fn test_group_sync_idempotent_for_existing_members() {

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -461,6 +461,7 @@ fn test_group_sync_roundtrip() {
         max_reelection_attempts: 1,
         liveness_criteria_yes: true,
         threshold_peer_score: 0,
+        pending_update_max_epochs: 3,
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
@@ -587,6 +588,7 @@ fn test_group_sync_idempotent_for_existing_members() {
         max_reelection_attempts: 1,
         liveness_criteria_yes: true,
         threshold_peer_score: 0,
+        pending_update_max_epochs: 3,
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet =
@@ -688,6 +690,7 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
         max_reelection_attempts: steward_handle.max_reelection_attempts(),
         liveness_criteria_yes: true,
         threshold_peer_score: 0,
+        pending_update_max_epochs: 3,
     };
 
     // Joiner re-derives the ordering using the wire seed — should match.

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -459,6 +459,7 @@ fn test_group_sync_roundtrip() {
         timing: None,
         retry_round: 0,
         max_reelection_attempts: 1,
+        liveness_criteria_yes: true,
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
@@ -583,6 +584,7 @@ fn test_group_sync_idempotent_for_existing_members() {
         timing: None,
         retry_round: 0,
         max_reelection_attempts: 1,
+        liveness_criteria_yes: true,
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet =
@@ -682,6 +684,7 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
         timing: None,
         retry_round: list.retry_round(),
         max_reelection_attempts: steward_handle.max_reelection_attempts(),
+        liveness_criteria_yes: true,
     };
 
     // Joiner re-derives the ordering using the wire seed — should match.

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -540,12 +540,10 @@ fn test_group_sync_roundtrip() {
     assert_eq!(joiner_list.election_epoch(), steward_list.election_epoch());
 }
 
-/// `GroupSync` propagates the per-group config that lives on `Group`
-/// (threshold, liveness flag, pending-update max age) end-to-end across
-/// the wire. Steward sets non-default values; joiner receives the sync
-/// and reads the steward's values back via the same getters production
-/// code uses. Also exercises a behaviour assertion: the synced
-/// threshold drives `members_below_threshold` selection.
+/// `GroupSync` carries per-group config from steward to joiner: the
+/// joiner adopts the steward's values via the same getters production
+/// code uses, and `members_below_threshold` selects on the synced
+/// threshold.
 #[test]
 fn test_group_sync_propagates_divergent_per_group_config() {
     use de_mls::app::{InMemoryPeerScoreStorage, PeerScoringService};
@@ -555,13 +553,18 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     const STEWARD_THRESHOLD: i64 = -50;
     const STEWARD_LIVENESS_YES: bool = false;
     const STEWARD_PENDING_MAX_EPOCHS: u32 = 11;
+    const STEWARD_SN_MIN: usize = 2;
+    const STEWARD_SN_MAX: usize = 8;
 
     let group_name = "sync-divergent-config";
     let steward_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
     let joiner_hex = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
-    let (steward_mls, mut steward_handle) = setup_steward(group_name, steward_hex);
-    let (joiner_mls, mut joiner_handle, kp_packet) = setup_joiner(group_name, joiner_hex);
+    let steward_protocol = ProtocolConfig::new(STEWARD_SN_MIN, STEWARD_SN_MAX).unwrap();
+    let (steward_mls, mut steward_handle) =
+        setup_steward_with_config(group_name, steward_hex, steward_protocol);
+    let (joiner_mls, mut joiner_handle, kp_packet) =
+        setup_joiner_with_config(group_name, joiner_hex, default_steward_config());
 
     // Steward configures the group with non-default per-group state.
     steward_handle.set_threshold_peer_score(STEWARD_THRESHOLD);
@@ -575,6 +578,8 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         joiner_handle.pending_update_max_epochs(),
         STEWARD_PENDING_MAX_EPOCHS
     );
+    assert_ne!(joiner_handle.protocol_config().sn_min, STEWARD_SN_MIN);
+    assert_ne!(joiner_handle.protocol_config().sn_max, STEWARD_SN_MAX);
 
     // Steward adds joiner so a Welcome path exists.
     let (welcome_packet, _) = steward_add_joiner(&steward_mls, &mut steward_handle, &kp_packet);
@@ -639,21 +644,28 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         received.pending_update_max_epochs,
         STEWARD_PENDING_MAX_EPOCHS
     );
+    assert_eq!(received.sn_min as usize, STEWARD_SN_MIN);
+    assert_eq!(received.sn_max as usize, STEWARD_SN_MAX);
 
     // App-layer application — same setters `User::on_group_sync` uses.
+    let mut applied_protocol =
+        ProtocolConfig::new(received.sn_min as usize, received.sn_max as usize).unwrap();
+    applied_protocol.allow_subset_candidates = received.allow_subset_candidates;
+    joiner_handle.set_protocol_config(applied_protocol);
     joiner_handle.set_threshold_peer_score(received.threshold_peer_score);
     joiner_handle.set_liveness_criteria_yes(received.liveness_criteria_yes);
     joiner_handle.set_pending_update_max_epochs(received.pending_update_max_epochs);
 
-    // Joiner now reads the steward's values via the same getters
-    // production code uses (steward.rs::check_and_initiate_score_removals,
-    // consensus.rs::register_new_proposal, steward.rs::prune_pending_updates_after_commit).
+    // Joiner now reads the steward's values via the same getters production
+    // code consults.
     assert_eq!(joiner_handle.threshold_peer_score(), STEWARD_THRESHOLD);
     assert_eq!(joiner_handle.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
     assert_eq!(
         joiner_handle.pending_update_max_epochs(),
         STEWARD_PENDING_MAX_EPOCHS
     );
+    assert_eq!(joiner_handle.protocol_config().sn_min, STEWARD_SN_MIN);
+    assert_eq!(joiner_handle.protocol_config().sn_max, STEWARD_SN_MAX);
 
     // Behaviour assertion: a scoring lookup at the synced threshold
     // returns members at or below it.

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -13,7 +13,7 @@ use de_mls::protos::de_mls::messages::v1::{
 };
 
 mod common;
-use common::{make_scoring, setup_mls};
+use common::{REMOVAL_THRESHOLD, make_scoring, setup_mls};
 
 // ─────────────────────────── Tests ───────────────────────────
 
@@ -155,7 +155,7 @@ fn test_full_pipeline_penalties_to_removal() {
             event: ScoreEvent::BrokenCommit,
         },
     );
-    assert!(!scoring.is_below_threshold(group_name, &target_id));
+    assert!(!scoring.is_below_threshold(group_name, &target_id, REMOVAL_THRESHOLD));
 
     // 50 - 50 = 0 (EmergencyNoCreator)
     scoring.apply_op(
@@ -165,10 +165,10 @@ fn test_full_pipeline_penalties_to_removal() {
             event: ScoreEvent::EmergencyNoCreator,
         },
     );
-    assert!(scoring.is_below_threshold(group_name, &target_id));
+    assert!(scoring.is_below_threshold(group_name, &target_id, REMOVAL_THRESHOLD));
 
     // Now steward creates SCORE_BELOW_THRESHOLD ECP
-    let below = scoring.members_below_threshold(group_name);
+    let below = scoring.members_below_threshold(group_name, REMOVAL_THRESHOLD);
     assert!(below.contains(&target_id));
 
     let current_score = scoring.score_for(group_name, &target_id).unwrap();
@@ -266,12 +266,12 @@ fn test_steward_skips_self_for_removal() {
         },
     );
 
-    assert!(scoring.is_below_threshold(group_name, &steward_id));
-    assert!(scoring.is_below_threshold(group_name, &other_id));
+    assert!(scoring.is_below_threshold(group_name, &steward_id, REMOVAL_THRESHOLD));
+    assert!(scoring.is_below_threshold(group_name, &other_id, REMOVAL_THRESHOLD));
 
     // Filter as the steward would
     let targets: Vec<Vec<u8>> = scoring
-        .members_below_threshold(group_name)
+        .members_below_threshold(group_name, REMOVAL_THRESHOLD)
         .into_iter()
         .filter(|id| *id != steward_id)
         .collect();

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -280,6 +280,48 @@ fn test_steward_skips_self_for_removal() {
     assert_eq!(targets[0], other_id);
 }
 
+/// `members_below_threshold` selects members against the per-group
+/// threshold the caller passes in (held on `Group::threshold_peer_score`),
+/// not against any global default. Drives the steward removal trigger
+/// in `User::check_and_initiate_score_removals` after a `GroupSync` may
+/// have updated the group's threshold.
+#[test]
+fn test_members_below_threshold_uses_per_group_value() {
+    let group_name = "per-group-threshold";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let group = create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
+    assert_eq!(
+        group.threshold_peer_score(),
+        de_mls::core::DEFAULT_THRESHOLD_PEER_SCORE
+    );
+
+    let alice = vec![0xAA];
+    let bob = vec![0xBB];
+    let carol = vec![0xCC];
+
+    let mut scoring = make_scoring();
+    scoring.add_member(group_name, &alice);
+    scoring.add_member(group_name, &bob);
+    scoring.add_member(group_name, &carol);
+    scoring.set_score(group_name, &alice, -10);
+    scoring.set_score(group_name, &bob, -30);
+    scoring.set_score(group_name, &carol, -60);
+
+    // Strict threshold (-50): only Carol qualifies for removal.
+    let strict = scoring.members_below_threshold(group_name, -50);
+    assert!(strict.contains(&carol));
+    assert!(!strict.contains(&bob));
+    assert!(!strict.contains(&alice));
+
+    // Loose threshold (-25, e.g. after a GroupSync reduced strictness):
+    // both Bob and Carol qualify; Alice still safe.
+    let loose = scoring.members_below_threshold(group_name, -25);
+    assert!(loose.contains(&bob));
+    assert!(loose.contains(&carol));
+    assert!(!loose.contains(&alice));
+}
+
 /// ViolationEvidence::score_below_threshold constructor correctness.
 #[test]
 fn test_violation_evidence_score_below_threshold_constructor() {

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -280,11 +280,8 @@ fn test_steward_skips_self_for_removal() {
     assert_eq!(targets[0], other_id);
 }
 
-/// `members_below_threshold` selects members against the per-group
-/// threshold the caller passes in (held on `Group::threshold_peer_score`),
-/// not against any global default. Drives the steward removal trigger
-/// in `User::check_and_initiate_score_removals` after a `GroupSync` may
-/// have updated the group's threshold.
+/// `members_below_threshold` selects against the threshold passed in,
+/// not a global default.
 #[test]
 fn test_members_below_threshold_uses_per_group_value() {
     let group_name = "per-group-threshold";

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -13,7 +13,7 @@ use de_mls::protos::de_mls::messages::v1::{
 };
 
 mod common;
-use common::{REMOVAL_THRESHOLD, make_scoring, setup_mls};
+use common::{make_scoring, setup_mls};
 
 // ─────────────────────────── Tests ───────────────────────────
 
@@ -142,6 +142,7 @@ fn test_full_pipeline_penalties_to_removal() {
     let steward_id = alice_mls.wallet_bytes();
     let target_id = vec![0xDD];
 
+    let threshold = group.threshold_peer_score();
     let mut scoring = make_scoring();
     scoring.add_member(group_name, &steward_id);
     scoring.add_member(group_name, &target_id);
@@ -155,7 +156,7 @@ fn test_full_pipeline_penalties_to_removal() {
             event: ScoreEvent::BrokenCommit,
         },
     );
-    assert!(!scoring.is_below_threshold(group_name, &target_id, REMOVAL_THRESHOLD));
+    assert!(!scoring.is_below_threshold(group_name, &target_id, threshold));
 
     // 50 - 50 = 0 (EmergencyNoCreator)
     scoring.apply_op(
@@ -165,10 +166,10 @@ fn test_full_pipeline_penalties_to_removal() {
             event: ScoreEvent::EmergencyNoCreator,
         },
     );
-    assert!(scoring.is_below_threshold(group_name, &target_id, REMOVAL_THRESHOLD));
+    assert!(scoring.is_below_threshold(group_name, &target_id, threshold));
 
     // Now steward creates SCORE_BELOW_THRESHOLD ECP
-    let below = scoring.members_below_threshold(group_name, REMOVAL_THRESHOLD);
+    let below = scoring.members_below_threshold(group_name, threshold);
     assert!(below.contains(&target_id));
 
     let current_score = scoring.score_for(group_name, &target_id).unwrap();
@@ -228,6 +229,11 @@ fn test_dedup_pending_removal_targets() {
 #[test]
 fn test_steward_skips_self_for_removal() {
     let group_name = "removal-self-guard";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let alice_mls = setup_mls(alice_hex);
+    let group = create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
+    let threshold = group.threshold_peer_score();
+
     let mut scoring = make_scoring();
 
     let steward_id = vec![0x01];
@@ -266,12 +272,12 @@ fn test_steward_skips_self_for_removal() {
         },
     );
 
-    assert!(scoring.is_below_threshold(group_name, &steward_id, REMOVAL_THRESHOLD));
-    assert!(scoring.is_below_threshold(group_name, &other_id, REMOVAL_THRESHOLD));
+    assert!(scoring.is_below_threshold(group_name, &steward_id, threshold));
+    assert!(scoring.is_below_threshold(group_name, &other_id, threshold));
 
     // Filter as the steward would
     let targets: Vec<Vec<u8>> = scoring
-        .members_below_threshold(group_name, REMOVAL_THRESHOLD)
+        .members_below_threshold(group_name, threshold)
         .into_iter()
         .filter(|id| *id != steward_id)
         .collect();


### PR DESCRIPTION
GroupSync now carries every per-group setting that affects protocol behaviour, so a joiner adopts the steward's values instead of its own User defaults.

What's new on the wire and applied joiner-side:

- `proposal_expiration` and `consensus_timeout` (already in the timing proto, silently dropped before this PR)
- `liveness_criteria_yes` (auto-vote default and consensus tie-break rule)
- `threshold_peer_score` (when the steward starts ECP-removing low-scored members)
- `pending_update_max_epochs` (when buffered membership changes age out)
- `sn_min` / `sn_max` (the steward-list size bounds — previously validated against but never actually applied)

Per-group state moved to the right layer along the way. Protocol parameters live in core and are synced; temporal parameters live in app, with the synced subset covered by the timing proto and the auto-vote delays kept deliberately local-only. The User-wide config struct is now consulted only at User construction and group creation; everywhere else reads from per-group state.

Side fixes: auto-vote no longer re-reads its tally rule after sleeping (a sync arriving during the delay can't flip the cast); the lock-then-lookup pattern that recurred across five sites is consolidated; the on-sync handler is split into validation and application halves; default-constant duplicates between core and app are removed.

Tests: end-to-end propagation with steward and joiner starting from divergent values; pending-update expiry boundary cases for the synced max age; per-group-threshold selection in the steward removal path. Three pure setter/getter unit tests dropped — they were verifying that field-write-then-read works.