### PR TITLE
refactor: code organization cleanup

### DIFF
--- a/apps/de_mls_desktop_ui/src/logging.rs
+++ b/apps/de_mls_desktop_ui/src/logging.rs
@@ -1,5 +1,6 @@
-use once_cell::sync::OnceCell;
 use std::{fmt, sync::Mutex};
+
+use once_cell::sync::OnceCell;
 use tracing::{
     Event, Level, Subscriber,
     field::{Field, Visit},

--- a/apps/de_mls_desktop_ui/src/main.rs
+++ b/apps/de_mls_desktop_ui/src/main.rs
@@ -1,10 +1,13 @@
 #![allow(non_snake_case)]
-use dioxus::prelude::*;
-use dioxus_desktop::{Config, LogicalSize, WindowBuilder, launch::launch as desktop_launch};
-use std::collections::HashMap;
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
+
+mod logging;
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use de_mls::{
@@ -14,10 +17,10 @@ use de_mls::{
 };
 use de_mls_gateway::{GATEWAY, bootstrap_core_from_env};
 use de_mls_ui_protocol::v1::{AppCmd, AppEvent, MemberInfo};
+use dioxus::prelude::*;
+use dioxus_desktop::{Config, LogicalSize, WindowBuilder, launch::launch as desktop_launch};
 use hashgraph_like_consensus::types::ConsensusEvent;
 use prost::Message;
-
-mod logging;
 
 static CSS: Asset = asset!("/assets/main.css");
 static NEXT_ALERT_ID: AtomicU64 = AtomicU64::new(1);

--- a/crates/de_mls_gateway/src/bootstrap.rs
+++ b/crates/de_mls_gateway/src/bootstrap.rs
@@ -1,13 +1,15 @@
-use std::{env::VarError, num::ParseIntError, sync::Arc};
+use std::{env::VarError, num::ParseIntError, sync::Arc, time::Duration};
+
+use de_mls::{
+    core::{DefaultProvider, ProviderConsensus},
+    ds::{
+        DeliveryService, DeliveryServiceError, InboundPacket, TopicFilter, WakuConfig,
+        WakuDeliveryService, WakuStartResult,
+    },
+};
 use tokio::sync::{broadcast, broadcast::Sender};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
-
-use de_mls::core::{DefaultProvider, ProviderConsensus};
-use de_mls::ds::{
-    DeliveryService, DeliveryServiceError, InboundPacket, TopicFilter, WakuConfig,
-    WakuDeliveryService, WakuStartResult,
-};
 
 pub struct AppState<DS: DeliveryService> {
     pub delivery: DS,
@@ -83,7 +85,6 @@ pub async fn bootstrap_core(
         std::thread::Builder::new()
             .name("ds-forwarder".into())
             .spawn(move || {
-                use std::time::Duration;
                 info!("delivery forwarder started");
                 loop {
                     if forward_cancel.is_cancelled() {

--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -1,5 +1,3 @@
-use futures::channel::mpsc::UnboundedSender;
-use hashgraph_like_consensus::events::ConsensusEventBus;
 use std::sync::{Arc, atomic::Ordering};
 
 use de_mls::{
@@ -7,6 +5,8 @@ use de_mls::{
     protos::de_mls::messages::v1::GroupUpdateRequest,
 };
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo};
+use futures::channel::mpsc::UnboundedSender;
+use hashgraph_like_consensus::events::ConsensusEventBus;
 
 use crate::{CoreCtx, Gateway, UserRef};
 

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -3,8 +3,10 @@ use de_mls::{
 };
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo};
 
-use crate::forwarder::{display_batch, load_member_info};
-use crate::{Gateway, UserRef};
+use crate::{
+    Gateway, UserRef,
+    forwarder::{display_batch, load_member_info},
+};
 
 impl Gateway<WakuDeliveryService> {
     pub async fn create_group(&self, group_name: String) -> anyhow::Result<()> {

--- a/crates/de_mls_gateway/src/handler.rs
+++ b/crates/de_mls_gateway/src/handler.rs
@@ -3,9 +3,10 @@
 //! Bridges output events from the User to the gateway's event pipe
 //! (delivery service for outbound, AppEvent for UI notifications).
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use futures::channel::mpsc::UnboundedSender;
-use std::sync::Arc;
 use tokio::task::spawn_blocking;
 
 use de_mls::{

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -5,14 +5,13 @@
 //! - Provide a command entrypoint UI -> gateway (`send(AppCmd)`)
 //! - Hold references to the core context (`CoreCtx`) and current user
 //! - Offer small helper methods (login_with_private_key, etc.)
-use futures::{
-    StreamExt,
-    channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded},
-};
-use once_cell::sync::Lazy;
-use parking_lot::RwLock;
+
+mod bootstrap;
+pub(crate) mod forwarder;
+mod group;
+pub mod handler;
+
 use std::sync::{Arc, atomic::AtomicBool};
-use tokio::sync::Mutex;
 
 use de_mls::{
     app::User,
@@ -20,18 +19,20 @@ use de_mls::{
     ds::{DeliveryService, WakuDeliveryService},
 };
 use de_mls_ui_protocol::v1::{AppCmd, AppEvent};
+use futures::{
+    StreamExt,
+    channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded},
+};
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use tokio::sync::Mutex;
 
-mod bootstrap;
-pub(crate) mod forwarder;
-mod group;
-pub mod handler;
+use crate::handler::GatewayEventHandler;
 
-pub use bootstrap::{
+pub use crate::bootstrap::{
     AppState, Bootstrap, BootstrapConfig, BootstrapError, CoreCtx, bootstrap_core,
     bootstrap_core_from_env,
 };
-
-use handler::GatewayEventHandler;
 
 /// Type alias for the user reference stored in the gateway.
 type UserRef = Arc<

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -26,7 +26,10 @@ pub(crate) mod forwarder;
 mod group;
 pub mod handler;
 
-pub use bootstrap::*;
+pub use bootstrap::{
+    AppState, Bootstrap, BootstrapConfig, BootstrapError, CoreCtx, bootstrap_core,
+    bootstrap_core_from_env,
+};
 
 use handler::GatewayEventHandler;
 

--- a/crates/ui_bridge/src/lib.rs
+++ b/crates/ui_bridge/src/lib.rs
@@ -5,15 +5,15 @@
 //!
 //! It ensures there is a Tokio runtime (desktop app may not have one yet).
 
-use futures::{
-    StreamExt,
-    channel::mpsc::{UnboundedReceiver, unbounded},
-};
 use std::sync::Arc;
 
 use de_mls::{ds::WakuDeliveryService, protos::de_mls::messages::v1::ConversationMessage};
 use de_mls_gateway::{CoreCtx, GATEWAY, init_core};
 use de_mls_ui_protocol::v1::{AppCmd, AppEvent};
+use futures::{
+    StreamExt,
+    channel::mpsc::{UnboundedReceiver, unbounded},
+};
 
 /// Call once during process startup (before launching the Dioxus UI).
 pub fn start_ui_bridge(core: Arc<CoreCtx<WakuDeliveryService>>) {

--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -2,11 +2,9 @@
 //! casting, and forwarding peer messages in. Not protocol invariants — they
 //! decide how consensus events reach the UI and the transport.
 
-use alloy::signers::Signer;
-use prost::Message;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tracing::info;
 
+use alloy::signers::Signer;
 use hashgraph_like_consensus::{
     error::ConsensusError,
     protos::consensus::v1::{Proposal, Vote},
@@ -14,14 +12,18 @@ use hashgraph_like_consensus::{
     types::CreateProposalRequest,
     utils::build_vote,
 };
+use prost::Message;
+use tracing::info;
 
-use crate::app::error::UserError;
-use crate::core::{
-    CoreError, DeMlsProvider, Group, GroupEventHandler, ProviderConsensus,
-    auto_approved_leave_proposal_id,
-};
-use crate::protos::de_mls::messages::v1::{
-    AppMessage, GroupUpdateRequest, RemoveMember, VotePayload, group_update_request,
+use crate::{
+    app::error::UserError,
+    core::{
+        CoreError, DeMlsProvider, Group, GroupEventHandler, ProviderConsensus,
+        auto_approved_leave_proposal_id,
+    },
+    protos::de_mls::messages::v1::{
+        AppMessage, GroupUpdateRequest, RemoveMember, VotePayload, group_update_request,
+    },
 };
 
 /// Consensus-session parameters that come from `GroupConfig`. Grouped so

--- a/src/app/display.rs
+++ b/src/app/display.rs
@@ -1,8 +1,10 @@
 //! Display helpers for rendering protobuf types in the UI.
 
-use crate::mls_crypto::format_wallet_address;
-use crate::protos::de_mls::messages::v1::{
-    GroupUpdateRequest, ViolationEvidence, ViolationType, app_message, group_update_request,
+use crate::{
+    mls_crypto::format_wallet_address,
+    protos::de_mls::messages::v1::{
+        GroupUpdateRequest, ViolationEvidence, ViolationType, app_message, group_update_request,
+    },
 };
 
 // ─────────────────────────── Member Role ───────────────────────────
@@ -54,17 +56,16 @@ pub trait MessageType {
 
 impl MessageType for app_message::Payload {
     fn message_type(&self) -> &'static str {
-        use message_types::*;
         match self {
-            app_message::Payload::ConversationMessage(_) => CONVERSATION_MESSAGE,
-            app_message::Payload::BanRequest(_) => BAN_REQUEST,
-            app_message::Payload::Proposal(_) => PROPOSAL,
-            app_message::Payload::Vote(_) => VOTE,
-            app_message::Payload::VotePayload(_) => VOTE_PAYLOAD,
-            app_message::Payload::UserVote(_) => USER_VOTE,
-            app_message::Payload::ProposalAdded(_) => PROPOSAL_ADDED,
-            app_message::Payload::CommitCandidate(_) => COMMIT_CANDIDATE,
-            app_message::Payload::GroupSync(_) => GROUP_SYNC,
+            app_message::Payload::ConversationMessage(_) => message_types::CONVERSATION_MESSAGE,
+            app_message::Payload::BanRequest(_) => message_types::BAN_REQUEST,
+            app_message::Payload::Proposal(_) => message_types::PROPOSAL,
+            app_message::Payload::Vote(_) => message_types::VOTE,
+            app_message::Payload::VotePayload(_) => message_types::VOTE_PAYLOAD,
+            app_message::Payload::UserVote(_) => message_types::USER_VOTE,
+            app_message::Payload::ProposalAdded(_) => message_types::PROPOSAL_ADDED,
+            app_message::Payload::CommitCandidate(_) => message_types::COMMIT_CANDIDATE,
+            app_message::Payload::GroupSync(_) => message_types::GROUP_SYNC,
         }
     }
 }

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -3,8 +3,10 @@
 use alloy::signers::local::LocalSignerError;
 use hashgraph_like_consensus::error::ConsensusError;
 
-use crate::core::{CallbackError, CoreError};
-use crate::mls_crypto::{IdentityError, MlsError};
+use crate::{
+    core::{CallbackError, CoreError},
+    mls_crypto::{IdentityError, MlsError},
+};
 
 /// Errors from User operations.
 #[derive(Debug, thiserror::Error)]

--- a/src/app/state_machine.rs
+++ b/src/app/state_machine.rs
@@ -1,13 +1,14 @@
 //! Per-group FSM: PendingJoin → Working → Freezing → Selection → Reelection → Leaving.
-use async_trait::async_trait;
+
 use std::{
     fmt::Display,
     time::{Duration, Instant},
 };
+
+use async_trait::async_trait;
 use tracing::info;
 
-use crate::app::config::GroupConfig;
-use crate::core::ProposalKind;
+use crate::{app::config::GroupConfig, core::ProposalKind};
 
 /// Notifies the integrator when a group transitions between [`GroupState`]
 /// variants. Fires from the app layer only — core never calls it.
@@ -443,8 +444,6 @@ mod tests {
     /// `voting_delay`.
     #[test]
     fn test_voting_delay_dispatch_on_proposal_kind() {
-        use crate::core::ProposalKind;
-
         let config = GroupConfig {
             voting_delay: Duration::from_secs(7),
             election_voting_delay: Duration::from_secs(3),

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use hashgraph_like_consensus::storage::ConsensusStorage;
+use hashgraph_like_consensus::{error::ConsensusError, storage::ConsensusStorage};
 use prost::Message;
 use tracing::{error, info};
 
@@ -293,8 +293,6 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// log accordingly and warn only for truly unknown IDs (indicates a logic
     /// bug, not a race).
     async fn resolve_on_timeout(&self, group_name: &str, proposal_id: u32) {
-        use hashgraph_like_consensus::error::ConsensusError;
-
         let scope = P::Scope::from(group_name.to_string());
         let still_active = self
             .consensus_service

--- a/src/app/user/emergency.rs
+++ b/src/app/user/emergency.rs
@@ -11,9 +11,11 @@
 
 use prost::Message;
 
-use crate::core::{ScoreEvent, ScoreOp};
-use crate::protos::de_mls::messages::v1::{
-    GroupUpdateRequest, ViolationEvidence, group_update_request::Payload,
+use crate::{
+    core::{ScoreEvent, ScoreOp},
+    protos::de_mls::messages::v1::{
+        GroupUpdateRequest, ViolationEvidence, group_update_request::Payload,
+    },
 };
 
 /// Score ops to apply when an emergency proposal resolves. Returns an

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -8,6 +8,7 @@ use crate::{
         DeMlsProvider, FreezeFinalizeResult, FreezeOutcome, GroupEventHandler, ScoreEvent, ScoreOp,
         create_commit_candidate, finalize_freeze_round, group_members,
     },
+    ds::WELCOME_SUBTOPIC,
 };
 
 impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
@@ -114,7 +115,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 // epoch ahead of the steward.
                 let has_welcome = outbound
                     .as_ref()
-                    .is_some_and(|p| p.subtopic == crate::ds::WELCOME_SUBTOPIC);
+                    .is_some_and(|p| p.subtopic == WELCOME_SUBTOPIC);
                 if let Some(packet) = outbound {
                     if let Err(e) = self.handler.on_outbound(group_name, packet).await {
                         error!(group = group_name, error = %e, "deferred welcome send failed");

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     core::{DeMlsProvider, GroupEventHandler, build_message, create_group, prepare_to_join},
     mls_crypto::parse_wallet_to_bytes,
-    protos::de_mls::messages::v1::GroupUpdateRequest,
+    protos::de_mls::messages::v1::{GroupUpdateRequest, RemoveMember, group_update_request},
 };
 
 impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
@@ -133,13 +133,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             return Ok(());
         }
 
-        let request = {
-            use crate::protos::de_mls::messages::v1::{RemoveMember, group_update_request};
-            GroupUpdateRequest {
-                payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
-                    identity: self_identity.clone(),
-                })),
-            }
+        let request = GroupUpdateRequest {
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: self_identity.clone(),
+            })),
         };
 
         // Register ownership BEFORE the session opens — the bundled YES

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -10,7 +10,10 @@ use crate::{
         GroupConfig, GroupState, GroupStateMachine, ProposalParams, StateChangeHandler, User,
         UserError, submit_self_leave_proposal, user::GroupEntry,
     },
-    core::{DeMlsProvider, GroupEventHandler, build_message, create_group, prepare_to_join},
+    core::{
+        DeMlsProvider, GroupEventHandler, auto_approved_leave_proposal_id, build_message,
+        create_group, prepare_to_join,
+    },
     mls_crypto::parse_wallet_to_bytes,
     protos::de_mls::messages::v1::{GroupUpdateRequest, RemoveMember, group_update_request},
 };
@@ -142,7 +145,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // Register ownership BEFORE the session opens — the bundled YES
         // fires `ConsensusReached` on submit, and `apply_consensus_result`
         // needs `is_owner_of_proposal` to be true by then.
-        let proposal_id = crate::core::auto_approved_leave_proposal_id(&self_identity);
+        let proposal_id = auto_approved_leave_proposal_id(&self_identity);
         let (proposal_expiration, consensus_timeout) = {
             let entry_arc = self
                 .lookup_entry(group_name)

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -9,13 +9,14 @@
 //! `User` is `Clone` — all fields are `Arc` or cheap `Clone` — so background
 //! tasks just take their own handle via `self.clone()`.
 
-use alloy::signers::local::PrivateKeySigner;
-use hashgraph_like_consensus::storage::ConsensusStorage;
 use std::{
     collections::HashMap,
     str::FromStr,
     sync::{Arc, Mutex},
 };
+
+use alloy::signers::local::PrivateKeySigner;
+use hashgraph_like_consensus::storage::ConsensusStorage;
 use tokio::{sync::RwLock, task::JoinHandle};
 
 use crate::{

--- a/src/core/api/inbound.rs
+++ b/src/core/api/inbound.rs
@@ -1,21 +1,25 @@
 //! Inbound message routing and processing.
 
+use hashgraph_like_consensus::protos::consensus::v1::Proposal;
 use openmls_rust_crypto::MemoryStorage;
 use prost::Message;
 use tracing::{info, warn};
 
-use crate::core::api::process_commit_candidate;
-use crate::core::{error::CoreError, group::Group, process_result::ProcessResult};
-use crate::ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC};
-use crate::mls_crypto::{
-    DeMlsStorage, DecryptResult, MlsService, ShortId, key_package_bytes_from_json,
-    parse_wallet_to_bytes,
+use crate::{
+    core::{
+        api::process_commit_candidate, error::CoreError, group::Group,
+        process_result::ProcessResult,
+    },
+    ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC},
+    mls_crypto::{
+        DeMlsStorage, DecryptResult, MlsService, ShortId, key_package_bytes_from_json,
+        parse_wallet_to_bytes,
+    },
+    protos::de_mls::messages::v1::{
+        AppMessage, GroupUpdateRequest, InviteMember, WelcomeMessage, app_message,
+        group_update_request, welcome_message,
+    },
 };
-use crate::protos::de_mls::messages::v1::{
-    AppMessage, GroupUpdateRequest, InviteMember, WelcomeMessage, app_message,
-    group_update_request, welcome_message,
-};
-use hashgraph_like_consensus::protos::consensus::v1::Proposal;
 
 /// Fast-path proposals (`expected_voters_count == 1`) bypass peer voting, so
 /// we restrict them to self-removal. Enforcing that the MLS-authenticated

--- a/src/core/api/steward.rs
+++ b/src/core/api/steward.rs
@@ -4,17 +4,20 @@ use openmls_rust_crypto::MemoryStorage;
 use prost::Message;
 use tracing::info;
 
-use crate::core::api::compute_commit_hash;
-use crate::core::proposal_kind::ProposalKind;
-use crate::core::{
-    error::CoreError,
-    group::{BufferedCommitCandidate, Group},
+use crate::{
+    core::{
+        api::compute_commit_hash,
+        error::CoreError,
+        group::{BufferedCommitCandidate, Group},
+        proposal_kind::ProposalKind,
+    },
+    ds::{APP_MSG_SUBTOPIC, OutboundPacket},
+    mls_crypto::{
+        CommitCandidate as MlsCommitCandidate, DeMlsStorage, GroupUpdate, KeyPackageBytes,
+        MlsService,
+    },
+    protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request},
 };
-use crate::ds::{APP_MSG_SUBTOPIC, OutboundPacket};
-use crate::mls_crypto::{
-    CommitCandidate as MlsCommitCandidate, DeMlsStorage, GroupUpdate, KeyPackageBytes, MlsService,
-};
-use crate::protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request};
 
 // ─────────────────────────── Steward Operations ───────────────────────────
 

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -12,11 +12,13 @@
 use prost::Message;
 use tracing::info;
 
-use crate::core::{CoreError, Group};
-use crate::mls_crypto::ShortId;
-use crate::protos::de_mls::messages::v1::{
-    GroupUpdateRequest, RemoveMember, StewardElectionProposal, ViolationEvidence, ViolationType,
-    group_update_request,
+use crate::{
+    core::{CoreError, Group},
+    mls_crypto::ShortId,
+    protos::de_mls::messages::v1::{
+        GroupUpdateRequest, RemoveMember, StewardElectionProposal, ViolationEvidence,
+        ViolationType, group_update_request,
+    },
 };
 
 /// Result of applying a consensus outcome. `force_freezing` signals
@@ -351,9 +353,9 @@ mod tests {
 
     fn remove_request(target: Vec<u8>) -> GroupUpdateRequest {
         GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember { identity: target },
-            )),
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: target,
+            })),
         }
     }
 

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -419,7 +419,6 @@ mod tests {
     }
 
     fn score_below_threshold_request(target: Vec<u8>, creator: Vec<u8>) -> GroupUpdateRequest {
-        use crate::protos::de_mls::messages::v1::ViolationEvidence;
         ViolationEvidence::score_below_threshold(target, 0, -10)
             .with_creator(creator)
             .into_update_request()
@@ -462,7 +461,6 @@ mod tests {
     }
 
     fn deadlock_request(creator: Vec<u8>) -> GroupUpdateRequest {
-        use crate::protos::de_mls::messages::v1::ViolationEvidence;
         ViolationEvidence::deadlock(0)
             .with_creator(creator)
             .into_update_request()

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -4,8 +4,10 @@
 
 use async_trait::async_trait;
 
-use crate::ds::OutboundPacket;
-use crate::protos::de_mls::messages::v1::{AppMessage, GroupUpdateRequest};
+use crate::{
+    ds::OutboundPacket,
+    protos::de_mls::messages::v1::{AppMessage, GroupUpdateRequest},
+};
 
 /// Error wrapper returned by [`GroupEventHandler`] callbacks. Integrators
 /// convert their transport/UI errors into this via `CallbackError(e.to_string())`.

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -6,11 +6,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use sha2::{Digest, Sha256};
 
-use crate::core::CoreError;
-use crate::core::proposal_kind::ProposalKind;
-use crate::core::steward_list::{ProtocolConfig, StewardList};
-use crate::protos::de_mls::messages::v1::{
-    CommitCandidate, GroupUpdateRequest, group_update_request,
+use crate::{
+    core::{
+        CoreError,
+        proposal_kind::ProposalKind,
+        steward_list::{ProtocolConfig, StewardList},
+    },
+    protos::de_mls::messages::v1::{CommitCandidate, GroupUpdateRequest, group_update_request},
 };
 
 /// Consensus proposal identifier (assigned by the consensus service).
@@ -931,6 +933,7 @@ impl ResolvedProposalCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protos::de_mls::messages::v1::{InviteMember, RemoveMember};
 
     fn member(id: u8) -> Vec<u8> {
         vec![id; 20]
@@ -1016,11 +1019,9 @@ mod tests {
 
     fn insert_self_leave(group: &mut Group, identity: &[u8]) {
         let remove = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember {
-                    identity: identity.to_vec(),
-                },
-            )),
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: identity.to_vec(),
+            })),
         };
         group.insert_approved_proposal(auto_approved_leave_proposal_id(identity), remove);
     }
@@ -1036,12 +1037,10 @@ mod tests {
         insert_self_leave(&mut group, &leaver);
         let ban_id: ProposalId = 0xdead_beef;
         let ban = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::InviteMember(
-                crate::protos::de_mls::messages::v1::InviteMember {
-                    key_package_bytes: vec![0; 8],
-                    identity: member(99),
-                },
-            )),
+            payload: Some(group_update_request::Payload::InviteMember(InviteMember {
+                key_package_bytes: vec![0; 8],
+                identity: member(99),
+            })),
         };
         group.insert_approved_proposal(ban_id, ban);
         assert_eq!(group.approved_proposals_count(), 2);
@@ -1139,11 +1138,9 @@ mod tests {
 
     fn insert_remove_member(group: &mut Group, target: &[u8], proposal_id: ProposalId) {
         let remove = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember {
-                    identity: target.to_vec(),
-                },
-            )),
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: target.to_vec(),
+            })),
         };
         group.insert_approved_proposal(proposal_id, remove);
     }
@@ -1216,12 +1213,10 @@ mod tests {
         insert_remove_member(&mut group, &member(2), ban_id);
         insert_remove_member(&mut group, &member(3), ecp_id);
         let add = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::InviteMember(
-                crate::protos::de_mls::messages::v1::InviteMember {
-                    key_package_bytes: vec![0; 8],
-                    identity: member(99),
-                },
-            )),
+            payload: Some(group_update_request::Payload::InviteMember(InviteMember {
+                key_package_bytes: vec![0; 8],
+                identity: member(99),
+            })),
         };
         group.insert_approved_proposal(add_id, add);
         assert_eq!(group.approved_proposals_count(), 3);
