### PR TITLE
refactor: cleanup pass — scoring, config, locking

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_EPOCH_DURATION: Duration = Duration::from_secs(60);
 
 /// Lifetime of a voting proposal before it expires unvoted
 /// (RFC §Creating Voting Proposal).
-pub const DEFAULT_PROPOSAL_EXPIRATION: Duration = Duration::from_secs(3600);
+pub const DEFAULT_PROPOSAL_EXPIRATION: Duration = Duration::from_secs(600);
 
 /// Library deadline for a single consensus session — bounds how long a
 /// vote can stay open. MUST be `> voting_delay`.

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -68,8 +68,6 @@ impl FixedScoringProvider {
 
     /// Default delta for each [`ScoreEvent`]. Values are placeholders
     /// pending an empirical tuning pass (see `docs/ROADMAP.md`).
-    /// `FreezeViolation` is reserved vocabulary with no producer yet and
-    /// is deliberately omitted.
     pub fn default_deltas() -> HashMap<ScoreEvent, i64> {
         HashMap::from([
             // ECP target penalties (violation-type-specific)
@@ -83,8 +81,6 @@ impl FixedScoringProvider {
             (ScoreEvent::SuccessfulCommit, 10),
             (ScoreEvent::HonestCommitAttempt, 5),
             (ScoreEvent::MisbehavingCommit, -30),
-            // Not yet wired
-            (ScoreEvent::NonFinalizedProposalCommit, -30),
         ])
     }
 
@@ -324,7 +320,7 @@ mod tests {
             GROUP,
             &ScoreOp {
                 member_id: member.to_vec(),
-                event: ScoreEvent::NonFinalizedProposalCommit,
+                event: ScoreEvent::MisbehavingCommit,
             },
         );
         svc.apply_op(

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -53,8 +53,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
         kind: ProposalKind,
     ) -> Result<u32, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         let state = entry.state_machine.current_state();
 
         match state {
@@ -200,8 +203,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         .await?;
 
         let group = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry_arc = self
+                .lookup_entry(group_name)
+                .await
+                .ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             entry
                 .group
                 .store_voting_proposal(proposal_id, request.clone());
@@ -310,12 +316,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         {
             Ok(_) => {}
             Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
-                let resolved_locally = {
-                    let groups = self.groups.read().await;
-                    groups
-                        .get(group_name)
-                        .is_some_and(|entry| entry.group.is_consensus_outcome_applied(proposal_id))
-                };
+                let resolved_locally = self
+                    .with_entry(group_name, |entry| {
+                        entry.group.is_consensus_outcome_applied(proposal_id)
+                    })
+                    .await
+                    .unwrap_or(false);
                 if resolved_locally {
                     tracing::debug!(
                         group = group_name,
@@ -351,9 +357,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // because a PendingJoin member has no MLS group yet —
         // `current_epoch()` would fail with `GroupNotFound` and surface as
         // a spurious error in the gateway's inbound forwarder.
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+
         let pending_join = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             entry.state_machine.current_state() == GroupState::PendingJoin
         };
         if pending_join {
@@ -363,8 +373,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let current_epoch = self.mls_service.current_epoch(group_name)?;
 
         let members_for_rotation = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             if self.mls_service.has_group(entry.group.group_name()) {
                 group_members(&entry.group, &self.mls_service)?
             } else {
@@ -373,8 +382,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         };
 
         let (inserted, is_epoch_steward, state, buffer_total, should_propose) = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
 
             // Defensive — core only emits membership changes here.
             if target_identity_of(&request).is_none() {
@@ -429,15 +437,19 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         proposal_id: u32,
         vote: bool,
     ) -> Result<(), UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        let state = entry.state_machine.current_state();
-        if state == GroupState::Freezing || state == GroupState::Selection {
-            return Err(UserError::GroupBlocked(state.to_string()));
-        }
-        let group = entry.group.clone();
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let group = {
+            let entry = entry_arc.read().await;
+            let state = entry.state_machine.current_state();
+            if state == GroupState::Freezing || state == GroupState::Selection {
+                return Err(UserError::GroupBlocked(state.to_string()));
+            }
+            entry.group.clone()
+        };
         let app_id = self.app_id.clone();
-        drop(groups);
 
         // Manual vote takes precedence over the pending auto-vote timer.
         self.cancel_auto_vote(group_name, proposal_id);
@@ -533,11 +545,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         proposal_id: u32,
         vote: bool,
     ) -> Result<(), UserError> {
-        let group = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-            entry.group.clone()
-        };
+        let group = self
+            .with_entry(group_name, |e| e.group.clone())
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let app_message = cast_vote::<P, _>(
             &group,
             proposal_id,

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -177,12 +177,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         kind: ProposalKind,
         creator_vote: Option<bool>,
     ) -> Result<u32, UserError> {
-        let (proposal_expiration, consensus_timeout, liveness_criteria_yes) = self
+        let (proposal_expiration, consensus_timeout, liveness_criteria_yes, voting_delay) = self
             .with_entry(group_name, |e| {
                 (
                     e.state_machine.proposal_expiration(),
                     e.state_machine.consensus_timeout(),
                     e.group.liveness_criteria_yes(),
+                    e.state_machine.voting_delay_for(kind),
                 )
             })
             .await
@@ -269,10 +270,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.handler
                     .on_app_message(group_name, vote_notification)
                     .await?;
-                let voting_delay = self
-                    .with_entry(group_name, |e| e.state_machine.voting_delay_for(kind))
-                    .await
-                    .ok_or(UserError::GroupNotFound)?;
                 self.spawn_auto_vote(
                     group_name.to_string(),
                     proposal_id,
@@ -362,24 +359,21 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .await
             .ok_or(UserError::GroupNotFound)?;
 
-        let pending_join = {
+        let (pending_join, members_for_rotation) = {
             let entry = entry_arc.read().await;
-            entry.state_machine.current_state() == GroupState::PendingJoin
+            let pending = entry.state_machine.current_state() == GroupState::PendingJoin;
+            let members = if !pending && self.mls_service.has_group(entry.group.group_name()) {
+                group_members(&entry.group, &self.mls_service)?
+            } else {
+                Vec::new()
+            };
+            (pending, members)
         };
         if pending_join {
             return Ok(());
         }
 
         let current_epoch = self.mls_service.current_epoch(group_name)?;
-
-        let members_for_rotation = {
-            let entry = entry_arc.read().await;
-            if self.mls_service.has_group(entry.group.group_name()) {
-                group_members(&entry.group, &self.mls_service)?
-            } else {
-                Vec::new()
-            }
-        };
 
         let (inserted, is_epoch_steward, state, buffer_total, should_propose) = {
             let mut entry = entry_arc.write().await;

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -44,18 +44,19 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         // Drop re-emissions from the consensus library (timeout-path race)
         // so we don't re-apply state or double-fire UI events.
-        {
-            let groups = self.groups.read().await;
-            if let Some(entry) = groups.get(group_name)
-                && entry.group.is_consensus_outcome_applied(proposal_id)
-            {
-                tracing::debug!(
-                    group = group_name,
-                    proposal_id,
-                    "duplicate consensus outcome dropped"
-                );
-                return Ok(());
-            }
+        let already_applied = self
+            .with_entry(group_name, |entry| {
+                entry.group.is_consensus_outcome_applied(proposal_id)
+            })
+            .await
+            .unwrap_or(false);
+        if already_applied {
+            tracing::debug!(
+                group = group_name,
+                proposal_id,
+                "duplicate consensus outcome dropped"
+            );
+            return Ok(());
         }
 
         // Fetch payload from consensus service (no group lock held).
@@ -69,9 +70,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         // The inactivity timer is self-started by `check_steward_inactivity`
         // on the next poll — no explicit notification needed here.
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let consensus_apply = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             info!(
                 group = group_name,
                 proposal_id, approved, "consensus reached"
@@ -102,8 +106,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 // if circumstances change. Drop the buffered entry so the
                 // next epoch steward doesn't auto-repromote it.
                 let target = target.to_vec();
-                let mut groups = self.groups.write().await;
-                if let Some(entry) = groups.get_mut(group_name) {
+                if let Some(entry_arc) = self.lookup_entry(group_name).await {
+                    let mut entry = entry_arc.write().await;
                     entry.group.remove_pending_update(&target);
                 }
             }
@@ -120,12 +124,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
     /// Bypass the inactivity timer so the urgent commit fires now.
     async fn force_freezing_for_urgent_commit(&self, group_name: &str) {
-        let transitioned = {
-            let mut groups = self.groups.write().await;
-            groups
-                .get_mut(group_name)
-                .map(|entry| entry.state_machine.force_freezing())
-                .unwrap_or(false)
+        let transitioned = match self.lookup_entry(group_name).await {
+            Some(entry_arc) => entry_arc.write().await.state_machine.force_freezing(),
+            None => false,
         };
         if transitioned {
             self.state_handler
@@ -137,15 +138,15 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// When the removal target is a current steward, fire a fresh election
     /// in parallel so the next epoch keeps a healthy ES + BS.
     async fn refresh_stewards_after_removal(&self, group_name: &str, target: &[u8]) {
-        let target_was_steward = {
-            let groups = self.groups.read().await;
-            groups.get(group_name).is_some_and(|entry| {
+        let target_was_steward = self
+            .with_entry(group_name, |entry| {
                 entry
                     .group
                     .steward_list()
                     .is_some_and(|l| l.contains(target))
             })
-        };
+            .await
+            .unwrap_or(false);
         if !target_was_steward {
             return;
         }
@@ -169,9 +170,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
         election: StewardElectionProposal,
     ) -> Result<(), UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+
         let is_valid = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             let members = group_members(&entry.group, &self.mls_service)?;
             entry.group.validate_steward_list_proposal(
                 &election.proposed_stewards,
@@ -189,8 +194,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         }
 
         let resumed_from_reelection = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             entry.group.generate_and_set_steward_list(
                 election.election_epoch,
                 &election.proposed_stewards,
@@ -227,18 +231,18 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// Rejected election: bump the retry round and retry under the max
     /// (idempotent), or escalate to a `Deadlock` ECP once exhausted.
     async fn handle_election_rejected(&self, group_name: &str) {
-        let (round, max) = {
-            let mut groups = self.groups.write().await;
-            let Some(entry) = groups.get_mut(group_name) else {
-                return;
-            };
-            entry.group.bump_reelection_round();
-            // Read the ceiling from the group, not the user-level default:
-            // joiners honor the group's configured policy via `GroupSync`.
-            (
-                entry.group.reelection_round(),
-                entry.group.max_reelection_attempts(),
-            )
+        let (round, max) = match self.lookup_entry(group_name).await {
+            Some(entry_arc) => {
+                let mut entry = entry_arc.write().await;
+                entry.group.bump_reelection_round();
+                // Read the ceiling from the group, not the user-level default:
+                // joiners honor the group's configured policy via `GroupSync`.
+                (
+                    entry.group.reelection_round(),
+                    entry.group.max_reelection_attempts(),
+                )
+            }
+            None => return,
         };
         if round > max {
             info!(
@@ -281,27 +285,24 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         if let Ok(req) = GroupUpdateRequest::decode(payload)
             && let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload
             && let Some(ev) = &ec.evidence
+            && let Some(entry_arc) = self.lookup_entry(group_name).await
         {
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
-                entry.group.resolve_pending_removal(&ev.target_member_id);
-            }
+            let mut entry = entry_arc.write().await;
+            entry.group.resolve_pending_removal(&ev.target_member_id);
         }
 
-        let resumed_from_reelection = {
-            let mut groups = self.groups.write().await;
-            match groups.get_mut(group_name) {
-                Some(entry) => {
-                    entry.group.resolve_emergency(proposal_id);
-                    if entry.state_machine.current_state() == GroupState::Reelection {
-                        entry.state_machine.start_working();
-                        true
-                    } else {
-                        false
-                    }
+        let resumed_from_reelection = match self.lookup_entry(group_name).await {
+            Some(entry_arc) => {
+                let mut entry = entry_arc.write().await;
+                entry.group.resolve_emergency(proposal_id);
+                if entry.state_machine.current_state() == GroupState::Reelection {
+                    entry.state_machine.start_working();
+                    true
+                } else {
+                    false
                 }
-                None => false,
             }
+            None => false,
         };
         if resumed_from_reelection {
             self.state_handler

--- a/src/app/user/emergency.rs
+++ b/src/app/user/emergency.rs
@@ -53,3 +53,87 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
         event: ScoreEvent::EmergencyNoCreator,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protos::de_mls::messages::v1::{EmergencyCriteriaProposal, ViolationType};
+
+    fn ecp_payload(violation_type: i32, target: Vec<u8>, creator: Vec<u8>) -> Vec<u8> {
+        let evidence = ViolationEvidence {
+            violation_type,
+            target_member_id: target,
+            evidence_payload: Vec::new(),
+            epoch: 0,
+            creator_member_id: creator,
+        };
+        let req = GroupUpdateRequest {
+            payload: Some(Payload::EmergencyCriteria(EmergencyCriteriaProposal {
+                evidence: Some(evidence),
+            })),
+        };
+        req.encode_to_vec()
+    }
+
+    /// Approved + target-mappable violation → creator reward + target penalty.
+    #[test]
+    fn approved_broken_commit_emits_reward_and_target_penalty() {
+        let payload = ecp_payload(ViolationType::BrokenCommit as i32, vec![0xAA], vec![0xBB]);
+        let ops = emergency_score_ops(&payload, true);
+        assert_eq!(ops.len(), 2);
+        assert_eq!(ops[0].event, ScoreEvent::EmergencyYesCreator);
+        assert_eq!(ops[0].member_id, vec![0xBB]);
+        assert_eq!(ops[1].event, ScoreEvent::BrokenCommit);
+        assert_eq!(ops[1].member_id, vec![0xAA]);
+    }
+
+    /// Approved + non-target violation (`Deadlock`) → creator reward only.
+    #[test]
+    fn approved_deadlock_emits_reward_only() {
+        let payload = ecp_payload(ViolationType::Deadlock as i32, Vec::new(), vec![0xBB]);
+        let ops = emergency_score_ops(&payload, true);
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].event, ScoreEvent::EmergencyYesCreator);
+    }
+
+    /// Approved `ScoreBelowThreshold` is the trigger for removal — no
+    /// target-side score op (the target gets removed instead).
+    #[test]
+    fn approved_score_below_threshold_emits_reward_only() {
+        let payload = ecp_payload(
+            ViolationType::ScoreBelowThreshold as i32,
+            vec![0xAA],
+            vec![0xBB],
+        );
+        let ops = emergency_score_ops(&payload, true);
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].event, ScoreEvent::EmergencyYesCreator);
+    }
+
+    /// Wire-malformed `Unspecified` violation type — emit creator reward,
+    /// drop the malformed target op silently. Previously the conversion
+    /// would have silently penalised the target as `BrokenCommit`.
+    #[test]
+    fn approved_unspecified_emits_reward_only() {
+        let payload = ecp_payload(0, vec![0xAA], vec![0xBB]);
+        let ops = emergency_score_ops(&payload, true);
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].event, ScoreEvent::EmergencyYesCreator);
+    }
+
+    /// Rejected → creator penalty regardless of violation type.
+    #[test]
+    fn rejected_emits_creator_penalty() {
+        for vt in [
+            ViolationType::BrokenCommit,
+            ViolationType::Deadlock,
+            ViolationType::ScoreBelowThreshold,
+        ] {
+            let payload = ecp_payload(vt as i32, vec![0xAA], vec![0xBB]);
+            let ops = emergency_score_ops(&payload, false);
+            assert_eq!(ops.len(), 1);
+            assert_eq!(ops[0].event, ScoreEvent::EmergencyNoCreator);
+            assert_eq!(ops[0].member_id, vec![0xBB]);
+        }
+    }
+}

--- a/src/app/user/emergency.rs
+++ b/src/app/user/emergency.rs
@@ -13,7 +13,7 @@ use prost::Message;
 
 use crate::core::{ScoreEvent, ScoreOp};
 use crate::protos::de_mls::messages::v1::{
-    GroupUpdateRequest, ViolationEvidence, ViolationType, group_update_request::Payload,
+    GroupUpdateRequest, ViolationEvidence, group_update_request::Payload,
 };
 
 /// Score ops to apply when an emergency proposal resolves. Returns an
@@ -30,21 +30,14 @@ pub fn emergency_score_ops(payload: &[u8], approved: bool) -> Vec<ScoreOp> {
     };
 
     if approved {
-        if is_targetless_or_self_executing(&evidence) {
-            vec![creator_reward(&evidence)]
-        } else {
-            vec![evidence.target_score_op(), creator_reward(&evidence)]
+        let mut ops = vec![creator_reward(&evidence)];
+        if let Some(target_op) = evidence.target_score_op() {
+            ops.push(target_op);
         }
+        ops
     } else {
         vec![creator_penalty(&evidence)]
     }
-}
-
-fn is_targetless_or_self_executing(ev: &ViolationEvidence) -> bool {
-    matches!(
-        ViolationType::try_from(ev.violation_type),
-        Ok(ViolationType::ScoreBelowThreshold) | Ok(ViolationType::Deadlock)
-    )
 }
 
 fn creator_reward(ev: &ViolationEvidence) -> ScoreOp {

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -17,15 +17,17 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// `false` once joined or once the join attempt has been torn down
     /// after timing out.
     pub async fn check_pending_join(&self, group_name: &str) -> Result<bool, UserError> {
-        let (state, expired) = {
-            let groups = self.groups.read().await;
-            match groups.get(group_name) {
-                Some(entry) => (
+        let (state, expired) = match self
+            .with_entry(group_name, |entry| {
+                (
                     entry.state_machine.current_state(),
                     entry.state_machine.is_pending_join_expired(),
-                ),
-                None => return Ok(false),
-            }
+                )
+            })
+            .await
+        {
+            Some(v) => v,
+            None => return Ok(false),
         };
 
         if state != GroupState::PendingJoin {
@@ -49,9 +51,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<FreezeTimeoutStatus, UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+
         let has_proposals = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
 
             let state = entry.state_machine.current_state();
             if state != GroupState::Freezing {
@@ -78,8 +84,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .await;
 
         let finalize_result = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             let allow_subset = entry.group.allow_subset_candidates();
             match finalize_freeze_round(
                 &mut entry.group,
@@ -137,8 +142,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 // node that failed to commit observes its own state directly
                 // and doesn't need to record a ScoreOp against itself.
                 let (next_state, accuse_target) = {
-                    let mut groups = self.groups.write().await;
-                    let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+                    let mut entry = entry_arc.write().await;
 
                     if has_proposals {
                         // Approved batch (and in-flight votes) survive so
@@ -202,8 +206,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// proposals for more than `epoch_duration`. Any member polls — not
     /// just the steward — so a fault gets picked up group-wide.
     pub async fn check_member_freeze(&self, group_name: &str) -> Result<bool, UserError> {
-        let mut groups = self.groups.write().await;
-        let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let mut entry = entry_arc.write().await;
 
         let state = entry.state_machine.current_state();
         if state == GroupState::PendingJoin || state == GroupState::Leaving {
@@ -259,7 +266,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             );
 
             // Drop lock before any async calls.
-            drop(groups);
+            drop(entry);
             self.state_handler
                 .on_state_changed(group_name, new_state)
                 .await;

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -130,7 +130,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
     /// We just joined via welcome. Broadcast a system "joined" chat message,
     /// sync scoring, and transition to Working. Pending-update pruning is
-    /// defensive — PendingJoin no longer buffers, but paths may change.
+    /// defensive — PendingJoin doesn't buffer, but paths may change.
     async fn on_joined_group(&self, name: &str) -> Result<(), UserError> {
         self.prune_pending_updates_after_commit(name).await?;
 

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -37,14 +37,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.on_incoming_proposal(group_name, proposal).await
             }
             ProcessResult::Vote(vote) => {
-                let group = {
-                    let groups = self.groups.read().await;
-                    groups
-                        .get(group_name)
-                        .ok_or(UserError::GroupNotFound)?
-                        .group
-                        .clone()
-                };
+                let group = self
+                    .with_entry(group_name, |e| e.group.clone())
+                    .await
+                    .ok_or(UserError::GroupNotFound)?;
                 forward_incoming_vote::<P>(group_name, &group, vote, &*self.consensus_service)
                     .await?;
                 Ok(())
@@ -83,8 +79,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let decoded = GroupUpdateRequest::decode(proposal.payload.as_slice()).ok();
         if let Some(req) = decoded.as_ref() {
             let current_epoch = self.mls_service.current_epoch(group_name)?;
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
+            if let Some(entry_arc) = self.lookup_entry(group_name).await {
+                let mut entry = entry_arc.write().await;
                 match &req.payload {
                     Some(group_update_request::Payload::EmergencyCriteria(_)) => {
                         entry.group.observe_emergency(proposal.proposal_id);
@@ -145,33 +141,28 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             group_name: name.to_string(),
         }
         .into();
+        let entry_arc = match self.lookup_entry(name).await {
+            Some(e) => e,
+            None => return Ok(()),
+        };
         let packet = {
-            let groups = self.groups.read().await;
-            match groups.get(name) {
-                Some(entry) => build_message(&entry.group, &self.mls_service, &msg, &self.app_id)?,
-                None => return Ok(()),
-            }
+            let entry = entry_arc.read().await;
+            build_message(&entry.group, &self.mls_service, &msg, &self.app_id)?
         };
         self.handler.on_outbound(name, packet).await?;
         self.handler.on_joined_group(name).await?;
 
         {
-            let groups = self.groups.read().await;
-            if let Some(entry) = groups.get(name) {
-                self.sync_scoring_members(name, &entry.group);
-            }
+            let entry = entry_arc.read().await;
+            self.sync_scoring_members(name, &entry.group);
         }
 
         let state = {
-            let mut groups = self.groups.write().await;
-            groups.get_mut(name).map(|entry| {
-                entry.state_machine.start_working();
-                entry.state_machine.current_state()
-            })
+            let mut entry = entry_arc.write().await;
+            entry.state_machine.start_working();
+            entry.state_machine.current_state()
         };
-        if let Some(state) = state {
-            self.state_handler.on_state_changed(name, state).await;
-        }
+        self.state_handler.on_state_changed(name, state).await;
         Ok(())
     }
 
@@ -180,38 +171,34 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// buffered-update drain). The commit author's `SuccessfulCommit`
     /// reward is emitted by `finalize_freeze_round`, not here.
     async fn on_group_updated(&self, group_name: &str) -> Result<(), UserError> {
-        {
-            let groups = self.groups.read().await;
-            if let Some(entry) = groups.get(group_name) {
-                self.sync_scoring_members(group_name, &entry.group);
-            }
+        if let Some(entry_arc) = self.lookup_entry(group_name).await {
+            let entry = entry_arc.read().await;
+            self.sync_scoring_members(group_name, &entry.group);
         }
         self.prune_pending_updates_after_commit(group_name).await?;
 
         // Transition to Working BEFORE steward checks (election needs Working
         // state). Reset reelection_round: this commit advanced the epoch,
         // so whatever retry cycle we were in belongs to the previous epoch.
-        let transitioned = {
-            let mut groups = self.groups.write().await;
-            match groups.get_mut(group_name) {
-                Some(entry) => {
-                    entry.group.reset_reelection_round();
-                    let state = entry.state_machine.current_state();
-                    if matches!(
-                        state,
-                        GroupState::Working
-                            | GroupState::Freezing
-                            | GroupState::Selection
-                            | GroupState::Reelection
-                    ) {
-                        entry.state_machine.start_working();
-                        true
-                    } else {
-                        false
-                    }
+        let transitioned = match self.lookup_entry(group_name).await {
+            Some(entry_arc) => {
+                let mut entry = entry_arc.write().await;
+                entry.group.reset_reelection_round();
+                let state = entry.state_machine.current_state();
+                if matches!(
+                    state,
+                    GroupState::Working
+                        | GroupState::Freezing
+                        | GroupState::Selection
+                        | GroupState::Reelection
+                ) {
+                    entry.state_machine.start_working();
+                    true
+                } else {
+                    false
                 }
-                None => false,
             }
+            None => false,
         };
 
         self.steward_list_housekeeping(group_name).await?;
@@ -229,12 +216,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// Fire a steward election while `recovery_mode` is set so the next
     /// list installs and closes the window.
     async fn maybe_close_recovery_window(&self, group_name: &str) {
-        let in_recovery_mode = {
-            let groups = self.groups.read().await;
-            groups
-                .get(group_name)
-                .is_some_and(|entry| entry.group.is_in_recovery_mode())
-        };
+        let in_recovery_mode = self
+            .with_entry(group_name, |entry| entry.group.is_in_recovery_mode())
+            .await
+            .unwrap_or(false);
         if !in_recovery_mode {
             return;
         }
@@ -262,11 +247,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// Peer broadcast a commit candidate. If we were in Working, enter
     /// Freezing and — if we're a steward — build our own candidate too.
     async fn on_commit_candidate_received(&self, group_name: &str) -> Result<(), UserError> {
+        let entry_arc = match self.lookup_entry(group_name).await {
+            Some(e) => e,
+            None => return Ok(()),
+        };
         let (transitioned, outbound) = {
-            let mut groups = self.groups.write().await;
-            let Some(entry) = groups.get_mut(group_name) else {
-                return Ok(());
-            };
+            let mut entry = entry_arc.write().await;
             if entry.state_machine.current_state() != GroupState::Working {
                 return Ok(());
             }
@@ -310,10 +296,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// existed), then applies list + protocol flags + timing + peer scores.
     async fn on_group_sync(&self, group_name: &str, sync: GroupSync) -> Result<(), UserError> {
         let members = {
-            let groups = self.groups.read().await;
-            let Some(entry) = groups.get(group_name) else {
-                return Ok(());
+            let entry_arc = match self.lookup_entry(group_name).await {
+                Some(e) => e,
+                None => return Ok(()),
             };
+            let entry = entry_arc.read().await;
             if entry.group.steward_list().is_some() {
                 return Ok(());
             }
@@ -361,10 +348,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let mut protocol_config = ProtocolConfig::new(sync.sn_min as usize, sync.sn_max as usize)?;
         protocol_config.allow_subset_candidates = sync.allow_subset_candidates;
 
-        let mut groups = self.groups.write().await;
-        let Some(entry) = groups.get_mut(group_name) else {
-            return Ok(());
+        let entry_arc = match self.lookup_entry(group_name).await {
+            Some(e) => e,
+            None => return Ok(()),
         };
+        let mut entry = entry_arc.write().await;
         let sn = sync.steward_members.len();
         entry.group.generate_and_set_steward_list(
             sync.election_epoch,
@@ -411,21 +399,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             return Ok(());
         }
 
-        // Verify group exists
-        {
-            let groups = self.groups.read().await;
-            if !groups.contains_key(&group_name) {
-                return Err(UserError::GroupNotFound);
-            }
-        }
-
-        // Process the packet
+        let entry_arc = self
+            .lookup_entry(&group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let result = {
-            let mut groups = self.groups.write().await;
-            let entry = groups
-                .get_mut(&group_name)
-                .ok_or(UserError::GroupNotFound)?;
-
+            let mut entry = entry_arc.write().await;
             process_inbound(
                 &mut entry.group,
                 &packet.payload,

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -152,10 +152,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         self.handler.on_outbound(name, packet).await?;
         self.handler.on_joined_group(name).await?;
 
-        {
+        let mls_members = {
             let entry = entry_arc.read().await;
-            self.sync_scoring_members(name, &entry.group);
-        }
+            group_members(&entry.group, &self.mls_service).unwrap_or_default()
+        };
+        self.sync_scoring_members(name, &mls_members);
 
         let state = {
             let mut entry = entry_arc.write().await;
@@ -172,8 +173,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// reward is emitted by `finalize_freeze_round`, not here.
     async fn on_group_updated(&self, group_name: &str) -> Result<(), UserError> {
         if let Some(entry_arc) = self.lookup_entry(group_name).await {
-            let entry = entry_arc.read().await;
-            self.sync_scoring_members(group_name, &entry.group);
+            let mls_members = {
+                let entry = entry_arc.read().await;
+                group_members(&entry.group, &self.mls_service).unwrap_or_default()
+            };
+            self.sync_scoring_members(group_name, &mls_members);
         }
         self.prune_pending_updates_after_commit(group_name).await?;
 

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -1,5 +1,8 @@
 //! Create and leave operations for a group.
 
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
 use tracing::info;
 
 use crate::{
@@ -70,10 +73,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         }
         groups.insert(
             group_name.to_string(),
-            GroupEntry {
+            Arc::new(RwLock::new(GroupEntry {
                 group,
                 state_machine,
-            },
+            })),
         );
         drop(groups);
 
@@ -99,13 +102,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     pub async fn leave_group(&mut self, group_name: &str) -> Result<(), UserError> {
         info!(group = group_name, "leaving group");
 
-        let is_pending_join = {
-            let groups = self.groups.read().await;
-            groups
-                .get(group_name)
-                .map(|entry| entry.state_machine.current_state() == GroupState::PendingJoin)
-                .ok_or(UserError::GroupNotFound)?
-        };
+        let is_pending_join = self
+            .with_entry(group_name, |entry| {
+                entry.state_machine.current_state() == GroupState::PendingJoin
+            })
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         if is_pending_join {
             self.groups.write().await.remove(group_name);
             self.cleanup_consensus_scope(group_name).await?;
@@ -117,16 +119,18 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         // Idempotent: a second click after a successful submit finds the
         // approved entry and short-circuits.
-        {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-            if entry.group.is_pending_self_leave(&self_identity) {
-                info!(
-                    group = group_name,
-                    "self-leave already in flight, ignoring duplicate"
-                );
-                return Ok(());
-            }
+        let already_pending = self
+            .with_entry(group_name, |entry| {
+                entry.group.is_pending_self_leave(&self_identity)
+            })
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        if already_pending {
+            info!(
+                group = group_name,
+                "self-leave already in flight, ignoring duplicate"
+            );
+            return Ok(());
         }
 
         let request = {
@@ -143,8 +147,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // needs `is_owner_of_proposal` to be true by then.
         let proposal_id = crate::core::auto_approved_leave_proposal_id(&self_identity);
         let (proposal_expiration, consensus_timeout) = {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry_arc = self
+                .lookup_entry(group_name)
+                .await
+                .ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             entry.group.store_voting_proposal(proposal_id, request);
             (
                 entry.state_machine.proposal_expiration(),
@@ -173,8 +180,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         };
 
         let packet = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry_arc = self
+                .lookup_entry(group_name)
+                .await
+                .ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             build_message(&entry.group, &self.mls_service, &app_msg, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -16,9 +16,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// Broadcast our key-package on the welcome subtopic so the steward
     /// can invite us.
     pub async fn send_kp_message(&self, group_name: &str) -> Result<(), UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         let packet = build_key_package_message(&entry.group, &self.mls_service, &self.app_id)?;
+        drop(entry);
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())
     }
@@ -32,10 +36,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
         message: Vec<u8>,
     ) -> Result<(), UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let packet = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-
+            let entry = entry_arc.read().await;
             let state = entry.state_machine.current_state();
             if matches!(
                 state,
@@ -67,8 +73,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         group_name: &str,
     ) -> Result<(), UserError> {
         {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry_arc = self
+                .lookup_entry(group_name)
+                .await
+                .ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             let state = entry.state_machine.current_state();
             if state != GroupState::Working {
                 return Err(UserError::GroupBlocked(state.to_string()));

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -51,7 +51,10 @@ type AutoVoteTimers = Arc<Mutex<HashMap<(String, u32), JoinHandle<()>>>>;
 
 pub struct User<P: DeMlsProvider, H: GroupEventHandler, SCH: StateChangeHandler> {
     mls_service: Arc<MlsService<P::Storage>>,
-    groups: Arc<RwLock<HashMap<String, GroupEntry>>>,
+    /// Outer lock: map CRUD (insert / remove / iterate names).
+    /// Inner per-entry lock: per-group reads and mutations. A long write
+    /// on group A no longer blocks reads on group B.
+    groups: Arc<RwLock<HashMap<String, Arc<RwLock<GroupEntry>>>>>,
     consensus_service: Arc<ProviderConsensus<P>>,
     eth_signer: PrivateKeySigner,
     handler: Arc<H>,
@@ -126,15 +129,23 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .unwrap_or_else(|e| e.into_inner())
     }
 
-    /// Run `f` under the groups read lock. Returns `None` if the entry
-    /// isn't present.
+    /// Look up a group entry. Returns `None` when the entry isn't present.
+    /// Takes the outer read lock briefly to clone the inner `Arc`, then
+    /// releases it before the caller acquires the entry's own lock.
+    pub(crate) async fn lookup_entry(&self, group_name: &str) -> Option<Arc<RwLock<GroupEntry>>> {
+        self.groups.read().await.get(group_name).cloned()
+    }
+
+    /// Run `f` under the entry's own read lock. Returns `None` if the
+    /// entry isn't present.
     pub(crate) async fn with_entry<R>(
         &self,
         group_name: &str,
         f: impl FnOnce(&GroupEntry) -> R,
     ) -> Option<R> {
-        let groups = self.groups.read().await;
-        groups.get(group_name).map(f)
+        let entry_arc = self.lookup_entry(group_name).await?;
+        let entry = entry_arc.read().await;
+        Some(f(&entry))
     }
 
     /// Wallet address as checksummed hex.

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -52,8 +52,13 @@ type AutoVoteTimers = Arc<Mutex<HashMap<(String, u32), JoinHandle<()>>>>;
 pub struct User<P: DeMlsProvider, H: GroupEventHandler, SCH: StateChangeHandler> {
     mls_service: Arc<MlsService<P::Storage>>,
     /// Outer lock: map CRUD (insert / remove / iterate names).
-    /// Inner per-entry lock: per-group reads and mutations. A long write
-    /// on group A no longer blocks reads on group B.
+    /// Inner per-entry lock: per-group reads and mutations. A write on
+    /// group A doesn't block reads on group B.
+    ///
+    /// Lock-order convention with [`Self::scoring_service`]: never hold
+    /// the scoring `Mutex` guard across `lookup_entry` or any acquisition
+    /// of the inner entry `RwLock`. Acquire `scoring()` in a single
+    /// statement and let the guard drop at the semicolon.
     groups: Arc<RwLock<HashMap<String, Arc<RwLock<GroupEntry>>>>>,
     consensus_service: Arc<ProviderConsensus<P>>,
     eth_signer: PrivateKeySigner,

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -11,16 +11,19 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     User<P, H, SCH>
 {
     pub async fn get_group_state(&self, group_name: &str) -> Result<GroupState, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        Ok(entry.state_machine.current_state())
+        self.with_entry(group_name, |e| e.state_machine.current_state())
+            .await
+            .ok_or(UserError::GroupNotFound)
     }
 
     /// Current MLS epoch + reelection retry round. `(0, 0)` if the group has
     /// no MLS state yet (pending join). Intended for UI status display.
     pub async fn get_epoch_and_retry(&self, group_name: &str) -> Result<(u64, u32), UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         let epoch = if self.mls_service.has_group(entry.group.group_name()) {
             self.mls_service.current_epoch(group_name)?
         } else {
@@ -37,9 +40,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// to verify buffer hygiene (e.g., that a joiner's buffer is empty right
     /// after they receive the welcome).
     pub async fn get_pending_update_count(&self, group_name: &str) -> Result<usize, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        Ok(entry.group.pending_update_count())
+        self.with_entry(group_name, |e| e.group.pending_update_count())
+            .await
+            .ok_or(UserError::GroupNotFound)
     }
 
     /// Freeze round progress: `(received, expected)`. Returns `(0, 0)` if not
@@ -48,27 +51,30 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<(usize, usize), UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        let received = entry.group.freeze_candidate_count();
-        let expected = entry.group.steward_list().map(|l| l.len()).unwrap_or(0);
-        Ok((received, expected))
+        self.with_entry(group_name, |e| {
+            let received = e.group.freeze_candidate_count();
+            let expected = e.group.steward_list().map(|l| l.len()).unwrap_or(0);
+            (received, expected)
+        })
+        .await
+        .ok_or(UserError::GroupNotFound)
     }
 
     pub async fn is_steward_for_group(&self, group_name: &str) -> Result<bool, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        Ok(entry.group.is_steward())
+        self.with_entry(group_name, |e| e.group.is_steward())
+            .await
+            .ok_or(UserError::GroupNotFound)
     }
 
     pub async fn get_group_members(&self, group_name: &str) -> Result<Vec<String>, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         if !self.mls_service.has_group(entry.group.group_name()) {
             return Ok(Vec::new());
         }
-
         let members = group_members(&entry.group, &self.mls_service)?;
         Ok(members
             .into_iter()
@@ -90,8 +96,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<Vec<Vec<u8>>, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         let members = group_members(&entry.group, &self.mls_service)?;
         Ok(members
             .into_iter()
@@ -105,8 +114,11 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<Vec<(Vec<u8>, MemberRole)>, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
+        let entry = entry_arc.read().await;
         let epoch = self.mls_service.current_epoch(group_name)?;
         let members = group_members(&entry.group, &self.mls_service)?;
 
@@ -141,22 +153,25 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<Vec<GroupUpdateRequest>, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        Ok(entry.group.approved_proposals().values().cloned().collect())
+        self.with_entry(group_name, |e| {
+            e.group.approved_proposals().values().cloned().collect()
+        })
+        .await
+        .ok_or(UserError::GroupNotFound)
     }
 
     pub async fn get_epoch_history(
         &self,
         group_name: &str,
     ) -> Result<Vec<Vec<GroupUpdateRequest>>, UserError> {
-        let groups = self.groups.read().await;
-        let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
-        Ok(entry
-            .group
-            .epoch_history()
-            .iter()
-            .map(|batch| batch.values().cloned().collect())
-            .collect())
+        self.with_entry(group_name, |e| {
+            e.group
+                .epoch_history()
+                .iter()
+                .map(|batch| batch.values().cloned().collect())
+                .collect()
+        })
+        .await
+        .ok_or(UserError::GroupNotFound)
     }
 }

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use crate::{
     app::{StateChangeHandler, User, UserError},
     core::{
-        DeMlsProvider, Group, GroupEventHandler, StewardList, build_message, group_members,
+        DeMlsProvider, GroupEventHandler, StewardList, build_message, group_members,
         target_identity_of,
     },
     mls_crypto::ShortId,
@@ -20,13 +20,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     User<P, H, SCH>
 {
     /// Add any MLS members not yet tracked in scoring, and drop scored
-    /// entries for identities no longer in MLS.
-    pub fn sync_scoring_members(&self, group_name: &str, group: &Group) {
-        let mls_members = match group_members(group, &self.mls_service) {
-            Ok(m) => m,
-            Err(_) => return,
-        };
-
+    /// entries for identities no longer in MLS. Takes `mls_members`
+    /// pre-fetched so the caller can release any group-entry guard
+    /// before the scoring mutex is acquired.
+    pub fn sync_scoring_members(&self, group_name: &str, mls_members: &[Vec<u8>]) {
         let mut scoring = self.scoring();
         let scored = scoring.all_members_with_scores(group_name);
         let scored_ids: std::collections::HashSet<Vec<u8>> =

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -48,9 +48,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// RFC rule: when `member_count < sn_min`, every member is a steward.
     /// Re-derive the list to cover that case after a membership-changing commit.
     async fn try_auto_fill_steward_list(&self, group_name: &str) -> Result<(), UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let (needs_fill, members) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             let members = group_members(&entry.group, &self.mls_service)?;
             let needs = members.len() < entry.group.protocol_config().sn_min;
             (needs, members)
@@ -62,8 +65,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
         let epoch = self.mls_service.current_epoch(group_name)?;
         {
-            let mut groups = self.groups.write().await;
-            let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+            let mut entry = entry_arc.write().await;
             let sn = entry
                 .group
                 .protocol_config()
@@ -90,9 +92,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         recovery: bool,
         extra_exclude: Option<&[u8]>,
     ) -> Result<(), UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let (members, election_epoch, config, retry_round) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             let epoch = self.mls_service.current_epoch(group_name)?;
             if !recovery && !entry.group.is_steward_list_exhausted(epoch) {
                 return Ok(());
@@ -184,9 +189,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         &self,
         group_name: &str,
     ) -> Result<(), UserError> {
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let (is_authorized, self_id, epoch) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             let mls_members = group_members(&entry.group, &self.mls_service)?;
             let self_id = self.mls_service.wallet_bytes();
             let is_authorized = entry
@@ -239,14 +247,16 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// tests and administrative tooling.
     pub async fn regenerate_steward_list(&self, group_name: &str) -> Result<(), UserError> {
         let current_epoch = self.mls_service.current_epoch(group_name)?;
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let members = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             group_members(&entry.group, &self.mls_service)?
         };
 
-        let mut groups = self.groups.write().await;
-        let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+        let mut entry = entry_arc.write().await;
         let sn = entry
             .group
             .protocol_config()
@@ -267,9 +277,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     ) -> Result<(), UserError> {
         let current_epoch = self.mls_service.current_epoch(group_name)?;
 
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let (members, max_age) = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
             if !self.mls_service.has_group(entry.group.group_name()) {
                 return Ok(());
             }
@@ -279,8 +292,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             )
         };
 
-        let mut groups = self.groups.write().await;
-        let entry = groups.get_mut(group_name).ok_or(UserError::GroupNotFound)?;
+        let mut entry = entry_arc.write().await;
         let before = entry.group.pending_update_count();
         entry.group.prune_pending_updates_for_members(&members);
         let expired = entry.group.expire_pending_updates(current_epoch, max_age);
@@ -303,9 +315,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     pub async fn process_buffered_updates(&self, group_name: &str) -> Result<(), UserError> {
         let current_epoch = self.mls_service.current_epoch(group_name)?;
 
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let to_propose: Vec<GroupUpdateRequest> = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
 
             let members = if self.mls_service.has_group(entry.group.group_name()) {
                 group_members(&entry.group, &self.mls_service)?
@@ -385,9 +400,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 .collect()
         };
 
+        let entry_arc = self
+            .lookup_entry(group_name)
+            .await
+            .ok_or(UserError::GroupNotFound)?;
         let packet = {
-            let groups = self.groups.read().await;
-            let entry = groups.get(group_name).ok_or(UserError::GroupNotFound)?;
+            let entry = entry_arc.read().await;
 
             let list = match entry.group.steward_list() {
                 Some(l) => l,
@@ -476,14 +494,12 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // Mark all targets pending under a single write-lock, then submit
         // proposals outside the lock to avoid holding it across `.await`.
         let mut to_remove = Vec::new();
-        {
-            let mut groups = self.groups.write().await;
-            if let Some(entry) = groups.get_mut(group_name) {
-                for (target_id, current_score) in targets {
-                    if !entry.group.has_pending_removal(&target_id) {
-                        entry.group.observe_pending_removal(target_id.clone());
-                        to_remove.push((target_id, current_score));
-                    }
+        if let Some(entry_arc) = self.lookup_entry(group_name).await {
+            let mut entry = entry_arc.write().await;
+            for (target_id, current_score) in targets {
+                if !entry.group.has_pending_removal(&target_id) {
+                    entry.group.observe_pending_removal(target_id.clone());
+                    to_remove.push((target_id, current_score));
                 }
             }
         }
@@ -508,8 +524,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 .initiate_proposal(group_name.to_string(), request, Some(true))
                 .await
             {
-                let mut groups = self.groups.write().await;
-                if let Some(entry) = groups.get_mut(group_name) {
+                if let Some(entry_arc) = self.lookup_entry(group_name).await {
+                    let mut entry = entry_arc.write().await;
                     entry.group.resolve_pending_removal(&target_id);
                 }
                 error!(

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -529,14 +529,21 @@ where
             }
             StagingOutcome::Violation(v) => {
                 mls.discard_staged_commit(&group_name)?;
-                return Ok(CandidateOutcome::Drop(v.target_score_op()));
+                return Ok(CandidateOutcome::Drop(
+                    v.target_score_op()
+                        .expect("staged-violation always has a target-side score"),
+                ));
             }
         };
 
     // Commit sender must be on the steward list (RFC §"Commit validation service").
     if let Some(violation) = check_commit_sender_authorized(group, &commit_sender, current_epoch) {
         mls.discard_staged_commit(&group_name)?;
-        return Ok(CandidateOutcome::Drop(violation.target_score_op()));
+        return Ok(CandidateOutcome::Drop(
+            violation
+                .target_score_op()
+                .expect("locally-built violation always has a target-side score"),
+        ));
     }
 
     // MLS actions must match the set we voted to approve.
@@ -548,7 +555,11 @@ where
         current_epoch,
     )? {
         mls.discard_staged_commit(&group_name)?;
-        return Ok(CandidateOutcome::Drop(violation.target_score_op()));
+        return Ok(CandidateOutcome::Drop(
+            violation
+                .target_score_op()
+                .expect("locally-built violation always has a target-side score"),
+        ));
     }
 
     mls.merge_staged_commit(&group_name)?;

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -9,11 +9,6 @@
 /// Each variant maps to a single score delta. Violation types (BrokenCommit, etc.)
 /// go through the ECP consensus path — when accepted, the target receives a
 /// violation-type-specific penalty and the creator receives a flat reward.
-///
-/// Some variants below are **reserved RFC vocabulary** — declared and wired
-/// into the scoring-delta table but not yet produced by core code (see
-/// `docs/ROADMAP.md`). They're listed here so adding the producer later is
-/// a one-line change instead of a new enum variant + migration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScoreEvent {
     // ── ECP target penalties (mapped from ViolationType in evidence) ──
@@ -39,17 +34,6 @@ pub enum ScoreEvent {
     /// Competing commit with a different proposal set than the selected one
     /// (RFC: "MUST be classified as misbehavior").
     MisbehavingCommit,
-
-    // ── Partial freeze ──
-    // TODO(roadmap): produced when peer-side partial-freeze enforcement lands.
-    /// Propagated lower-priority governance traffic during an active freeze.
-    FreezeViolation,
-
-    // ── Commit validation ──
-    // TODO(roadmap): produced when local commit-validation scoring lands.
-    /// Commit referenced proposals not yet finalised by consensus. Detected
-    /// locally, not via ECP.
-    NonFinalizedProposalCommit,
 }
 
 /// A score operation produced by core logic and fed into the app's

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -137,24 +137,29 @@ impl ViolationEvidence {
         })
     }
 
-    /// Peer-score penalty the target takes for this violation.
-    /// `ScoreBelowThreshold` is filtered upstream (target is being removed);
-    /// unknown wire values fall back to the harshest penalty.
-    pub fn target_score_event(&self) -> ScoreEvent {
+    /// Peer-score penalty the target takes for this violation, or `None`
+    /// for violation types that have no target-side score (`ScoreBelowThreshold`
+    /// drives a removal, not a penalty; `Deadlock` has no target;
+    /// `Unspecified` and unknown wire values are malformed).
+    pub fn target_score_event(&self) -> Option<ScoreEvent> {
         match ViolationType::try_from(self.violation_type) {
-            Ok(ViolationType::BrokenCommit) => ScoreEvent::BrokenCommit,
-            Ok(ViolationType::BrokenMlsProposal) => ScoreEvent::BrokenMlsProposal,
-            Ok(ViolationType::CensorshipInactivity) => ScoreEvent::CensorshipInactivity,
-            _ => ScoreEvent::BrokenCommit,
+            Ok(ViolationType::BrokenCommit) => Some(ScoreEvent::BrokenCommit),
+            Ok(ViolationType::BrokenMlsProposal) => Some(ScoreEvent::BrokenMlsProposal),
+            Ok(ViolationType::CensorshipInactivity) => Some(ScoreEvent::CensorshipInactivity),
+            Ok(ViolationType::ScoreBelowThreshold)
+            | Ok(ViolationType::Deadlock)
+            | Ok(ViolationType::ViolationUnspecified)
+            | Err(_) => None,
         }
     }
 
     /// `ScoreOp` applying [`Self::target_score_event`] to [`Self::target_member_id`].
-    pub fn target_score_op(&self) -> ScoreOp {
-        ScoreOp {
+    /// `None` when the violation type carries no target-side score.
+    pub fn target_score_op(&self) -> Option<ScoreOp> {
+        Some(ScoreOp {
             member_id: self.target_member_id.clone(),
-            event: self.target_score_event(),
-        }
+            event: self.target_score_event()?,
+        })
     }
 }
 

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -1,14 +1,8 @@
-//! Integration tests for the recovery-flow rework.
+//! Recovery-flow integration tests.
 //!
-//! Exercises the bad-path scenarios observed in real-UI logs:
-//! - Concurrent joins (all pending-joiners see each others' KPs on broadcast)
-//! - Buffer must not be polluted on PendingJoin members
-//! - After commit, no member has stale buffered invites that would fail
-//!   with MLS "Duplicate signature key" when they later become steward
-//!
-//! The happy path (one-joiner-at-a-time) is already covered by
-//! `tests/async_scoring_removal.rs`. This file focuses on the specific
-//! bugs surfaced on 2026-04-22.
+//! Concurrent joins, PendingJoin buffer hygiene, and stale-buffered-invite
+//! prevention so a future-steward member doesn't propose Adds for
+//! already-joined identities.
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;


### PR DESCRIPTION
Four small focused refactors gathered into one cleanup branch.

The default proposal lifetime drops from 1 hour to 10 minutes. The previous default left a wide window for an approved proposal to outlive its TTL during prolonged recovery; the layered recovery already makes
that scenario rare and shrinking the default narrows it further. Receive-side enforcement remains deferred — the cost of tracking infrastructure doesn't justify it at current group sizes.

The conversion from a wire violation to a local score op is now fallible. Previously the conversion silently fell back to the harshest penalty for any violation type without a target-side score, including
SCORE_BELOW_THRESHOLD and Deadlock — a real bug if upstream filtering ever broke. The conversion now returns Option, callers handle the None case explicitly, and a redundant filter helper that expressed the same
intent imperatively is gone.

Two reserved score-event variants had no producer in core code, only TODO comments pointing at future work. They're dropped; restore when the producers ship. Reserved vocabulary in code without producers gives
the illusion of completeness without the function.

The User-level group registry now uses a per-entry lock. The outer RwLock becomes CRUD-only (insert / remove / iterate names); each entry owns its own RwLock. A write on group A no longer blocks reads on group B.
 Lookup pattern is take the outer read briefly to clone the inner Arc, release it, then acquire the entry's own lock — surfaced via a new lookup helper. ~70 call sites translated.

Tests add inline coverage for every branch the new fallible score-op API exposes — including the previously-unreachable malformed-violation arm where the old code would have silently penalised the target.