### PR TITLE
refactor: hot-path perf cleanups (members, group, wallet, timers)

### DIFF
--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -50,7 +50,7 @@ pub struct ProposalParams {
 pub async fn submit_proposal<P: DeMlsProvider>(
     group_name: &str,
     request: &GroupUpdateRequest,
-    identity_string: String,
+    creator_id: &[u8],
     consensus: &ProviderConsensus<P>,
     params: ProposalParams,
 ) -> Result<(u32, AppMessage), CoreError> {
@@ -58,7 +58,7 @@ pub async fn submit_proposal<P: DeMlsProvider>(
     let create_request = CreateProposalRequest::new(
         uuid::Uuid::new_v4().to_string(),
         payload,
-        identity_string.into(),
+        creator_id.to_vec(),
         params.expected_voters,
         params.proposal_expiration.as_secs(),
         params.liveness_criteria_yes,

--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -97,7 +97,7 @@ pub async fn submit_proposal<P: DeMlsProvider>(
 /// because that is the only legitimate case for broadcasting proposal +
 /// vote atomically as a single wire message.
 pub async fn cast_vote<P, SN>(
-    group: &Group,
+    group_name: &str,
     proposal_id: u32,
     vote: bool,
     consensus: &ProviderConsensus<P>,
@@ -107,13 +107,10 @@ where
     P: DeMlsProvider,
     SN: Signer + Send + Sync,
 {
-    let group_name = group.group_name();
-    let is_owner = group.is_owner_of_proposal(proposal_id);
     let scope = P::Scope::from(group_name.to_string());
 
     let choice = if vote { "YES" } else { "NO" };
-    let actor = if is_owner { "owner" } else { "member" };
-    info!(group = group_name, proposal_id, choice, actor, "vote cast");
+    info!(group = group_name, proposal_id, choice, "vote cast");
 
     let vote_msg = consensus
         .cast_vote(&scope, proposal_id, vote, signer)

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -5,7 +5,7 @@
 //! timeout. Since `User` is `Clone` (every field is `Arc` or cheap `Clone`),
 //! each spawn just owns its own handle — no ctx struct per task kind.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use hashgraph_like_consensus::{error::ConsensusError, storage::ConsensusStorage};
 use prost::Message;
@@ -269,12 +269,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.handler
                     .on_app_message(group_name, vote_notification)
                     .await?;
-                self.spawn_auto_vote(
-                    group_name.to_string(),
-                    proposal_id,
-                    voting_delay,
-                    liveness_criteria_yes,
-                );
+                self.spawn_auto_vote(group_name, proposal_id, voting_delay, liveness_criteria_yes);
             }
         }
 
@@ -463,28 +458,32 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// delay can't change it.
     pub(crate) fn spawn_auto_vote(
         &self,
-        group_name: String,
+        group_name: &str,
         proposal_id: u32,
         delay: Duration,
         vote: bool,
     ) {
-        self.cancel_auto_vote(&group_name, proposal_id);
+        self.cancel_auto_vote(group_name, proposal_id);
 
         let user = self.clone();
-        let key = (group_name.clone(), proposal_id);
+        let group_key: Arc<str> = Arc::from(group_name);
+        let group_key_for_task = Arc::clone(&group_key);
 
         let handle = tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            if let Err(e) = user.cast_auto_vote(&group_name, proposal_id, vote).await {
+            if let Err(e) = user
+                .cast_auto_vote(&group_key_for_task, proposal_id, vote)
+                .await
+            {
                 tracing::debug!(
-                    group = %group_name,
+                    group = %group_key_for_task,
                     proposal_id,
                     error = %e,
                     "auto-vote skipped (already voted or session resolved)"
                 );
             } else {
                 info!(
-                    group = %group_name,
+                    group = %group_key_for_task,
                     proposal_id,
                     vote,
                     "auto-vote cast on timer"
@@ -492,13 +491,21 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
             // Remove the handle when the task completes so repeated manual
             // votes after the timer fires don't try to abort a dead handle.
-            if let Ok(mut timers) = user.auto_vote_timers.lock() {
-                timers.remove(&(group_name, proposal_id));
+            if let Ok(mut timers) = user.auto_vote_timers.lock()
+                && let Some(per_group) = timers.get_mut(&*group_key_for_task)
+            {
+                per_group.remove(&proposal_id);
+                if per_group.is_empty() {
+                    timers.remove(&*group_key_for_task);
+                }
             }
         });
 
         if let Ok(mut timers) = self.auto_vote_timers.lock() {
-            timers.insert(key, handle);
+            timers
+                .entry(group_key)
+                .or_default()
+                .insert(proposal_id, handle);
         }
     }
 
@@ -506,24 +513,26 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
     /// registered. No-op otherwise.
     pub(crate) fn cancel_auto_vote(&self, group_name: &str, proposal_id: u32) {
         if let Ok(mut timers) = self.auto_vote_timers.lock()
-            && let Some(handle) = timers.remove(&(group_name.to_string(), proposal_id))
+            && let Some(per_group) = timers.get_mut(group_name)
         {
-            handle.abort();
+            if let Some(handle) = per_group.remove(&proposal_id) {
+                handle.abort();
+            }
+            if per_group.is_empty() {
+                timers.remove(group_name);
+            }
         }
     }
 
     /// Abort every auto-vote timer belonging to `group_name`. Called on
     /// group leave so no stale timers fire against a group we've left.
     pub(crate) fn cancel_group_auto_votes(&self, group_name: &str) {
-        if let Ok(mut timers) = self.auto_vote_timers.lock() {
-            timers.retain(|(g, _), handle| {
-                if g == group_name {
-                    handle.abort();
-                    false
-                } else {
-                    true
-                }
-            });
+        if let Ok(mut timers) = self.auto_vote_timers.lock()
+            && let Some(per_group) = timers.remove(group_name)
+        {
+            for handle in per_group.into_values() {
+                handle.abort();
+            }
         }
     }
 

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -203,7 +203,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         )
         .await?;
 
-        let group = {
+        {
             let entry_arc = self
                 .lookup_entry(group_name)
                 .await
@@ -215,8 +215,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             if kind.is_emergency() {
                 entry.group.observe_emergency(proposal_id);
             }
-            entry.group.clone()
-        };
+        }
 
         let outbound = match creator_vote {
             Some(vote) => {
@@ -242,7 +241,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             None => unbundled,
         };
 
-        let packet = build_message(&group, &self.mls_service, &outbound, &self.app_id)?;
+        let packet = build_message(group_name, &self.mls_service, &outbound, &self.app_id)?;
         self.handler.on_outbound(group_name, packet).await?;
 
         match creator_vote {
@@ -433,28 +432,27 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             .lookup_entry(group_name)
             .await
             .ok_or(UserError::GroupNotFound)?;
-        let group = {
+        {
             let entry = entry_arc.read().await;
             let state = entry.state_machine.current_state();
             if state == GroupState::Freezing || state == GroupState::Selection {
                 return Err(UserError::GroupBlocked(state.to_string()));
             }
-            entry.group.clone()
-        };
+        }
         let app_id = self.app_id.clone();
 
         // Manual vote takes precedence over the pending auto-vote timer.
         self.cancel_auto_vote(group_name, proposal_id);
 
         let app_message = cast_vote::<P, _>(
-            &group,
+            group_name,
             proposal_id,
             vote,
             &self.consensus_service,
             self.eth_signer.clone(),
         )
         .await?;
-        let packet = build_message(&group, &self.mls_service, &app_message, &app_id)?;
+        let packet = build_message(group_name, &self.mls_service, &app_message, &app_id)?;
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())
     }
@@ -537,19 +535,18 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         proposal_id: u32,
         vote: bool,
     ) -> Result<(), UserError> {
-        let group = self
-            .with_entry(group_name, |e| e.group.clone())
-            .await
-            .ok_or(UserError::GroupNotFound)?;
+        if self.lookup_entry(group_name).await.is_none() {
+            return Err(UserError::GroupNotFound);
+        }
         let app_message = cast_vote::<P, _>(
-            &group,
+            group_name,
             proposal_id,
             vote,
             &self.consensus_service,
             self.eth_signer.clone(),
         )
         .await?;
-        let packet = build_message(&group, &self.mls_service, &app_message, &self.app_id)?;
+        let packet = build_message(group_name, &self.mls_service, &app_message, &self.app_id)?;
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())
     }

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -192,7 +192,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let (proposal_id, unbundled) = submit_proposal::<P>(
             group_name,
             &request,
-            self.mls_service.wallet_hex(),
+            self.mls_service.wallet_bytes(),
             &self.consensus_service,
             ProposalParams {
                 expected_voters,

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -158,7 +158,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                         let target = entry
                             .group
                             .live_epoch_steward(violation_epoch, &members)
-                            .filter(|id| !id.is_empty() && *id != self_identity.as_slice())
+                            .filter(|id| !id.is_empty() && *id != self_identity)
                             .map(|id| id.to_vec());
 
                         (GroupState::Reelection, target)

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     core::{
         DeMlsProvider, GroupEventHandler, ProcessResult, ProposalKind, ProtocolConfig, StewardList,
-        build_message, create_commit_candidate, group_members, process_inbound,
+        build_message, create_commit_candidate, group_members, member_set, process_inbound,
     },
     ds::InboundPacket,
     protos::de_mls::messages::v1::{
@@ -37,12 +37,18 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 self.on_incoming_proposal(group_name, proposal).await
             }
             ProcessResult::Vote(vote) => {
-                let group = self
-                    .with_entry(group_name, |e| e.group.clone())
+                let entry_arc = self
+                    .lookup_entry(group_name)
                     .await
                     .ok_or(UserError::GroupNotFound)?;
-                forward_incoming_vote::<P>(group_name, &group, vote, &*self.consensus_service)
-                    .await?;
+                let entry = entry_arc.read().await;
+                forward_incoming_vote::<P>(
+                    group_name,
+                    &entry.group,
+                    vote,
+                    &*self.consensus_service,
+                )
+                .await?;
                 Ok(())
             }
             ProcessResult::MembershipChangeReceived(request) => {
@@ -141,14 +147,10 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             group_name: name.to_string(),
         }
         .into();
-        let entry_arc = match self.lookup_entry(name).await {
-            Some(e) => e,
-            None => return Ok(()),
+        let Some(entry_arc) = self.lookup_entry(name).await else {
+            return Ok(());
         };
-        let packet = {
-            let entry = entry_arc.read().await;
-            build_message(&entry.group, &self.mls_service, &msg, &self.app_id)?
-        };
+        let packet = build_message(name, &self.mls_service, &msg, &self.app_id)?;
         self.handler.on_outbound(name, packet).await?;
         self.handler.on_joined_group(name).await?;
 
@@ -449,7 +451,11 @@ fn validate_group_sync(
         return Ok(false);
     }
 
-    let any_present = sync.steward_members.iter().any(|s| members.contains(s));
+    let members_set = member_set(members);
+    let any_present = sync
+        .steward_members
+        .iter()
+        .any(|s| members_set.contains(s.as_slice()));
     let ordering_valid = StewardList::validate(
         &sync.steward_members,
         sync.election_epoch,

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -129,7 +129,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             else {
                 return Ok(());
             };
-            self.spawn_auto_vote(group_name.to_string(), proposal_id, delay, vote);
+            self.spawn_auto_vote(group_name, proposal_id, delay, vote);
         }
         Ok(())
     }

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -55,7 +55,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         } else {
             let group = prepare_to_join(
                 group_name,
-                self.mls_service.wallet_bytes(),
+                self.mls_service.wallet_bytes().to_vec(),
                 config.protocol.clone(),
             );
             let state_machine = GroupStateMachine::new_as_pending_join_with_config(config);
@@ -86,7 +86,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         // Joiners start tracked at `JoinedGroup` time (once members are known).
         if is_creation {
             self.scoring()
-                .add_member(group_name, &self.mls_service.wallet_bytes());
+                .add_member(group_name, self.mls_service.wallet_bytes());
         }
 
         self.state_handler

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -179,14 +179,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             return Ok(());
         };
 
-        let packet = {
-            let entry_arc = self
-                .lookup_entry(group_name)
-                .await
-                .ok_or(UserError::GroupNotFound)?;
-            let entry = entry_arc.read().await;
-            build_message(&entry.group, &self.mls_service, &app_msg, &self.app_id)?
-        };
+        let packet = build_message(group_name, &self.mls_service, &app_msg, &self.app_id)?;
         self.handler.on_outbound(group_name, packet).await?;
 
         Ok(())

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -57,7 +57,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             }
             .into();
 
-            build_message(&entry.group, &self.mls_service, &app_msg, &self.app_id)?
+            build_message(group_name, &self.mls_service, &app_msg, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -47,8 +47,8 @@ pub(crate) struct GroupEntry {
 
 /// Registry of outstanding auto-vote timers, keyed by
 /// `(group_name, proposal_id)`. Cancelled on manual vote, consensus
-/// resolution, or group leave. Keyed by group, then proposal id, so manual
-/// votes and group-leave teardown look up by `&str` without allocating.
+/// resolution, or group leave. Outer key is the group name (`Arc<str>` so
+/// `&str` lookups don't allocate); inner key is the proposal id.
 type AutoVoteTimers = Arc<Mutex<HashMap<Arc<str>, HashMap<u32, JoinHandle<()>>>>>;
 
 pub struct User<P: DeMlsProvider, H: GroupEventHandler, SCH: StateChangeHandler> {

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -156,7 +156,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
 
     /// Wallet address as checksummed hex.
     pub fn identity_string(&self) -> String {
-        self.mls_service.wallet_hex()
+        self.mls_service.wallet_hex().to_string()
     }
 
     /// Drop all proposals / votes / sessions for this group from the

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -47,8 +47,9 @@ pub(crate) struct GroupEntry {
 
 /// Registry of outstanding auto-vote timers, keyed by
 /// `(group_name, proposal_id)`. Cancelled on manual vote, consensus
-/// resolution, or group leave.
-type AutoVoteTimers = Arc<Mutex<HashMap<(String, u32), JoinHandle<()>>>>;
+/// resolution, or group leave. Keyed by group, then proposal id, so manual
+/// votes and group-leave teardown look up by `&str` without allocating.
+type AutoVoteTimers = Arc<Mutex<HashMap<Arc<str>, HashMap<u32, JoinHandle<()>>>>>;
 
 pub struct User<P: DeMlsProvider, H: GroupEventHandler, SCH: StateChangeHandler> {
     mls_service: Arc<MlsService<P::Storage>>,

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use crate::{
     app::{StateChangeHandler, User, UserError},
     core::{
-        DeMlsProvider, GroupEventHandler, StewardList, build_message, group_members,
+        DeMlsProvider, GroupEventHandler, StewardList, build_message, group_members, member_set,
         target_identity_of,
     },
     mls_crypto::ShortId,
@@ -103,14 +103,13 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
                 return Ok(());
             }
             let mls_members = group_members(&entry.group, &self.mls_service)?;
+            let mls_members_set = member_set(&mls_members);
 
             let self_identity = self.mls_service.wallet_bytes();
             let is_authorized = entry
                 .group
                 .steward_list()
-                .and_then(|list| {
-                    list.responsible_election_proposer(|c| mls_members.iter().any(|m| m == c))
-                })
+                .and_then(|list| list.responsible_election_proposer(|c| mls_members_set.contains(c)))
                 .is_some_and(|proposer| proposer == self_identity);
             if !is_authorized {
                 return Ok(());
@@ -193,13 +192,14 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         let (is_authorized, self_id, epoch) = {
             let entry = entry_arc.read().await;
             let mls_members = group_members(&entry.group, &self.mls_service)?;
+            let mls_members_set = member_set(&mls_members);
             let self_id = self.mls_service.wallet_bytes();
             let is_authorized = entry
                 .group
                 .steward_list()
                 .and_then(|list| {
                     list.responsible_election_proposer(|c| {
-                        mls_members.iter().any(|m| m == c) && !entry.group.is_pending_removal(c)
+                        mls_members_set.contains(c) && !entry.group.is_pending_removal(c)
                     })
                 })
                 .is_some_and(|proposer| proposer == self_id);
@@ -331,20 +331,20 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             // Collect buffered updates whose target isn't already in the
             // active proposal queues. The approved queue is also in the group.
             let approved = entry.group.approved_proposals();
-            let approved_targets: std::collections::HashSet<Vec<u8>> = approved
+            let approved_targets: std::collections::HashSet<&[u8]> = approved
                 .values()
-                .filter_map(|req| target_identity_of(req).map(|id| id.to_vec()))
+                .filter_map(target_identity_of)
                 .collect();
-            let members_set: std::collections::HashSet<Vec<u8>> = members.iter().cloned().collect();
+            let members_set = member_set(&members);
 
             entry
                 .group
                 .pending_updates()
                 .iter()
-                .filter(|(id, _)| !approved_targets.contains(*id))
+                .filter(|(id, _)| !approved_targets.contains(id.as_slice()))
                 .filter(|(id, p)| {
                     // Drop Add for already-member and Remove for non-member.
-                    let is_member = members_set.contains(*id);
+                    let is_member = members_set.contains(id.as_slice());
                     match p.request.payload.as_ref() {
                         Some(group_update_request::Payload::InviteMember(_)) => !is_member,
                         Some(group_update_request::Payload::RemoveMember(_)) => is_member,
@@ -447,7 +447,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             };
 
             let app_msg: AppMessage = sync.into();
-            build_message(&entry.group, &self.mls_service, &app_msg, &self.app_id)?
+            build_message(group_name, &self.mls_service, &app_msg, &self.app_id)?
         };
 
         self.handler.on_outbound(group_name, packet).await?;

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -109,7 +109,9 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             let is_authorized = entry
                 .group
                 .steward_list()
-                .and_then(|list| list.responsible_election_proposer(|c| mls_members_set.contains(c)))
+                .and_then(|list| {
+                    list.responsible_election_proposer(|c| mls_members_set.contains(c))
+                })
                 .is_some_and(|proposer| proposer == self_identity);
             if !is_authorized {
                 return Ok(());
@@ -212,7 +214,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         }
 
         let request = ViolationEvidence::deadlock(epoch)
-            .with_creator(self_id)
+            .with_creator(self_id.to_vec())
             .into_update_request()?;
 
         info!(group = group_name, epoch, "initiating Deadlock ECP");
@@ -331,10 +333,8 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
             // Collect buffered updates whose target isn't already in the
             // active proposal queues. The approved queue is also in the group.
             let approved = entry.group.approved_proposals();
-            let approved_targets: std::collections::HashSet<&[u8]> = approved
-                .values()
-                .filter_map(target_identity_of)
-                .collect();
+            let approved_targets: std::collections::HashSet<&[u8]> =
+                approved.values().filter_map(target_identity_of).collect();
             let members_set = member_set(&members);
 
             entry
@@ -505,7 +505,7 @@ impl<P: DeMlsProvider, H: GroupEventHandler + 'static, SCH: StateChangeHandler +
         for (target_id, current_score) in to_remove {
             let evidence =
                 ViolationEvidence::score_below_threshold(target_id.clone(), epoch, current_score)
-                    .with_creator(self_id.clone());
+                    .with_creator(self_id.to_vec());
             let request = evidence.into_update_request()?;
 
             info!(

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -159,14 +159,11 @@ where
     let current_epoch = mls.current_epoch(group.group_name())?;
     group.lock_freeze_round_selection(current_epoch);
 
-    let candidates = match group.freeze_round() {
-        Some(round) if round.epoch == current_epoch => round.candidates.clone(),
-        _ => {
-            // Drop any local pending commit so the next MLS encrypt
-            // doesn't trip on "pending proposal exists".
-            let _ = mls.discard_own_commit(group.group_name());
-            return Ok(FreezeFinalizeResult::default());
-        }
+    let Some(candidates) = group.take_round_candidates(current_epoch) else {
+        // Drop any local pending commit so the next MLS encrypt
+        // doesn't trip on "pending proposal exists".
+        let _ = mls.discard_own_commit(group.group_name());
+        return Ok(FreezeFinalizeResult::default());
     };
 
     if candidates.is_empty() {
@@ -178,7 +175,6 @@ where
     let sorted = rank_applicable_candidates(candidates, &ctx, allow_subset_candidates);
 
     if sorted.is_empty() {
-        group.clear_freeze_round();
         let _ = mls.discard_own_commit(group.group_name());
         return Ok(FreezeFinalizeResult::default());
     }
@@ -220,7 +216,7 @@ impl RoundContext {
     where
         S: DeMlsStorage<MlsStorage = MemoryStorage>,
     {
-        let self_identity = mls.wallet_bytes();
+        let self_identity = mls.wallet_bytes().to_vec();
 
         let mut mls_actions: Vec<MlsProposalAction> = Vec::new();
         let mut self_remove_pending = false;

--- a/src/core/api/lifecycle.rs
+++ b/src/core/api/lifecycle.rs
@@ -24,7 +24,7 @@ where
     S: DeMlsStorage<MlsStorage = MemoryStorage>,
 {
     mls.create_group(name)?;
-    Group::new_as_creator(name, mls.wallet_bytes(), protocol_config)
+    Group::new_as_creator(name, mls.wallet_bytes().to_vec(), protocol_config)
 }
 
 /// Prepare a handle for joining an existing group.

--- a/src/core/api/lifecycle.rs
+++ b/src/core/api/lifecycle.rs
@@ -43,7 +43,7 @@ pub fn prepare_to_join(
 
 /// Build an MLS-encrypted application message.
 pub fn build_message<S>(
-    group: &Group,
+    group_name: &str,
     mls: &MlsService<S>,
     app_msg: &AppMessage,
     app_id: &[u8],
@@ -51,16 +51,16 @@ pub fn build_message<S>(
 where
     S: DeMlsStorage<MlsStorage = MemoryStorage>,
 {
-    if !mls.has_group(group.group_name()) {
+    if !mls.has_group(group_name) {
         return Err(CoreError::MlsGroupNotInitialized);
     }
 
-    let message_out = mls.encrypt(group.group_name(), &app_msg.encode_to_vec())?;
+    let message_out = mls.encrypt(group_name, &app_msg.encode_to_vec())?;
 
     Ok(OutboundPacket::new(
         message_out,
         APP_MSG_SUBTOPIC,
-        group.group_name(),
+        group_name,
         app_id,
     ))
 }

--- a/src/core/api/steward.rs
+++ b/src/core/api/steward.rs
@@ -145,7 +145,7 @@ where
         group_name: group.group_name_bytes().to_vec(),
         mls_proposals,
         commit_message: commit,
-        steward_identity: mls.wallet_bytes(),
+        steward_identity: mls.wallet_bytes().to_vec(),
     };
 
     // Welcome bytes are deferred: sent from finalize_freeze_round after the

--- a/src/core/api/steward.rs
+++ b/src/core/api/steward.rs
@@ -8,7 +8,7 @@ use crate::{
     core::{
         api::compute_commit_hash,
         error::CoreError,
-        group::{BufferedCommitCandidate, Group},
+        group::{BufferedCommitCandidate, Group, member_set},
         proposal_kind::ProposalKind,
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
@@ -85,7 +85,8 @@ where
     // rebroadcast KPs, duplicate removes) — without this MLS would reject
     // the whole batch with "Duplicate signature key in proposals and group".
     let current_members = mls.members(group.group_name())?;
-    let is_member = |id: &[u8]| current_members.iter().any(|m| m == id);
+    let current_members_set = member_set(&current_members);
+    let is_member = |id: &[u8]| current_members_set.contains(id);
 
     // Urgent (ECP-driven) freeze: restrict the batch to just the target's
     // RemoveMember. See `Group::urgent_commit_target`.

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -47,6 +47,13 @@ pub fn is_auto_approved_entry(proposal_id: u32, request: &GroupUpdateRequest) ->
     }
 }
 
+/// Build a borrow-only set view over a slice of identity blobs. Lets the hot
+/// `is_steward_eligible_in` and `is_member`-style checks short-circuit linear
+/// scans in `Vec<Vec<u8>>` lookups.
+pub(crate) fn member_set(members: &[Vec<u8>]) -> HashSet<&[u8]> {
+    members.iter().map(|m| m.as_slice()).collect()
+}
+
 /// Return the target identity of a membership-changing `GroupUpdateRequest`.
 ///
 /// Used as the stable key for buffering pending updates so duplicates don't
@@ -284,9 +291,10 @@ impl Group {
     /// Resolve the live epoch steward. Skips stewards no longer in the group
     /// and stewards that have buffered an auto-approved self-leave.
     pub fn live_epoch_steward<'a>(&'a self, epoch: u64, members: &[Vec<u8>]) -> Option<&'a [u8]> {
+        let member_set = member_set(members);
         self.steward_list.as_ref().and_then(|l| {
             l.live_epoch_steward(epoch, |candidate| {
-                self.is_steward_eligible(candidate, members)
+                self.is_steward_eligible_in(candidate, &member_set)
             })
         })
     }
@@ -299,13 +307,16 @@ impl Group {
         members: &[Vec<u8>],
     ) -> (Option<&'a [u8]>, Option<&'a [u8]>) {
         match self.steward_list.as_ref() {
-            Some(l) => l.live_epoch_and_backup(epoch, |c| self.is_steward_eligible(c, members)),
+            Some(l) => {
+                let member_set = member_set(members);
+                l.live_epoch_and_backup(epoch, |c| self.is_steward_eligible_in(c, &member_set))
+            }
             None => (None, None),
         }
     }
 
-    fn is_steward_eligible(&self, candidate: &[u8], members: &[Vec<u8>]) -> bool {
-        !self.is_pending_removal(candidate) && members.iter().any(|m| m == candidate)
+    fn is_steward_eligible_in(&self, candidate: &[u8], member_set: &HashSet<&[u8]>) -> bool {
+        !self.is_pending_removal(candidate) && member_set.contains(candidate)
     }
 
     /// True iff `approved_proposals` carries any `RemoveMember(identity)` —
@@ -541,9 +552,10 @@ impl Group {
         let Some(list) = self.steward_list.as_ref() else {
             return Vec::new();
         };
+        let member_set = member_set(members);
         list.members()
             .iter()
-            .filter(|m| self.is_steward_eligible(m, members))
+            .filter(|m| self.is_steward_eligible_in(m, &member_set))
             .cloned()
             .collect()
     }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -709,6 +709,24 @@ impl Group {
         self.freeze_round = None;
     }
 
+    /// Move the active round's candidates out and discard the round itself.
+    /// Returns `None` when no round is active or its epoch doesn't match.
+    /// Used by `finalize_freeze_round` to consume candidates without cloning
+    /// the buffer (each `BufferedCommitCandidate` carries multiple `Vec<u8>`).
+    pub(crate) fn take_round_candidates(
+        &mut self,
+        epoch: u64,
+    ) -> Option<Vec<BufferedCommitCandidate>> {
+        let round = self.freeze_round.take()?;
+        if round.epoch != epoch {
+            // Wrong epoch — restore so the caller can discard it via the
+            // normal "no candidate" path without losing diagnostic state.
+            self.freeze_round = Some(round);
+            return None;
+        }
+        Some(round.candidates)
+    }
+
     // ─────────────────────────── Dedup Operations ───────────────────────────
 
     /// Check if a commit hash has already been committed (in committed history).

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -47,9 +47,8 @@ pub fn is_auto_approved_entry(proposal_id: u32, request: &GroupUpdateRequest) ->
     }
 }
 
-/// Build a borrow-only set view over a slice of identity blobs. Lets the hot
-/// `is_steward_eligible_in` and `is_member`-style checks short-circuit linear
-/// scans in `Vec<Vec<u8>>` lookups.
+/// Borrow-only `HashSet` view over a slice of identity blobs, for O(1)
+/// membership lookups against `Vec<Vec<u8>>`.
 pub(crate) fn member_set(members: &[Vec<u8>]) -> HashSet<&[u8]> {
     members.iter().map(|m| m.as_slice()).collect()
 }
@@ -709,18 +708,14 @@ impl Group {
         self.freeze_round = None;
     }
 
-    /// Move the active round's candidates out and discard the round itself.
+    /// Move the active round's candidates out and clear the round.
     /// Returns `None` when no round is active or its epoch doesn't match.
-    /// Used by `finalize_freeze_round` to consume candidates without cloning
-    /// the buffer (each `BufferedCommitCandidate` carries multiple `Vec<u8>`).
     pub(crate) fn take_round_candidates(
         &mut self,
         epoch: u64,
     ) -> Option<Vec<BufferedCommitCandidate>> {
         let round = self.freeze_round.take()?;
         if round.epoch != epoch {
-            // Wrong epoch — restore so the caller can discard it via the
-            // normal "no candidate" path without losing diagnostic state.
             self.freeze_round = Some(round);
             return None;
         }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,6 +47,7 @@ pub use group::{
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_THRESHOLD_PEER_SCORE, Group, PendingUpdate,
     ProposalId, auto_approved_leave_proposal_id, target_identity_of,
 };
+pub(crate) use group::member_set;
 
 // ── Proposal classification ──
 pub use proposal_kind::ProposalKind;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,12 +42,12 @@ pub use error::CoreError;
 pub use events::{CallbackError, GroupEventHandler};
 
 // ── Group state ──
+pub(crate) use group::member_set;
 pub use group::{
     DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_MAX_REELECTION_ATTEMPTS,
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_THRESHOLD_PEER_SCORE, Group, PendingUpdate,
     ProposalId, auto_approved_leave_proposal_id, target_identity_of,
 };
-pub(crate) use group::member_set;
 
 // ── Proposal classification ──
 pub use proposal_kind::ProposalKind;

--- a/src/mls_crypto/service/identity.rs
+++ b/src/mls_crypto/service/identity.rs
@@ -51,24 +51,21 @@ where
             .write()
             .map_err(|e| StorageError::Lock(e.to_string()))?;
         *guard = Some(data);
+
+        let _ = self.wallet_bytes.set(wallet.as_slice().to_vec());
+        let _ = self.wallet_hex.set(wallet.to_checksum(None));
         Ok(())
     }
 
-    /// Get the wallet address as a checksummed hex string ("0x...").
-    pub fn wallet_hex(&self) -> String {
-        self.identity
-            .read()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|id| id.wallet.to_checksum(None)))
-            .unwrap_or_default()
+    /// Get the wallet address as a checksummed hex string ("0x..."). Empty
+    /// string if `init()` hasn't run.
+    pub fn wallet_hex(&self) -> &str {
+        self.wallet_hex.get().map(String::as_str).unwrap_or("")
     }
 
-    /// Get the wallet address as raw bytes.
-    pub fn wallet_bytes(&self) -> Vec<u8> {
-        self.identity
-            .read()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|id| id.wallet.as_slice().to_vec()))
-            .unwrap_or_default()
+    /// Get the wallet address as raw bytes. Empty slice if `init()` hasn't
+    /// run.
+    pub fn wallet_bytes(&self) -> &[u8] {
+        self.wallet_bytes.get().map(Vec::as_slice).unwrap_or(&[])
     }
 }

--- a/src/mls_crypto/service/mod.rs
+++ b/src/mls_crypto/service/mod.rs
@@ -1,6 +1,9 @@
 //! Main MLS service providing all cryptographic operations.
 
-use std::{collections::HashMap, sync::RwLock};
+use std::{
+    collections::HashMap,
+    sync::{OnceLock, RwLock},
+};
 
 use openmls::{
     group::{MlsGroup, StagedCommit},
@@ -57,6 +60,10 @@ impl<'a> OpenMlsProvider for MlsProvider<'a> {
 pub struct MlsService<S: DeMlsStorage> {
     storage: S,
     crypto: RustCrypto,
+    /// Wallet bytes, populated by `init()`. Empty slice before init.
+    wallet_bytes: OnceLock<Vec<u8>>,
+    /// Checksummed wallet hex, same lifecycle as `wallet_bytes`.
+    wallet_hex: OnceLock<String>,
     identity: RwLock<Option<IdentityData>>,
     groups: RwLock<HashMap<String, MlsGroup>>,
     pending_staged_commits: RwLock<HashMap<String, StagedCommit>>,
@@ -71,6 +78,8 @@ where
         Self {
             storage,
             crypto: RustCrypto::default(),
+            wallet_bytes: OnceLock::new(),
+            wallet_hex: OnceLock::new(),
             identity: RwLock::new(None),
             groups: RwLock::new(HashMap::new()),
             pending_staged_commits: RwLock::new(HashMap::new()),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -158,7 +158,7 @@ pub fn setup_joiner_with_config(
     config: ProtocolConfig,
 ) -> (MlsService<MemoryDeMlsStorage>, Group, OutboundPacket) {
     let mls = setup_mls(wallet_hex);
-    let group = prepare_to_join(group_name, mls.wallet_bytes(), config);
+    let group = prepare_to_join(group_name, mls.wallet_bytes().to_vec(), config);
     let kp_packet = build_key_package_message(&group, &mls, b"test-app-id").unwrap();
     (mls, group, kp_packet)
 }

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -69,7 +69,7 @@ fn test_process_inbound_conversation_message_roundtrip() {
         group_name: group_name.to_string(),
     };
     let app_msg: AppMessage = conv.into();
-    let outbound = build_message(&steward_handle, &steward_mls, &app_msg, b"test-app-id").unwrap();
+    let outbound = build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
 
     let result = process_inbound(
         &mut joiner_handle,
@@ -582,7 +582,7 @@ fn test_group_sync_roundtrip() {
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
-        build_message(&steward_handle, &steward_mls, &app_msg, b"test-app-id").unwrap();
+        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
 
     // Joiner processes the encrypted sync message
     let result = process_inbound(
@@ -739,7 +739,7 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet =
-        build_message(&steward_handle, &steward_mls, &app_msg, b"test-app-id").unwrap();
+        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
 
     // Joiner processes the encrypted sync.
     let result = process_inbound(
@@ -869,7 +869,7 @@ fn test_group_sync_idempotent_for_existing_members() {
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet =
-        build_message(&steward_handle, &steward_mls, &app_msg, b"test-app-id").unwrap();
+        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
 
     // Joiner processes sync — should get GroupSyncReceived at the core level
     let result = process_inbound(

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -37,7 +37,11 @@ fn test_process_inbound_invalid_subtopic() {
 #[test]
 fn test_process_inbound_app_msg_before_mls_init() {
     let mls = setup_mls("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group = prepare_to_join("test-group", mls.wallet_bytes(), default_steward_config());
+    let mut group = prepare_to_join(
+        "test-group",
+        mls.wallet_bytes().to_vec(),
+        default_steward_config(),
+    );
 
     let result = process_inbound(&mut group, b"some payload", APP_MSG_SUBTOPIC, &mls).unwrap();
     assert!(matches!(result, ProcessResult::Noop));
@@ -69,7 +73,13 @@ fn test_process_inbound_conversation_message_roundtrip() {
         group_name: group_name.to_string(),
     };
     let app_msg: AppMessage = conv.into();
-    let outbound = build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
+    let outbound = build_message(
+        steward_handle.group_name(),
+        &steward_mls,
+        &app_msg,
+        b"test-app-id",
+    )
+    .unwrap();
 
     let result = process_inbound(
         &mut joiner_handle,
@@ -124,7 +134,11 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
     let group_name = "non-steward-kp";
 
     let mls = setup_mls("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group = prepare_to_join(group_name, mls.wallet_bytes(), default_steward_config());
+    let mut group = prepare_to_join(
+        group_name,
+        mls.wallet_bytes().to_vec(),
+        default_steward_config(),
+    );
 
     let (_joiner_mls, _joiner_handle, kp_packet) =
         setup_joiner(group_name, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
@@ -363,7 +377,7 @@ fn test_rejoin_after_eviction() {
     // steward re-adds.
     let mut joiner_handle = prepare_to_join(
         group_name,
-        joiner_mls.wallet_bytes(),
+        joiner_mls.wallet_bytes().to_vec(),
         default_steward_config(),
     );
     let kp_packet = build_key_package_message(&joiner_handle, &joiner_mls, b"test-app-id").unwrap();
@@ -388,7 +402,7 @@ fn test_rejoin_after_eviction() {
     );
     assert!(steward_mls.is_member(group_name, &joiner_id));
     assert!(joiner_mls.is_member(group_name, &joiner_id));
-    assert!(joiner_mls.is_member(group_name, &steward_mls.wallet_bytes()));
+    assert!(joiner_mls.is_member(group_name, steward_mls.wallet_bytes()));
 }
 
 #[test]
@@ -581,8 +595,13 @@ fn test_group_sync_roundtrip() {
         pending_update_max_epochs: 3,
     };
     let app_msg: AppMessage = sync.clone().into();
-    let sync_packet =
-        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
+    let sync_packet = build_message(
+        steward_handle.group_name(),
+        &steward_mls,
+        &app_msg,
+        b"test-app-id",
+    )
+    .unwrap();
 
     // Joiner processes the encrypted sync message
     let result = process_inbound(
@@ -738,8 +757,13 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         pending_update_max_epochs: steward_handle.pending_update_max_epochs(),
     };
     let app_msg: AppMessage = sync.clone().into();
-    let sync_packet =
-        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
+    let sync_packet = build_message(
+        steward_handle.group_name(),
+        &steward_mls,
+        &app_msg,
+        b"test-app-id",
+    )
+    .unwrap();
 
     // Joiner processes the encrypted sync.
     let result = process_inbound(
@@ -868,8 +892,13 @@ fn test_group_sync_idempotent_for_existing_members() {
         pending_update_max_epochs: 3,
     };
     let app_msg: AppMessage = sync.into();
-    let sync_packet =
-        build_message(steward_handle.group_name(), &steward_mls, &app_msg, b"test-app-id").unwrap();
+    let sync_packet = build_message(
+        steward_handle.group_name(),
+        &steward_mls,
+        &app_msg,
+        b"test-app-id",
+    )
+    .unwrap();
 
     // Joiner processes sync — should get GroupSyncReceived at the core level
     let result = process_inbound(

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -424,7 +424,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         .steward_list()
         .expect("steward should have a list");
     assert!(
-        steward_list.contains(&steward_mls.wallet_bytes()),
+        steward_list.contains(steward_mls.wallet_bytes()),
         "Steward should be on the steward list"
     );
 }
@@ -446,8 +446,8 @@ fn test_backup_commit_scores_absent_steward() {
 
     let (alice_mls, mut alice_group) = setup_steward(group_name, alice_hex);
     let (bob_mls, mut bob_group, bob_kp_packet) = setup_joiner(group_name, bob_hex);
-    let alice_id = alice_mls.wallet_bytes();
-    let bob_id = bob_mls.wallet_bytes();
+    let alice_id = alice_mls.wallet_bytes().to_vec();
+    let bob_id = bob_mls.wallet_bytes().to_vec();
 
     let (welcome, _) = steward_add_joiner(&alice_mls, &mut alice_group, &bob_kp_packet);
     let join_result =
@@ -603,7 +603,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
     // MLS commit message is still signed by the real steward, so staging
     // succeeds and the cross-check fires.
     let mut app_msg = AppMessage::decode(batch_packet.payload.as_slice()).unwrap();
-    let real_steward_id = steward_mls.wallet_bytes();
+    let real_steward_id = steward_mls.wallet_bytes().to_vec();
     let forged_id = vec![0xCC; real_steward_id.len()];
     match &mut app_msg.payload {
         Some(app_message::Payload::CommitCandidate(c)) => {

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -86,7 +86,7 @@ fn test_new_joiner_starts_with_default_scores() {
     let alice_mls = setup_mls(alice_hex);
     let mut alice_handle =
         create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
-    let alice_id = alice_mls.wallet_bytes();
+    let alice_id = alice_mls.wallet_bytes().to_vec();
 
     // Alice's scoring has her at a non-default score (simulating prior events).
     let mut alice_scoring = make_scoring();
@@ -107,7 +107,7 @@ fn test_new_joiner_starts_with_default_scores() {
     let bob_mls = setup_mls(bob_hex);
     let mut bob_handle = prepare_to_join(
         group_name,
-        bob_mls.wallet_bytes(),
+        bob_mls.wallet_bytes().to_vec(),
         ProtocolConfig::new(1, 5).unwrap(),
     );
     let bob_kp = build_key_package_message(&bob_handle, &bob_mls, b"test-app-id").unwrap();

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -25,7 +25,7 @@ fn test_score_below_threshold_yes_transforms_to_remove_member() {
     let alice_mls = setup_mls(alice_hex);
     let mut group =
         create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
-    let steward_id = alice_mls.wallet_bytes();
+    let steward_id = alice_mls.wallet_bytes().to_vec();
 
     let target_id = vec![0xBB];
     let proposal_id = 100;
@@ -106,7 +106,7 @@ fn test_score_below_threshold_no_penalizes_creator() {
     let alice_mls = setup_mls(alice_hex);
     let mut group =
         create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
-    let steward_id = alice_mls.wallet_bytes();
+    let steward_id = alice_mls.wallet_bytes().to_vec();
 
     let target_id = vec![0xBB];
     let proposal_id = 102;
@@ -139,7 +139,7 @@ fn test_full_pipeline_penalties_to_removal() {
     let alice_mls = setup_mls(alice_hex);
     let mut group =
         create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
-    let steward_id = alice_mls.wallet_bytes();
+    let steward_id = alice_mls.wallet_bytes().to_vec();
     let target_id = vec![0xDD];
 
     let threshold = group.threshold_peer_score();
@@ -370,7 +370,7 @@ fn test_regular_emergency_yes_no_transform() {
         create_group(group_name, &alice_mls, ProtocolConfig::new(1, 5).unwrap()).unwrap();
 
     let target_id = vec![0xBB];
-    let creator_id = alice_mls.wallet_bytes();
+    let creator_id = alice_mls.wallet_bytes().to_vec();
     let proposal_id = 300;
 
     // Regular violation (not score-below-threshold)


### PR DESCRIPTION
- Build a borrow-only `HashSet<&[u8]>` once at hot call sites (`core/api/steward.rs`, `Group` steward-eligibility, two manual `.iter().any` patterns) instead of repeated O(M) scans.
- Drop `Group::clone()` on the four vote paths. `build_message` and `cast_vote` now take `group_name: &str` (the only field they used); `forward_incoming_vote` borrows under the existing read lock.
- Replace `round.candidates.clone()` in `finalize_freeze_round` with a `take_round_candidates` helper that moves the buffer out of the round.
- Cache `wallet_bytes` / `wallet_hex` on `MlsService` behind `OnceLock` cells set on `init()`; the accessors return `&[u8]` and `&str`. `submit_proposal` takes `creator_id: &[u8]` instead of the hex `String`, so
the consensus library sees a 20-byte identifier and hex stays only at display boundaries.
- Switch `auto_vote_timers` to a nested `HashMap<Arc<str>, HashMap<u32, JoinHandle>>` so manual votes and group-leave teardown look up by `&str` without allocating a `String`.