@@ -1290,11 +1285,9 @@ mod tests {
 
     fn buffer_remove_at(group: &mut Group, target: &[u8], epoch: u64) {
         let request = GroupUpdateRequest {
-            payload: Some(group_update_request::Payload::RemoveMember(
-                crate::protos::de_mls::messages::v1::RemoveMember {
-                    identity: target.to_vec(),
-                },
-            )),
+            payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
+                identity: target.to_vec(),
+            })),
         };
         assert!(group.buffer_pending_update(request, epoch));
     }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -4,6 +4,8 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use sha2::{Digest, Sha256};
+
 use crate::core::CoreError;
 use crate::core::proposal_kind::ProposalKind;
 use crate::core::steward_list::{ProtocolConfig, StewardList};
@@ -28,7 +30,6 @@ const MAX_EPOCH_HISTORY: usize = 10;
 /// commit batch. It also doubles as the self-leave signature used by
 /// `is_auto_approved_entry` and `reject_all_approved_proposals`.
 pub fn auto_approved_leave_proposal_id(identity: &[u8]) -> u32 {
-    use sha2::{Digest, Sha256};
     let hash = Sha256::digest(identity);
     u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])
 }
@@ -54,54 +55,6 @@ pub fn target_identity_of(request: &GroupUpdateRequest) -> Option<&[u8]> {
         group_update_request::Payload::InviteMember(m) => Some(&m.identity),
         group_update_request::Payload::RemoveMember(m) => Some(&m.identity),
         _ => None,
-    }
-}
-
-/// Bounded FIFO of proposal IDs for which a local consensus outcome has been
-/// observed (`ConsensusReached` or timeout-path resolution). Oldest entries
-/// are evicted once `capacity` is reached.
-///
-/// Serves two callers: (a) duplicate-drop guard in `apply_consensus_outcome`
-/// against consensus-library re-emissions, and (b) late-packet classifier in
-/// `forward_incoming_vote` — a `SessionNotFound` for an id in this cache is
-/// a benign late vote (session was trimmed after we resolved it), while the
-/// same error for an id we never saw is suspicious and warrants a warn-log.
-///
-/// `CAPACITY` is sized well above the consensus library's
-/// `max_sessions_per_scope` (default 10) so a late vote arriving within any
-/// plausible peer-lag window still finds its id cached.
-#[derive(Clone, Debug)]
-struct ResolvedProposalCache {
-    ids: HashSet<ProposalId>,
-    order: VecDeque<ProposalId>,
-    capacity: usize,
-}
-
-const RESOLVED_PROPOSAL_CACHE_CAPACITY: usize = 256;
-
-impl ResolvedProposalCache {
-    fn new(capacity: usize) -> Self {
-        Self {
-            ids: HashSet::new(),
-            order: VecDeque::with_capacity(capacity),
-            capacity,
-        }
-    }
-
-    fn contains(&self, id: ProposalId) -> bool {
-        self.ids.contains(&id)
-    }
-
-    fn record(&mut self, id: ProposalId) {
-        if !self.ids.insert(id) {
-            return;
-        }
-        self.order.push_back(id);
-        while self.order.len() > self.capacity
-            && let Some(old) = self.order.pop_front()
-        {
-            self.ids.remove(&old);
-        }
     }
 }
 
