### PR TITLE
feat(group_sync): tighten joiner-side validation

### DIFF
--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -471,5 +471,107 @@ fn validate_group_sync(
         );
         return Ok(false);
     }
+
+    if let Some(timing) = &sync.timing
+        && let Some(zero_field) = first_zero_timing_field(timing)
+    {
+        info!(
+            group = group_name,
+            field = zero_field,
+            "group sync rejected: zero-valued timing field"
+        );
+        return Ok(false);
+    }
     Ok(true)
+}
+
+/// Name of the first zero-valued field in `timing`, or `None` if all
+/// fields are non-zero. Zero in any timing field would short-circuit the
+/// timer it drives (consensus_timeout firing immediately, epoch_duration
+/// breaking the inactivity tracker, etc.).
+fn first_zero_timing_field(
+    timing: &crate::protos::de_mls::messages::v1::TimingConfig,
+) -> Option<&'static str> {
+    if timing.epoch_duration_ms == 0 {
+        Some("epoch_duration_ms")
+    } else if timing.freeze_duration_ms == 0 {
+        Some("freeze_duration_ms")
+    } else if timing.proposal_expiration_ms == 0 {
+        Some("proposal_expiration_ms")
+    } else if timing.consensus_timeout_ms == 0 {
+        Some("consensus_timeout_ms")
+    } else if timing.retry_inactivity_duration_ms == 0 {
+        Some("retry_inactivity_duration_ms")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protos::de_mls::messages::v1::TimingConfig;
+
+    fn nonzero_timing() -> TimingConfig {
+        TimingConfig {
+            epoch_duration_ms: 60_000,
+            freeze_duration_ms: 30_000,
+            proposal_expiration_ms: 3_600_000,
+            consensus_timeout_ms: 30_000,
+            retry_inactivity_duration_ms: 5_000,
+        }
+    }
+
+    #[test]
+    fn nonzero_timing_passes() {
+        assert!(first_zero_timing_field(&nonzero_timing()).is_none());
+    }
+
+    #[test]
+    fn each_zero_field_is_detected() {
+        let cases = [
+            (
+                "epoch_duration_ms",
+                TimingConfig {
+                    epoch_duration_ms: 0,
+                    ..nonzero_timing()
+                },
+            ),
+            (
+                "freeze_duration_ms",
+                TimingConfig {
+                    freeze_duration_ms: 0,
+                    ..nonzero_timing()
+                },
+            ),
+            (
+                "proposal_expiration_ms",
+                TimingConfig {
+                    proposal_expiration_ms: 0,
+                    ..nonzero_timing()
+                },
+            ),
+            (
+                "consensus_timeout_ms",
+                TimingConfig {
+                    consensus_timeout_ms: 0,
+                    ..nonzero_timing()
+                },
+            ),
+            (
+                "retry_inactivity_duration_ms",
+                TimingConfig {
+                    retry_inactivity_duration_ms: 0,
+                    ..nonzero_timing()
+                },
+            ),
+        ];
+        for (name, timing) in cases {
+            assert_eq!(
+                first_zero_timing_field(&timing),
+                Some(name),
+                "expected field {name} to be detected as zero"
+            );
+        }
+    }
 }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -321,7 +321,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         };
 
         let current_epoch = self.mls_service.current_epoch(group_name)?;
-        if !validate_group_sync(group_name, &sync, current_epoch, &members)? {
+        let local_default_peer_score = self.default_group_config.default_peer_score;
+        if !validate_group_sync(
+            group_name,
+            &sync,
+            current_epoch,
+            &members,
+            local_default_peer_score,
+        )? {
             return Ok(());
         }
 
@@ -437,11 +444,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 /// `members` is the joiner's current MLS member set; ghost stewards
 /// (removed since the list was elected) are tolerated as long as at
 /// least one listed steward is still present.
+///
+/// `local_default_peer_score` is the joiner's configured starting score
+/// for new members (not synced; per-node). Rejecting when it sits at
+/// or below the synced threshold prevents a misconfiguration where every
+/// new member added by this joiner starts already eligible for removal.
 fn validate_group_sync(
     group_name: &str,
     sync: &GroupSync,
     current_epoch: u64,
     members: &[Vec<u8>],
+    local_default_peer_score: i64,
 ) -> Result<bool, UserError> {
     if sync.election_epoch > current_epoch {
         info!(
@@ -479,6 +492,16 @@ fn validate_group_sync(
             group = group_name,
             field = zero_field,
             "group sync rejected: zero-valued timing field"
+        );
+        return Ok(false);
+    }
+
+    if local_default_peer_score <= sync.threshold_peer_score {
+        info!(
+            group = group_name,
+            local_default_peer_score,
+            threshold_peer_score = sync.threshold_peer_score,
+            "group sync rejected: default_peer_score at or below threshold would mark new members removable on add"
         );
         return Ok(false);
     }
@@ -525,6 +548,48 @@ mod tests {
     #[test]
     fn nonzero_timing_passes() {
         assert!(first_zero_timing_field(&nonzero_timing()).is_none());
+    }
+
+    fn valid_sync_with(threshold: i64) -> GroupSync {
+        GroupSync {
+            steward_members: vec![b"alice".to_vec()],
+            election_epoch: 0,
+            sn_min: 1,
+            sn_max: 5,
+            allow_subset_candidates: false,
+            peer_scores: vec![],
+            timing: Some(nonzero_timing()),
+            retry_round: 0,
+            max_reelection_attempts: 1,
+            liveness_criteria_yes: true,
+            threshold_peer_score: threshold,
+            pending_update_max_epochs: 3,
+        }
+    }
+
+    /// Joiner's `default_peer_score` strictly above the synced threshold
+    /// — new members added by this joiner start safely above the bar.
+    #[test]
+    fn validate_accepts_default_above_threshold() {
+        let sync = valid_sync_with(0);
+        assert!(validate_group_sync("g", &sync, 0, &[b"alice".to_vec()], 100).unwrap());
+    }
+
+    /// Joiner's `default_peer_score` equal to the threshold — new members
+    /// would start at threshold and `score <= threshold` already qualifies
+    /// them for removal.
+    #[test]
+    fn validate_rejects_default_equal_to_threshold() {
+        let sync = valid_sync_with(50);
+        assert!(!validate_group_sync("g", &sync, 0, &[b"alice".to_vec()], 50).unwrap());
+    }
+
+    /// Joiner's `default_peer_score` below the threshold — every new
+    /// member added by this joiner starts removable.
+    #[test]
+    fn validate_rejects_default_below_threshold() {
+        let sync = valid_sync_with(100);
+        assert!(!validate_group_sync("g", &sync, 0, &[b"alice".to_vec()], 50).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Two new defensive checks reject GroupSync values that pass proto decode but would misconfigure the joiner.

- Zero-valued duration fields in TimingConfig: any of the five timing fields at zero would short-circuit the timer it drives — consensus sessions firing immediately, the inactivity tracker breaking, and so on.
Rejecting on receipt surfaces the misconfiguration instead of silently breaking timers.
- default_peer_score at or below the synced threshold: the joiner's starting score for new members is local-only (not synced). When the steward's threshold is high enough that the joiner's default sits at or
below it, every new member this joiner adds starts already eligible for SCORE_BELOW_THRESHOLD removal. Rejecting the sync forces the operator to reconcile the two values rather than silently producing a
self-removing membership pipeline.

Existing validation (election_epoch ≤ current_epoch, ≥1 listed steward in MLS members, steward-list ordering) is unchanged.