@@ -248,11 +201,11 @@ impl Group {
         }
     }
 
-    pub fn is_consensus_outcome_applied(&self, proposal_id: ProposalId) -> bool {
+    pub(crate) fn is_consensus_outcome_applied(&self, proposal_id: ProposalId) -> bool {
         self.resolved_proposals.contains(proposal_id)
     }
 
-    pub fn mark_consensus_outcome_applied(&mut self, proposal_id: ProposalId) {
+    pub(crate) fn mark_consensus_outcome_applied(&mut self, proposal_id: ProposalId) {
         self.resolved_proposals.record(proposal_id);
     }
 
@@ -516,7 +469,7 @@ impl Group {
     // ─────────────────────────── Urgent (ECP-driven) Commit ───────────────────────────
 
     /// Mark the next freeze cycle as urgent and committed-only-for `target`.
-    pub fn set_urgent_commit_target(&mut self, target: Vec<u8>) {
+    pub(crate) fn set_urgent_commit_target(&mut self, target: Vec<u8>) {
         self.urgent_commit_target = Some(target);
     }
 
@@ -524,7 +477,7 @@ impl Group {
         self.urgent_commit_target.as_deref()
     }
 
-    pub fn take_urgent_commit_target(&mut self) -> Option<Vec<u8>> {
+    pub(crate) fn take_urgent_commit_target(&mut self) -> Option<Vec<u8>> {
         self.urgent_commit_target.take()
     }
 
@@ -582,7 +535,7 @@ impl Group {
     /// via `GroupSync` so they don't inherit ghosts or members whose
     /// removal is queued. Order is preserved from the canonical list.
     /// Returns an empty `Vec` if no list is set.
-    pub fn live_steward_members(&self, members: &[Vec<u8>]) -> Vec<Vec<u8>> {
+    pub(crate) fn live_steward_members(&self, members: &[Vec<u8>]) -> Vec<Vec<u8>> {
         let Some(list) = self.steward_list.as_ref() else {
             return Vec::new();
         };
@@ -924,6 +877,54 @@ impl Group {
         });
         self.approved_order
             .retain(|pid| self.approved_proposals.contains_key(pid));
+    }
+}
+
+const RESOLVED_PROPOSAL_CACHE_CAPACITY: usize = 256;
+
+/// Bounded FIFO of proposal IDs for which a local consensus outcome has been
+/// observed (`ConsensusReached` or timeout-path resolution). Oldest entries
+/// are evicted once `capacity` is reached.
+///
+/// Serves two callers: (a) duplicate-drop guard in `apply_consensus_outcome`
+/// against consensus-library re-emissions, and (b) late-packet classifier in
+/// `forward_incoming_vote` — a `SessionNotFound` for an id in this cache is
+/// a benign late vote (session was trimmed after we resolved it), while the
+/// same error for an id we never saw is suspicious and warrants a warn-log.
+///
+/// `CAPACITY` is sized well above the consensus library's
+/// `max_sessions_per_scope` (default 10) so a late vote arriving within any
+/// plausible peer-lag window still finds its id cached.
+#[derive(Clone, Debug)]
+struct ResolvedProposalCache {
+    ids: HashSet<ProposalId>,
+    order: VecDeque<ProposalId>,
+    capacity: usize,
+}
+
+impl ResolvedProposalCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            ids: HashSet::new(),
+            order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn contains(&self, id: ProposalId) -> bool {
+        self.ids.contains(&id)
+    }
+
+    fn record(&mut self, id: ProposalId) {
+        if !self.ids.insert(id) {
+            return;
+        }
+        self.order.push_back(id);
+        while self.order.len() > self.capacity
+            && let Some(old) = self.order.pop_front()
+        {
+            self.ids.remove(&old);
+        }
     }
 }
 

--- a/src/ds/error.rs
+++ b/src/ds/error.rs
@@ -1,16 +1,17 @@
 /// Errors originating from the delivery service layer.
-///
-/// String payloads carry the underlying libwaku error message. These are
-/// human-readable but not structured — callers should treat them as opaque
-/// diagnostic text, not match on their content.
 #[derive(Debug, thiserror::Error)]
 pub enum DeliveryServiceError {
-    #[error("Waku publish message error: {0}")]
-    WakuPublishMessageError(String),
-    #[error("Waku node already initialized: {0}")]
-    WakuNodeAlreadyInitialized(String),
-    #[error("Waku connect peer error: {0}")]
-    WakuConnectPeerError(String),
+    #[cfg(feature = "waku")]
+    #[error("Waku publish failed: {0}")]
+    WakuPublish(#[source] crate::ds::waku::wrapper::WakuFfiError),
+
+    #[cfg(feature = "waku")]
+    #[error("Waku node startup failed: {0}")]
+    WakuStartup(#[source] crate::ds::waku::wrapper::WakuFfiError),
+
+    #[cfg(feature = "waku")]
+    #[error("Waku connect peer failed: {0}")]
+    WakuConnectPeer(#[source] crate::ds::waku::wrapper::WakuFfiError),
 
     #[error("An unknown error occurred: {0}")]
     Other(anyhow::Error),

--- a/src/ds/error.rs
+++ b/src/ds/error.rs
@@ -1,17 +1,20 @@
+#[cfg(feature = "waku")]
+use crate::ds::waku::wrapper::WakuFfiError;
+
 /// Errors originating from the delivery service layer.
 #[derive(Debug, thiserror::Error)]
 pub enum DeliveryServiceError {
     #[cfg(feature = "waku")]
     #[error("Waku publish failed: {0}")]
-    WakuPublish(#[source] crate::ds::waku::wrapper::WakuFfiError),
+    WakuPublish(#[source] WakuFfiError),
 
     #[cfg(feature = "waku")]
     #[error("Waku node startup failed: {0}")]
-    WakuStartup(#[source] crate::ds::waku::wrapper::WakuFfiError),
+    WakuStartup(#[source] WakuFfiError),
 
     #[cfg(feature = "waku")]
     #[error("Waku connect peer failed: {0}")]
-    WakuConnectPeer(#[source] crate::ds::waku::wrapper::WakuFfiError),
+    WakuConnectPeer(#[source] WakuFfiError),
 
     #[error("An unknown error occurred: {0}")]
     Other(anyhow::Error),

--- a/src/ds/waku/mod.rs
+++ b/src/ds/waku/mod.rs
@@ -3,9 +3,11 @@
 pub(crate) mod sys;
 pub(crate) mod wrapper;
 
-use std::sync::{Arc, Mutex, mpsc};
-use std::thread;
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex, mpsc},
+    thread,
+    time::Duration,
+};
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use tracing::{debug, error, info};
@@ -13,8 +15,8 @@ use tracing::{debug, error, info};
 use crate::ds::{
     DeliveryServiceError, GROUP_VERSION, SUBTOPICS,
     transport::{DeliveryService, InboundPacket, OutboundPacket},
+    waku::wrapper::WakuNodeCtx,
 };
-use wrapper::WakuNodeCtx;
 
 /// The pubsub topic for the Waku Node.
 pub fn pubsub_topic() -> String {

--- a/src/ds/waku/mod.rs
+++ b/src/ds/waku/mod.rs
@@ -177,14 +177,14 @@ impl WakuDeliveryService {
         let waku = match WakuNodeCtx::new(&config_json) {
             Ok(w) => w,
             Err(e) => {
-                let _ = ready_tx.send(Err(DeliveryServiceError::WakuNodeAlreadyInitialized(e)));
+                let _ = ready_tx.send(Err(DeliveryServiceError::WakuStartup(e)));
                 return;
             }
         };
 
         // Start node
         if let Err(e) = waku.start() {
-            let _ = ready_tx.send(Err(DeliveryServiceError::WakuNodeAlreadyInitialized(e)));
+            let _ = ready_tx.send(Err(DeliveryServiceError::WakuStartup(e)));
             return;
         }
         info!("Waku node started");
@@ -278,7 +278,7 @@ impl WakuDeliveryService {
         waku.relay_publish(pubsub_topic, &msg_json, 10_000)
             .map_err(|e| {
                 error!("Failed to relay publish: {e}");
-                DeliveryServiceError::WakuPublishMessageError(e)
+                DeliveryServiceError::WakuPublish(e)
             })
     }
 

--- a/src/ds/waku/wrapper.rs
+++ b/src/ds/waku/wrapper.rs
@@ -148,7 +148,8 @@ impl WakuNodeCtx {
 
     /// Connect to a peer by multiaddr.
     pub fn connect(&self, peer_multi_addr: &str, timeout_ms: u32) -> Result<(), WakuFfiError> {
-        let addr_cstr = CString::new(peer_multi_addr).map_err(invalid_cstring("peer_multi_addr"))?;
+        let addr_cstr =
+            CString::new(peer_multi_addr).map_err(invalid_cstring("peer_multi_addr"))?;
 
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {

--- a/src/ds/waku/wrapper.rs
+++ b/src/ds/waku/wrapper.rs
@@ -1,8 +1,35 @@
 //! Safe synchronous wrapper around the raw libwaku FFI.
+//!
+//! Some methods are intentionally unused today (kept for future bring-up of
+//! discv5/peer-id/version exposure); the `#![allow(unused)]` covers them.
 #![allow(unused)]
 use std::{cell::OnceCell, ffi::CString, os::raw::c_void};
 
 use crate::ds::waku::sys::{self as waku_sys, RET_OK, get_trampoline};
+
+/// Structured error from a libwaku FFI call. The `op` carries the C symbol
+/// name so logs and `Display` output identify which call failed.
+#[derive(Debug, thiserror::Error)]
+pub enum WakuFfiError {
+    #[error("invalid C string for {arg}: {source}")]
+    InvalidCString {
+        arg: &'static str,
+        #[source]
+        source: std::ffi::NulError,
+    },
+    #[error("{op} failed (code {code}): {msg}")]
+    Call {
+        op: &'static str,
+        code: i32,
+        msg: String,
+    },
+    #[error("{op} returned no data")]
+    NoData { op: &'static str },
+}
+
+fn invalid_cstring(arg: &'static str) -> impl FnOnce(std::ffi::NulError) -> WakuFfiError {
+    move |source| WakuFfiError::InvalidCString { arg, source }
+}
 /// Opaque handle to a libwaku node context.
 pub struct WakuNodeCtx {
     ctx: *mut c_void,
@@ -14,8 +41,8 @@ unsafe impl Sync for WakuNodeCtx {}
 
 impl WakuNodeCtx {
     /// Create a new waku node. `config_json` is the JSON string for node configuration.
-    pub fn new(config_json: &str) -> Result<Self, String> {
-        let config_cstr = CString::new(config_json).map_err(|e| e.to_string())?;
+    pub fn new(config_json: &str) -> Result<Self, WakuFfiError> {
+        let config_cstr = CString::new(config_json).map_err(invalid_cstring("config_json"))?;
 
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
@@ -34,14 +61,18 @@ impl WakuNodeCtx {
         };
 
         if ctx.is_null() || err.is_some() {
-            return Err(err.unwrap_or_else(|| "waku_new returned null".into()));
+            return Err(WakuFfiError::Call {
+                op: "waku_new",
+                code: RET_OK, // null ctx surfaces with no code; report 0 as sentinel
+                msg: err.unwrap_or_else(|| "returned null".into()),
+            });
         }
 
         Ok(Self { ctx })
     }
 
     /// Start the node.
-    pub fn start(&self) -> Result<(), String> {
+    pub fn start(&self) -> Result<(), WakuFfiError> {
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
             if ret != RET_OK {
@@ -54,13 +85,17 @@ impl WakuNodeCtx {
             unsafe { waku_sys::waku_start(self.ctx, cb, &mut closure as *mut _ as *const c_void) };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_start returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_start",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(())
     }
 
     /// Get the node version string.
-    pub fn version(&self) -> Result<String, String> {
+    pub fn version(&self) -> Result<String, WakuFfiError> {
         let version: OnceCell<String> = OnceCell::new();
         let mut closure = |ret: i32, data: &str| {
             if ret == RET_OK {
@@ -74,15 +109,19 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK {
-            return Err(format!("waku_version returned {ret}"));
+            return Err(WakuFfiError::Call {
+                op: "waku_version",
+                code: ret,
+                msg: String::new(),
+            });
         }
         version
             .into_inner()
-            .ok_or_else(|| "no version returned".into())
+            .ok_or(WakuFfiError::NoData { op: "waku_version" })
     }
 
     /// Get the local peer ID.
-    pub fn get_peer_id(&self) -> Result<String, String> {
+    pub fn get_peer_id(&self) -> Result<String, WakuFfiError> {
         let peer_id: OnceCell<String> = OnceCell::new();
         let mut closure = |ret: i32, data: &str| {
             if ret == RET_OK {
@@ -96,16 +135,20 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK {
-            return Err(format!("waku_get_my_peerid returned {ret}"));
+            return Err(WakuFfiError::Call {
+                op: "waku_get_my_peerid",
+                code: ret,
+                msg: String::new(),
+            });
         }
-        peer_id
-            .into_inner()
-            .ok_or_else(|| "no peer id returned".into())
+        peer_id.into_inner().ok_or(WakuFfiError::NoData {
+            op: "waku_get_my_peerid",
+        })
     }
 
     /// Connect to a peer by multiaddr.
-    pub fn connect(&self, peer_multi_addr: &str, timeout_ms: u32) -> Result<(), String> {
-        let addr_cstr = CString::new(peer_multi_addr).map_err(|e| e.to_string())?;
+    pub fn connect(&self, peer_multi_addr: &str, timeout_ms: u32) -> Result<(), WakuFfiError> {
+        let addr_cstr = CString::new(peer_multi_addr).map_err(invalid_cstring("peer_multi_addr"))?;
 
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
@@ -126,7 +169,11 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_connect returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_connect",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(())
     }
@@ -137,9 +184,9 @@ impl WakuNodeCtx {
         pubsub_topic: &str,
         json_message: &str,
         timeout_ms: u32,
-    ) -> Result<String, String> {
-        let topic_cstr = CString::new(pubsub_topic).map_err(|e| e.to_string())?;
-        let msg_cstr = CString::new(json_message).map_err(|e| e.to_string())?;
+    ) -> Result<String, WakuFfiError> {
+        let topic_cstr = CString::new(pubsub_topic).map_err(invalid_cstring("pubsub_topic"))?;
+        let msg_cstr = CString::new(json_message).map_err(invalid_cstring("json_message"))?;
 
         let result: OnceCell<String> = OnceCell::new();
         let mut err: Option<String> = None;
@@ -164,14 +211,18 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_relay_publish returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_relay_publish",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(result.into_inner().unwrap_or_default())
     }
 
     /// Subscribe to a relay pubsub topic.
-    pub fn relay_subscribe(&self, pubsub_topic: &str) -> Result<(), String> {
-        let topic_cstr = CString::new(pubsub_topic).map_err(|e| e.to_string())?;
+    pub fn relay_subscribe(&self, pubsub_topic: &str) -> Result<(), WakuFfiError> {
+        let topic_cstr = CString::new(pubsub_topic).map_err(invalid_cstring("pubsub_topic"))?;
 
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
@@ -191,7 +242,11 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_relay_subscribe returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_relay_subscribe",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(())
     }
@@ -211,7 +266,7 @@ impl WakuNodeCtx {
     }
 
     /// Stop the node. Should be called before dropping to cleanly release resources.
-    pub fn stop(&self) -> Result<(), String> {
+    pub fn stop(&self) -> Result<(), WakuFfiError> {
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
             if ret != RET_OK {
@@ -224,13 +279,17 @@ impl WakuNodeCtx {
             unsafe { waku_sys::waku_stop(self.ctx, cb, &mut closure as *mut _ as *const c_void) };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_stop returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_stop",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(())
     }
 
     /// Start the discv5 discovery service.
-    pub fn start_discv5(&self) -> Result<(), String> {
+    pub fn start_discv5(&self) -> Result<(), WakuFfiError> {
         let mut err: Option<String> = None;
         let mut closure = |ret: i32, data: &str| {
             if ret != RET_OK {
@@ -244,13 +303,17 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK || err.is_some() {
-            return Err(err.unwrap_or_else(|| format!("waku_start_discv5 returned {ret}")));
+            return Err(WakuFfiError::Call {
+                op: "waku_start_discv5",
+                code: ret,
+                msg: err.unwrap_or_default(),
+            });
         }
         Ok(())
     }
 
     /// Get the local ENR (Ethereum Node Record) string.
-    pub fn get_enr(&self) -> Result<String, String> {
+    pub fn get_enr(&self) -> Result<String, WakuFfiError> {
         let enr: OnceCell<String> = OnceCell::new();
         let mut closure = |ret: i32, data: &str| {
             if ret == RET_OK {
@@ -264,9 +327,15 @@ impl WakuNodeCtx {
         };
 
         if ret != RET_OK {
-            return Err(format!("waku_get_my_enr returned {ret}"));
+            return Err(WakuFfiError::Call {
+                op: "waku_get_my_enr",
+                code: ret,
+                msg: String::new(),
+            });
         }
-        enr.into_inner().ok_or_else(|| "no ENR returned".into())
+        enr.into_inner().ok_or(WakuFfiError::NoData {
+            op: "waku_get_my_enr",
+        })
     }
 }
 

--- a/src/mls_crypto/identity.rs
+++ b/src/mls_crypto/identity.rs
@@ -1,9 +1,10 @@
 //! Ethereum wallet-based identity for DE-MLS.
 
+use std::str::FromStr;
+
 use alloy::{hex, primitives::Address};
 use openmls::credentials::CredentialWithKey;
 use openmls_basic_credential::SignatureKeyPair;
-use std::str::FromStr;
 
 use crate::mls_crypto::IdentityError;
 

--- a/src/mls_crypto/storage/memory.rs
+++ b/src/mls_crypto/storage/memory.rs
@@ -1,7 +1,8 @@
 //! In-memory storage implementation.
 
-use openmls_rust_crypto::MemoryStorage;
 use std::{collections::HashSet, sync::RwLock};
+
+use openmls_rust_crypto::MemoryStorage;
 
 use crate::mls_crypto::{DeMlsStorage, error::StorageError};
 


### PR DESCRIPTION
- Replace stringly-typed `Result<_, String>` in the libwaku FFI shim with a structured `WakuFfiError` carried through `DeliveryServiceError` via `#[source]`; the unused-but-future FFI methods stay in place under
`#![allow(unused)]`.
- Move `ResolvedProposalCache` below the `Group` impl in `core/group.rs` so the file follows public-then-private order; hoist the `sha2` import to the top.
- Replace the `pub use bootstrap::*` glob in `de_mls_gateway` with the seven actual exports.
- Drop function-body `use` statements in `app/user/lifecycle.rs` and the `core/consensus.rs` test module (already in scope via `super::*`).
- Downgrade five `Group` methods to `pub(crate)` — `mark`/`is_consensus_outcome_applied`, `set`/`take_urgent_commit_target`, `live_steward_members` — none have external callers and they're all internal protocol
mechanics. The `urgent_commit_target` getter stays `pub` for diagnostics. Other generous public surface stays so library consumers can drive the protocol state machine themselves.