### PR TITLE
refactor(scoring): per-group PeerScoringPlugin with cross events

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -28,7 +28,7 @@ pub(crate) async fn load_member_info(
 ) -> anyhow::Result<Vec<MemberInfo>> {
     let user = user.read().await;
     let addresses = user.get_group_members(group_name).await?;
-    let scores = user.get_member_scores(group_name);
+    let scores = user.get_member_scores(group_name).await;
     let roles = user.get_member_roles(group_name).await.unwrap_or_default();
     let pending_leavers: Vec<String> = user
         .get_pending_leave_identities(group_name)

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -45,6 +45,7 @@ type UserRef = Arc<
         User<
             DefaultProvider,
             de_mls::app::DefaultMlsService,
+            de_mls::app::DefaultPeerScoring,
             GatewayEventHandler<WakuDeliveryService>,
             GatewayEventHandler<WakuDeliveryService>,
         >,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,7 +36,7 @@ pub use display::{
     MemberRole, MessageType, format_group_request, format_group_request_target, message_types,
 };
 pub use error::UserError;
-pub use peer_scoring::{FixedScoringProvider, InMemoryPeerScoreStorage, PeerScoringService};
+pub use peer_scoring::{FixedScoringProvider, InMemoryPeerScoreStorage};
 pub use state_machine::{FreezeTimeoutStatus, GroupState, GroupStateMachine, StateChangeHandler};
 pub use user::{
     DefaultMlsService, KeyPackageGenerator, MlsCreatorFactory, MlsWelcomeFactory, User,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -39,5 +39,6 @@ pub use error::UserError;
 pub use peer_scoring::{FixedScoringProvider, InMemoryPeerScoreStorage};
 pub use state_machine::{FreezeTimeoutStatus, GroupState, GroupStateMachine, StateChangeHandler};
 pub use user::{
-    DefaultMlsService, KeyPackageGenerator, MlsCreatorFactory, MlsWelcomeFactory, User,
+    DefaultMlsService, DefaultPeerScoring, KeyPackageGenerator, MlsCreatorFactory,
+    MlsWelcomeFactory, ScoringFactory, User,
 };

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -1,10 +1,11 @@
-//! [`PeerScoringService`] plus default in-memory backends. One instance
-//! per group; scores are keyed by `member_id` via a [`PeerScoreStorage`]
-//! and mapped from events via a [`ScoringProvider`].
+//! App-layer scoring backends: an in-memory storage and a
+//! HashMap-backed [`ScoringProvider`] with RFC-default deltas. Both
+//! plug into the reference [`PeerScoringService`](crate::core::PeerScoringService)
+//! in core.
 
 use std::collections::HashMap;
 
-use crate::core::{PeerScoreStorage, ScoreEvent, ScoreOp, ScoringConfig, ScoringProvider};
+use crate::core::{PeerScoreStorage, ScoreEvent, ScoringProvider};
 
 // ── In-memory storage ───────────────────────────────────────────────
 
@@ -42,6 +43,8 @@ impl PeerScoreStorage for InMemoryPeerScoreStorage {
 // ── Default provider ───────────────────────────────────────────────
 
 /// Constant [`ScoringProvider`] — events not in the map produce a delta of 0.
+/// Default deltas via [`Self::default_deltas`] encode RFC §Peer Scoring
+/// recommendations; integrators may swap in their own values.
 #[derive(Debug, Clone)]
 pub struct FixedScoringProvider {
     deltas: HashMap<ScoreEvent, i64>,
@@ -82,321 +85,35 @@ impl ScoringProvider for FixedScoringProvider {
     }
 }
 
-// ── Service ─────────────────────────────────────────────────────────
-
-/// Per-group, per-member score tracker. One instance per group;
-/// threshold travels with [`ScoringConfig`].
-pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
-    storage: S,
-    provider: P,
-    config: ScoringConfig,
-}
-
-impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
-    pub fn new(storage: S, provider: P, config: ScoringConfig) -> Self {
-        Self {
-            storage,
-            provider,
-            config,
-        }
-    }
-
-    /// Start tracking a member with the default score.
-    pub fn add_member(&mut self, member_id: &[u8]) {
-        self.storage.set(member_id, self.config.default_score);
-    }
-
-    pub fn remove_member(&mut self, member_id: &[u8]) {
-        self.storage.remove(member_id);
-    }
-
-    /// Apply a single [`ScoreOp`] and return the target's new score, or
-    /// `None` if the target isn't tracked.
-    pub fn apply_op(&mut self, op: &ScoreOp) -> Option<i64> {
-        let current = self.storage.get(&op.member_id)?;
-        let delta = self.provider.score_delta(op.event);
-        let new_score = current.saturating_add(delta);
-        self.storage.set(&op.member_id, new_score);
-        Some(new_score)
-    }
-
-    /// Apply a batch of [`ScoreOp`]s. Untracked targets are skipped
-    /// silently (same semantics as [`Self::apply_op`]).
-    pub fn apply_ops(&mut self, ops: &[ScoreOp]) {
-        for op in ops {
-            self.apply_op(op);
-        }
-    }
-
-    pub fn score_for(&self, member_id: &[u8]) -> Option<i64> {
-        self.storage.get(member_id)
-    }
-
-    /// Force-set a score; used when applying a `GroupSync` from the steward.
-    pub fn set_score(&mut self, member_id: &[u8], score: i64) {
-        self.storage.set(member_id, score);
-    }
-
-    pub fn members_below_threshold(&self) -> Vec<Vec<u8>> {
-        let threshold = self.config.threshold;
-        self.storage
-            .all_scores()
-            .into_iter()
-            .filter(|(_, score)| *score <= threshold)
-            .map(|(id, _)| id)
-            .collect()
-    }
-
-    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
-        self.storage
-            .get(member_id)
-            .is_some_and(|s| s <= self.config.threshold)
-    }
-
-    pub fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
-        self.storage.all_scores()
-    }
-
-    pub fn config(&self) -> &ScoringConfig {
-        &self.config
-    }
-
-    pub fn set_threshold(&mut self, threshold: i64) {
-        self.config.threshold = threshold;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn default_config() -> ScoringConfig {
-        ScoringConfig {
-            default_score: 100,
-            threshold: 0,
-        }
-    }
-
-    fn make_service() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
-        PeerScoringService::new(
-            InMemoryPeerScoreStorage::new(),
-            FixedScoringProvider::with_default_deltas(),
-            default_config(),
-        )
+    #[test]
+    fn in_memory_storage_round_trip() {
+        let mut storage = InMemoryPeerScoreStorage::new();
+        assert_eq!(storage.get(b"alice"), None);
+        storage.set(b"alice", 42);
+        assert_eq!(storage.get(b"alice"), Some(42));
+        storage.set(b"bob", -3);
+        let all = storage.all_scores();
+        assert_eq!(all.len(), 2);
+        storage.remove(b"alice");
+        assert_eq!(storage.get(b"alice"), None);
+        assert_eq!(storage.all_scores().len(), 1);
     }
 
     #[test]
-    fn test_add_member_gets_default_score() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-        assert_eq!(svc.score_for(b"alice"), Some(100));
+    fn fixed_provider_returns_zero_for_unknown_event() {
+        let p = FixedScoringProvider::new(HashMap::new());
+        assert_eq!(p.score_delta(ScoreEvent::SuccessfulCommit), 0);
     }
 
     #[test]
-    fn test_unknown_member_returns_none() {
-        let svc = make_service();
-        assert_eq!(svc.score_for(b"unknown"), None);
-    }
-
-    #[test]
-    fn test_remove_member() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.remove_member(b"alice");
-        assert_eq!(svc.score_for(b"alice"), None);
-    }
-
-    #[test]
-    fn test_apply_event_decreases_score() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-
-        let new_score = svc.apply_op(&ScoreOp {
-            member_id: b"alice".to_vec(),
-            event: ScoreEvent::EmergencyNoCreator,
-        });
-
-        assert_eq!(new_score, Some(50));
-        assert_eq!(svc.score_for(b"alice"), Some(50));
-    }
-
-    #[test]
-    fn test_apply_event_increases_score() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-
-        let new_score = svc.apply_op(&ScoreOp {
-            member_id: b"alice".to_vec(),
-            event: ScoreEvent::SuccessfulCommit,
-        });
-
-        assert_eq!(new_score, Some(110));
-    }
-
-    #[test]
-    fn test_apply_event_unknown_member_returns_none() {
-        let mut svc = make_service();
-
-        let result = svc.apply_op(&ScoreOp {
-            member_id: b"unknown".to_vec(),
-            event: ScoreEvent::EmergencyNoCreator,
-        });
-
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_multiple_events_accumulate() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-
-        for event in [
-            ScoreEvent::EmergencyNoCreator,
-            ScoreEvent::MisbehavingCommit,
-            ScoreEvent::SuccessfulCommit,
-        ] {
-            svc.apply_op(&ScoreOp {
-                member_id: b"alice".to_vec(),
-                event,
-            });
-        }
-
-        assert_eq!(svc.score_for(b"alice"), Some(30));
-    }
-
-    #[test]
-    fn test_members_below_threshold() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.add_member(b"bob");
-        svc.add_member(b"charlie");
-
-        for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
-            svc.apply_op(&ScoreOp {
-                member_id: b"alice".to_vec(),
-                event,
-            });
-        }
-        for _ in 0..2 {
-            svc.apply_op(&ScoreOp {
-                member_id: b"charlie".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            });
-        }
-
-        let below = svc.members_below_threshold();
-        assert_eq!(below.len(), 2);
-        assert!(below.contains(&b"alice".to_vec()));
-        assert!(below.contains(&b"charlie".to_vec()));
-        assert!(!below.contains(&b"bob".to_vec()));
-    }
-
-    #[test]
-    fn test_is_below_threshold() {
-        let mut svc = make_service();
-        svc.add_member(b"alice");
-
-        assert!(!svc.is_below_threshold(b"alice"));
-
-        for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
-            svc.apply_op(&ScoreOp {
-                member_id: b"alice".to_vec(),
-                event,
-            });
-        }
-
-        assert!(svc.is_below_threshold(b"alice"));
-    }
-
-    #[test]
-    fn test_is_below_threshold_unknown_member() {
-        let svc = make_service();
-        assert!(!svc.is_below_threshold(b"unknown"));
-    }
-
-    #[test]
-    fn test_score_saturates_no_overflow() {
-        let mut svc = PeerScoringService::new(
-            InMemoryPeerScoreStorage::new(),
-            FixedScoringProvider::new(HashMap::from([(ScoreEvent::SuccessfulCommit, i64::MAX)])),
-            ScoringConfig {
-                default_score: i64::MAX,
-                threshold: 0,
-            },
-        );
-        svc.add_member(b"alice");
-
-        let new_score = svc.apply_op(&ScoreOp {
-            member_id: b"alice".to_vec(),
-            event: ScoreEvent::SuccessfulCommit,
-        });
-
-        assert_eq!(new_score, Some(i64::MAX));
-    }
-
-    #[test]
-    fn test_unknown_event_in_provider_returns_zero_delta() {
-        let mut svc = PeerScoringService::new(
-            InMemoryPeerScoreStorage::new(),
-            FixedScoringProvider::new(HashMap::from([(ScoreEvent::EmergencyNoCreator, -50)])),
-            default_config(),
-        );
-        svc.add_member(b"alice");
-
-        let new_score = svc.apply_op(&ScoreOp {
-            member_id: b"alice".to_vec(),
-            event: ScoreEvent::SuccessfulCommit,
-        });
-
-        assert_eq!(new_score, Some(100));
-    }
-
-    #[test]
-    fn test_determinism_independent_instances() {
-        let events = vec![
-            (b"alice".as_slice(), ScoreEvent::EmergencyNoCreator),
-            (b"alice".as_slice(), ScoreEvent::SuccessfulCommit),
-            (b"bob".as_slice(), ScoreEvent::BrokenCommit),
-            (b"bob".as_slice(), ScoreEvent::SuccessfulCommit),
-        ];
-
-        let mut svc1 = make_service();
-        let mut svc2 = make_service();
-
-        for svc in [&mut svc1, &mut svc2] {
-            svc.add_member(b"alice");
-            svc.add_member(b"bob");
-        }
-
-        for (member, event) in &events {
-            for svc in [&mut svc1, &mut svc2] {
-                svc.apply_op(&ScoreOp {
-                    member_id: member.to_vec(),
-                    event: *event,
-                });
-            }
-        }
-
-        assert_eq!(svc1.score_for(b"alice"), svc2.score_for(b"alice"));
-        assert_eq!(svc1.score_for(b"bob"), svc2.score_for(b"bob"));
-        assert_eq!(
-            svc1.members_below_threshold().len(),
-            svc2.members_below_threshold().len()
-        );
-    }
-
-    #[test]
-    fn test_false_accusation_penalty() {
-        let mut svc = make_service();
-        svc.add_member(b"accuser");
-        svc.add_member(b"target");
-
-        svc.apply_op(&ScoreOp {
-            member_id: b"accuser".to_vec(),
-            event: ScoreEvent::EmergencyNoCreator,
-        });
-
-        assert_eq!(svc.score_for(b"accuser"), Some(50));
-        assert_eq!(svc.score_for(b"target"), Some(100));
+    fn fixed_provider_returns_default_deltas() {
+        let p = FixedScoringProvider::with_default_deltas();
+        assert_eq!(p.score_delta(ScoreEvent::SuccessfulCommit), 10);
+        assert_eq!(p.score_delta(ScoreEvent::BrokenCommit), -50);
+        assert_eq!(p.score_delta(ScoreEvent::EmergencyYesCreator), 20);
     }
 }

--- a/src/app/peer_scoring.rs
+++ b/src/app/peer_scoring.rs
@@ -1,6 +1,6 @@
 //! [`PeerScoringService`] plus default in-memory backends. One instance
-//! per [`User`](super::User); scores are keyed by `(group_id, member_id)`
-//! via a [`PeerScoreStorage`] and mapped from events via a [`ScoringProvider`].
+//! per group; scores are keyed by `member_id` via a [`PeerScoreStorage`]
+//! and mapped from events via a [`ScoringProvider`].
 
 use std::collections::HashMap;
 
@@ -12,7 +12,7 @@ use crate::core::{PeerScoreStorage, ScoreEvent, ScoreOp, ScoringConfig, ScoringP
 /// Production integrators should supply a durable backend.
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryPeerScoreStorage {
-    scores: HashMap<String, HashMap<Vec<u8>, i64>>,
+    scores: HashMap<Vec<u8>, i64>,
 }
 
 impl InMemoryPeerScoreStorage {
@@ -22,34 +22,20 @@ impl InMemoryPeerScoreStorage {
 }
 
 impl PeerScoreStorage for InMemoryPeerScoreStorage {
-    fn get(&self, group_id: &str, member_id: &[u8]) -> Option<i64> {
-        self.scores
-            .get(group_id)
-            .and_then(|members| members.get(member_id).copied())
+    fn get(&self, member_id: &[u8]) -> Option<i64> {
+        self.scores.get(member_id).copied()
     }
 
-    fn set(&mut self, group_id: &str, member_id: &[u8], score: i64) {
-        self.scores
-            .entry(group_id.to_string())
-            .or_default()
-            .insert(member_id.to_vec(), score);
+    fn set(&mut self, member_id: &[u8], score: i64) {
+        self.scores.insert(member_id.to_vec(), score);
     }
 
-    fn remove(&mut self, group_id: &str, member_id: &[u8]) {
-        if let Some(members) = self.scores.get_mut(group_id) {
-            members.remove(member_id);
-        }
+    fn remove(&mut self, member_id: &[u8]) {
+        self.scores.remove(member_id);
     }
 
-    fn all_scores(&self, group_id: &str) -> Vec<(Vec<u8>, i64)> {
-        self.scores
-            .get(group_id)
-            .map(|members| members.iter().map(|(k, v)| (k.clone(), *v)).collect())
-            .unwrap_or_default()
-    }
-
-    fn remove_group(&mut self, group_id: &str) {
-        self.scores.remove(group_id);
+    fn all_scores(&self) -> Vec<(Vec<u8>, i64)> {
+        self.scores.iter().map(|(k, v)| (k.clone(), *v)).collect()
     }
 }
 
@@ -98,8 +84,8 @@ impl ScoringProvider for FixedScoringProvider {
 
 // ── Service ─────────────────────────────────────────────────────────
 
-/// Per-member score tracker. Threshold is supplied per-call by the caller
-/// (held on `Group::threshold_peer_score`).
+/// Per-group, per-member score tracker. One instance per group;
+/// threshold travels with [`ScoringConfig`].
 pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
     storage: S,
     provider: P,
@@ -116,68 +102,67 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
     }
 
     /// Start tracking a member with the default score.
-    pub fn add_member(&mut self, group_id: &str, member_id: &[u8]) {
-        self.storage
-            .set(group_id, member_id, self.config.default_score);
+    pub fn add_member(&mut self, member_id: &[u8]) {
+        self.storage.set(member_id, self.config.default_score);
     }
 
-    pub fn remove_member(&mut self, group_id: &str, member_id: &[u8]) {
-        self.storage.remove(group_id, member_id);
-    }
-
-    /// Drop every score entry for `group_id`. Called on leave.
-    pub fn remove_group(&mut self, group_id: &str) {
-        self.storage.remove_group(group_id);
+    pub fn remove_member(&mut self, member_id: &[u8]) {
+        self.storage.remove(member_id);
     }
 
     /// Apply a single [`ScoreOp`] and return the target's new score, or
     /// `None` if the target isn't tracked.
-    pub fn apply_op(&mut self, group_id: &str, op: &ScoreOp) -> Option<i64> {
-        let current = self.storage.get(group_id, &op.member_id)?;
+    pub fn apply_op(&mut self, op: &ScoreOp) -> Option<i64> {
+        let current = self.storage.get(&op.member_id)?;
         let delta = self.provider.score_delta(op.event);
         let new_score = current.saturating_add(delta);
-        self.storage.set(group_id, &op.member_id, new_score);
+        self.storage.set(&op.member_id, new_score);
         Some(new_score)
     }
 
     /// Apply a batch of [`ScoreOp`]s. Untracked targets are skipped
     /// silently (same semantics as [`Self::apply_op`]).
-    pub fn apply_ops(&mut self, group_id: &str, ops: &[ScoreOp]) {
+    pub fn apply_ops(&mut self, ops: &[ScoreOp]) {
         for op in ops {
-            self.apply_op(group_id, op);
+            self.apply_op(op);
         }
     }
 
-    pub fn score_for(&self, group_id: &str, member_id: &[u8]) -> Option<i64> {
-        self.storage.get(group_id, member_id)
+    pub fn score_for(&self, member_id: &[u8]) -> Option<i64> {
+        self.storage.get(member_id)
     }
 
     /// Force-set a score; used when applying a `GroupSync` from the steward.
-    pub fn set_score(&mut self, group_id: &str, member_id: &[u8], score: i64) {
-        self.storage.set(group_id, member_id, score);
+    pub fn set_score(&mut self, member_id: &[u8], score: i64) {
+        self.storage.set(member_id, score);
     }
 
-    pub fn members_below_threshold(&self, group_id: &str, threshold: i64) -> Vec<Vec<u8>> {
+    pub fn members_below_threshold(&self) -> Vec<Vec<u8>> {
+        let threshold = self.config.threshold;
         self.storage
-            .all_scores(group_id)
+            .all_scores()
             .into_iter()
             .filter(|(_, score)| *score <= threshold)
             .map(|(id, _)| id)
             .collect()
     }
 
-    pub fn is_below_threshold(&self, group_id: &str, member_id: &[u8], threshold: i64) -> bool {
+    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
         self.storage
-            .get(group_id, member_id)
-            .is_some_and(|s| s <= threshold)
+            .get(member_id)
+            .is_some_and(|s| s <= self.config.threshold)
     }
 
-    pub fn all_members_with_scores(&self, group_id: &str) -> Vec<(Vec<u8>, i64)> {
-        self.storage.all_scores(group_id)
+    pub fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
+        self.storage.all_scores()
     }
 
     pub fn config(&self) -> &ScoringConfig {
         &self.config
+    }
+
+    pub fn set_threshold(&mut self, threshold: i64) {
+        self.config.threshold = threshold;
     }
 }
 
@@ -185,11 +170,11 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
 mod tests {
     use super::*;
 
-    const GROUP: &str = "test-group";
-    const REMOVAL_THRESHOLD: i64 = 0;
-
     fn default_config() -> ScoringConfig {
-        ScoringConfig { default_score: 100 }
+        ScoringConfig {
+            default_score: 100,
+            threshold: 0,
+        }
     }
 
     fn make_service() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
@@ -203,87 +188,47 @@ mod tests {
     #[test]
     fn test_add_member_gets_default_score() {
         let mut svc = make_service();
-        let member = b"alice";
-
-        svc.add_member(GROUP, member);
-
-        assert_eq!(svc.score_for(GROUP, member), Some(100));
+        svc.add_member(b"alice");
+        assert_eq!(svc.score_for(b"alice"), Some(100));
     }
 
     #[test]
     fn test_unknown_member_returns_none() {
         let svc = make_service();
-
-        assert_eq!(svc.score_for(GROUP, b"unknown"), None);
+        assert_eq!(svc.score_for(b"unknown"), None);
     }
 
     #[test]
     fn test_remove_member() {
         let mut svc = make_service();
-        let member = b"alice";
-
-        svc.add_member(GROUP, member);
-        svc.remove_member(GROUP, member);
-
-        assert_eq!(svc.score_for(GROUP, member), None);
-    }
-
-    /// `remove_group` drops every score in the target group while leaving
-    /// other groups untouched. Idempotent on an unknown group_id.
-    #[test]
-    fn test_remove_group_clears_only_target_group() {
-        let mut svc = make_service();
-        let other_group = "other-group";
-
-        svc.add_member(GROUP, b"alice");
-        svc.add_member(GROUP, b"bob");
-        svc.add_member(other_group, b"carol");
-
-        svc.remove_group(GROUP);
-
-        assert_eq!(svc.score_for(GROUP, b"alice"), None);
-        assert_eq!(svc.score_for(GROUP, b"bob"), None);
-        assert!(svc.all_members_with_scores(GROUP).is_empty());
-        assert_eq!(
-            svc.score_for(other_group, b"carol"),
-            Some(default_config().default_score)
-        );
-
-        // Idempotent on a group that was never tracked.
-        svc.remove_group("never-existed");
+        svc.add_member(b"alice");
+        svc.remove_member(b"alice");
+        assert_eq!(svc.score_for(b"alice"), None);
     }
 
     #[test]
     fn test_apply_event_decreases_score() {
         let mut svc = make_service();
-        let member = b"alice";
-        svc.add_member(GROUP, member);
+        svc.add_member(b"alice");
 
-        let new_score = svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
 
         assert_eq!(new_score, Some(50));
-        assert_eq!(svc.score_for(GROUP, member), Some(50));
+        assert_eq!(svc.score_for(b"alice"), Some(50));
     }
 
     #[test]
     fn test_apply_event_increases_score() {
         let mut svc = make_service();
-        let member = b"alice";
-        svc.add_member(GROUP, member);
+        svc.add_member(b"alice");
 
-        let new_score = svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::SuccessfulCommit,
-            },
-        );
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
 
         assert_eq!(new_score, Some(110));
     }
@@ -292,13 +237,10 @@ mod tests {
     fn test_apply_event_unknown_member_returns_none() {
         let mut svc = make_service();
 
-        let result = svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"unknown".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
+        let result = svc.apply_op(&ScoreOp {
+            member_id: b"unknown".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
 
         assert_eq!(result, None);
     }
@@ -306,72 +248,43 @@ mod tests {
     #[test]
     fn test_multiple_events_accumulate() {
         let mut svc = make_service();
-        let member = b"alice";
-        svc.add_member(GROUP, member);
+        svc.add_member(b"alice");
 
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::MisbehavingCommit,
-            },
-        );
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::SuccessfulCommit,
-            },
-        );
+        for event in [
+            ScoreEvent::EmergencyNoCreator,
+            ScoreEvent::MisbehavingCommit,
+            ScoreEvent::SuccessfulCommit,
+        ] {
+            svc.apply_op(&ScoreOp {
+                member_id: b"alice".to_vec(),
+                event,
+            });
+        }
 
-        assert_eq!(svc.score_for(GROUP, member), Some(30));
+        assert_eq!(svc.score_for(b"alice"), Some(30));
     }
 
     #[test]
     fn test_members_below_threshold() {
         let mut svc = make_service();
-        svc.add_member(GROUP, b"alice");
-        svc.add_member(GROUP, b"bob");
-        svc.add_member(GROUP, b"charlie");
+        svc.add_member(b"alice");
+        svc.add_member(b"bob");
+        svc.add_member(b"charlie");
 
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
+        for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
+            svc.apply_op(&ScoreOp {
                 member_id: b"alice".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::BrokenCommit,
-            },
-        );
-
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
+                event,
+            });
+        }
+        for _ in 0..2 {
+            svc.apply_op(&ScoreOp {
                 member_id: b"charlie".to_vec(),
                 event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"charlie".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
+            });
+        }
 
-        let below = svc.members_below_threshold(GROUP, REMOVAL_THRESHOLD);
+        let below = svc.members_below_threshold();
         assert_eq!(below.len(), 2);
         assert!(below.contains(&b"alice".to_vec()));
         assert!(below.contains(&b"charlie".to_vec()));
@@ -381,33 +294,24 @@ mod tests {
     #[test]
     fn test_is_below_threshold() {
         let mut svc = make_service();
-        svc.add_member(GROUP, b"alice");
+        svc.add_member(b"alice");
 
-        assert!(!svc.is_below_threshold(GROUP, b"alice", REMOVAL_THRESHOLD));
+        assert!(!svc.is_below_threshold(b"alice"));
 
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
+        for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
+            svc.apply_op(&ScoreOp {
                 member_id: b"alice".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::BrokenCommit,
-            },
-        );
+                event,
+            });
+        }
 
-        assert!(svc.is_below_threshold(GROUP, b"alice", REMOVAL_THRESHOLD));
+        assert!(svc.is_below_threshold(b"alice"));
     }
 
     #[test]
     fn test_is_below_threshold_unknown_member() {
         let svc = make_service();
-
-        assert!(!svc.is_below_threshold(GROUP, b"unknown", REMOVAL_THRESHOLD));
+        assert!(!svc.is_below_threshold(b"unknown"));
     }
 
     #[test]
@@ -417,17 +321,15 @@ mod tests {
             FixedScoringProvider::new(HashMap::from([(ScoreEvent::SuccessfulCommit, i64::MAX)])),
             ScoringConfig {
                 default_score: i64::MAX,
+                threshold: 0,
             },
         );
-        svc.add_member(GROUP, b"alice");
+        svc.add_member(b"alice");
 
-        let new_score = svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::SuccessfulCommit,
-            },
-        );
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
 
         assert_eq!(new_score, Some(i64::MAX));
     }
@@ -439,15 +341,12 @@ mod tests {
             FixedScoringProvider::new(HashMap::from([(ScoreEvent::EmergencyNoCreator, -50)])),
             default_config(),
         );
-        svc.add_member(GROUP, b"alice");
+        svc.add_member(b"alice");
 
-        let new_score = svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::SuccessfulCommit,
-            },
-        );
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
 
         assert_eq!(new_score, Some(100));
     }
@@ -465,120 +364,39 @@ mod tests {
         let mut svc2 = make_service();
 
         for svc in [&mut svc1, &mut svc2] {
-            svc.add_member(GROUP, b"alice");
-            svc.add_member(GROUP, b"bob");
+            svc.add_member(b"alice");
+            svc.add_member(b"bob");
         }
 
         for (member, event) in &events {
-            svc1.apply_op(
-                GROUP,
-                &ScoreOp {
+            for svc in [&mut svc1, &mut svc2] {
+                svc.apply_op(&ScoreOp {
                     member_id: member.to_vec(),
                     event: *event,
-                },
-            );
-            svc2.apply_op(
-                GROUP,
-                &ScoreOp {
-                    member_id: member.to_vec(),
-                    event: *event,
-                },
-            );
+                });
+            }
         }
 
+        assert_eq!(svc1.score_for(b"alice"), svc2.score_for(b"alice"));
+        assert_eq!(svc1.score_for(b"bob"), svc2.score_for(b"bob"));
         assert_eq!(
-            svc1.score_for(GROUP, b"alice"),
-            svc2.score_for(GROUP, b"alice")
-        );
-        assert_eq!(svc1.score_for(GROUP, b"bob"), svc2.score_for(GROUP, b"bob"));
-        assert_eq!(
-            svc1.members_below_threshold(GROUP, REMOVAL_THRESHOLD).len(),
-            svc2.members_below_threshold(GROUP, REMOVAL_THRESHOLD).len()
+            svc1.members_below_threshold().len(),
+            svc2.members_below_threshold().len()
         );
     }
 
     #[test]
     fn test_false_accusation_penalty() {
         let mut svc = make_service();
-        svc.add_member(GROUP, b"accuser");
-        svc.add_member(GROUP, b"target");
+        svc.add_member(b"accuser");
+        svc.add_member(b"target");
 
-        svc.apply_op(
-            GROUP,
-            &ScoreOp {
-                member_id: b"accuser".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
+        svc.apply_op(&ScoreOp {
+            member_id: b"accuser".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
 
-        assert_eq!(svc.score_for(GROUP, b"accuser"), Some(50));
-        assert_eq!(svc.score_for(GROUP, b"target"), Some(100));
-    }
-
-    #[test]
-    fn test_scores_isolated_between_groups() {
-        let mut svc = make_service();
-        let group_a = "group-a";
-        let group_b = "group-b";
-        let member = b"alice";
-
-        svc.add_member(group_a, member);
-        svc.add_member(group_b, member);
-
-        svc.apply_op(
-            group_a,
-            &ScoreOp {
-                member_id: member.to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-
-        assert_eq!(svc.score_for(group_a, member), Some(50));
-        assert_eq!(svc.score_for(group_b, member), Some(100));
-    }
-
-    #[test]
-    fn test_members_below_threshold_only_returns_group_members() {
-        let mut svc = make_service();
-        let group_a = "group-a";
-        let group_b = "group-b";
-
-        svc.add_member(group_a, b"alice");
-        svc.add_member(group_b, b"bob");
-
-        svc.apply_op(
-            group_a,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            group_a,
-            &ScoreOp {
-                member_id: b"alice".to_vec(),
-                event: ScoreEvent::BrokenCommit,
-            },
-        );
-        svc.apply_op(
-            group_b,
-            &ScoreOp {
-                member_id: b"bob".to_vec(),
-                event: ScoreEvent::EmergencyNoCreator,
-            },
-        );
-        svc.apply_op(
-            group_b,
-            &ScoreOp {
-                member_id: b"bob".to_vec(),
-                event: ScoreEvent::BrokenCommit,
-            },
-        );
-
-        let below_a = svc.members_below_threshold(group_a, REMOVAL_THRESHOLD);
-        let below_b = svc.members_below_threshold(group_b, REMOVAL_THRESHOLD);
-
-        assert_eq!(below_a, vec![b"alice".to_vec()]);
-        assert_eq!(below_b, vec![b"bob".to_vec()]);
+        assert_eq!(svc.score_for(b"accuser"), Some(50));
+        assert_eq!(svc.score_for(b"target"), Some(100));
     }
 }

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -15,7 +15,10 @@ use crate::{
     app::{
         GroupState, ProposalParams, StateChangeHandler, User, UserError, cast_vote, submit_proposal,
     },
-    core::{DeMlsProvider, GroupEventHandler, ProposalKind, group_members, target_identity_of},
+    core::{
+        DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProposalKind, group_members,
+        target_identity_of,
+    },
     mls_crypto::{IdentityProvider, MlsService},
     protos::de_mls::messages::v1::{AppMessage, GroupUpdateRequest, VotePayload},
 };
@@ -40,9 +43,10 @@ struct NewProposal {
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -287,15 +287,15 @@ where
         payload: &[u8],
         score_ops: &[ScoreOp],
     ) -> Result<(), UserError> {
-        self.scoring().apply_ops(group_name, score_ops);
-
-        if let Ok(req) = GroupUpdateRequest::decode(payload)
-            && let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload
-            && let Some(ev) = &ec.evidence
-            && let Some(entry_arc) = self.lookup_entry(group_name).await
-        {
+        if let Some(entry_arc) = self.lookup_entry(group_name).await {
             let mut entry = entry_arc.write().await;
-            entry.group.resolve_pending_removal(&ev.target_member_id);
+            entry.scoring.apply_ops(score_ops);
+            if let Ok(req) = GroupUpdateRequest::decode(payload)
+                && let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload
+                && let Some(ev) = &ec.evidence
+            {
+                entry.group.resolve_pending_removal(&ev.target_member_id);
+            }
         }
 
         let resumed_from_reelection = match self.lookup_entry(group_name).await {

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -289,6 +289,10 @@ where
     ) -> Result<(), UserError> {
         if let Some(entry_arc) = self.lookup_entry(group_name).await {
             let mut entry = entry_arc.write().await;
+            // Events from this apply chain into the score-removal pass
+            // below (after `handle_emergency_scored` returns into its
+            // caller). The terminal `check_and_initiate_score_removals`
+            // call covers it, so we only need to drop the events here.
             let _events = entry.scoring.apply_ops(score_ops);
             if let Ok(req) = GroupUpdateRequest::decode(payload)
                 && let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -10,8 +10,8 @@ use tracing::{error, info};
 use crate::{
     app::{GroupState, StateChangeHandler, User, UserError},
     core::{
-        DeMlsProvider, GroupEventHandler, ProposalKind, ScoreOp, apply_consensus_result,
-        emergency_score_ops, group_members, target_identity_of,
+        DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProposalKind, ScoreOp,
+        apply_consensus_result, emergency_score_ops, group_members, target_identity_of,
     },
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
@@ -289,7 +289,7 @@ where
     ) -> Result<(), UserError> {
         if let Some(entry_arc) = self.lookup_entry(group_name).await {
             let mut entry = entry_arc.write().await;
-            entry.scoring.apply_ops(score_ops);
+            let _events = entry.scoring.apply_ops(score_ops);
             if let Ok(req) = GroupUpdateRequest::decode(payload)
                 && let Some(group_update_request::Payload::EmergencyCriteria(ec)) = &req.payload
                 && let Some(ev) = &ec.evidence

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -22,9 +22,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -121,6 +121,11 @@ where
             (result, cross)
         };
 
+        // Lock split is intentional: `check_and_initiate_score_removals`
+        // re-acquires the entry write lock and calls `initiate_proposal`
+        // which `.await`s on the consensus service. Holding the entry
+        // lock across that await would block other operations on this
+        // group, so we drop the lock above before chaining.
         if downward_cross && let Err(e) = self.check_and_initiate_score_removals(group_name).await {
             error!(group = group_name, error = %e, "score-removal check failed (freeze finalize)");
         }

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -12,6 +12,8 @@ use crate::{
     mls_crypto::{IdentityProvider, MlsService},
 };
 
+use super::has_downward_cross;
+
 impl<
     P: DeMlsProvider,
     M: MlsService,
@@ -114,7 +116,7 @@ where
             // removal-init pass below, after the lock drops.
             let cross = if !result.score_ops.is_empty() {
                 let events = entry.scoring.apply_ops(&result.score_ops);
-                crate::app::user::has_downward_cross(&events)
+                has_downward_cross(&events)
             } else {
                 false
             };
@@ -196,7 +198,7 @@ where
                                 member_id: steward_id,
                                 event: ScoreEvent::CensorshipInactivity,
                             });
-                            crate::app::user::has_downward_cross(&events)
+                            has_downward_cross(&events)
                         } else {
                             false
                         };

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -106,16 +106,15 @@ where
                 FreezeFinalizeResult::default()
             };
             entry.archive_committed_batch(result.committed_batch.clone());
+            // Apply locally-observed score events before releasing the
+            // entry lock. These come from dropped candidates in the
+            // phase-3 loop (RFC §Peer Scoring: direct local observation,
+            // no ECP needed).
+            if !result.score_ops.is_empty() {
+                entry.scoring.apply_ops(&result.score_ops);
+            }
             result
         };
-
-        // Apply locally-observed score events before dispatching the
-        // outcome. These come from dropped candidates in the phase-3 loop
-        // (RFC §Peer Scoring: direct local observation, no ECP needed).
-        if !finalize_result.score_ops.is_empty() {
-            self.scoring()
-                .apply_ops(group_name, &finalize_result.score_ops);
-        }
 
         match finalize_result.outcome {
             FreezeOutcome::Applied { result, outbound } => {
@@ -150,7 +149,7 @@ where
                 // other than ourselves. Self-penalties are skipped — the
                 // node that failed to commit observes its own state directly
                 // and doesn't need to record a ScoreOp against itself.
-                let (next_state, accuse_target) = {
+                let next_state = {
                     let mut entry = entry_arc.write().await;
 
                     if has_proposals {
@@ -160,7 +159,12 @@ where
                         entry.state_machine.clear_proposal_timer();
                         entry.state_machine.start_reelection();
 
-                        let target = match entry.group.mls() {
+                        // Local observation → direct peer-score penalty,
+                        // no ECP round-trip. Each honest member records
+                        // the same event independently; threshold-crossing
+                        // removal still goes through SCORE_BELOW_THRESHOLD
+                        // consensus in steward.rs.
+                        let accuse_target = match entry.group.mls() {
                             Some(mls) => {
                                 let violation_epoch = mls.current_epoch()?;
                                 let self_identity = self.identity().identity_bytes();
@@ -173,12 +177,18 @@ where
                             }
                             None => None,
                         };
+                        if let Some(steward_id) = accuse_target {
+                            entry.scoring.apply_op(&ScoreOp {
+                                member_id: steward_id,
+                                event: ScoreEvent::CensorshipInactivity,
+                            });
+                        }
 
-                        (GroupState::Reelection, target)
+                        GroupState::Reelection
                     } else {
                         entry.group.clear_freeze_round();
                         entry.state_machine.start_working();
-                        (GroupState::Working, None)
+                        GroupState::Working
                     }
                 };
 
@@ -186,20 +196,6 @@ where
                 self.state_handler
                     .on_state_changed(group_name, next_state)
                     .await;
-
-                if let Some(steward_id) = accuse_target {
-                    // Local observation → direct peer-score penalty, no ECP
-                    // round-trip. Each honest member records the same event
-                    // independently; threshold-crossing removal still goes
-                    // through SCORE_BELOW_THRESHOLD consensus in steward.rs.
-                    self.scoring().apply_op(
-                        group_name,
-                        &ScoreOp {
-                            member_id: steward_id,
-                            event: ScoreEvent::CensorshipInactivity,
-                        },
-                    );
-                }
 
                 // Layer 2 recovery: regenerate the steward list. Only the
                 // responsible proposer's call actually submits.

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -15,9 +15,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -91,7 +91,7 @@ where
             .on_state_changed(group_name, GroupState::Selection)
             .await;
 
-        let finalize_result = {
+        let (finalize_result, downward_cross) = {
             let mut entry = entry_arc.write().await;
             let allow_subset = entry.group.allow_subset_candidates();
             let result = if entry.group.mls().is_some() {
@@ -109,15 +109,20 @@ where
             // Apply locally-observed score events before releasing the
             // entry lock. These come from dropped candidates in the
             // phase-3 loop (RFC §Peer Scoring: direct local observation,
-            // no ECP needed). Threshold-cross events from this apply
-            // belong to the steward coordinator's event drain; this
-            // commit ignores them. Wired into removal triggers in the
-            // next commit.
-            if !result.score_ops.is_empty() {
-                let _events = entry.scoring.apply_ops(&result.score_ops);
-            }
-            result
+            // no ECP needed). A downward threshold cross schedules a
+            // removal-init pass below, after the lock drops.
+            let cross = if !result.score_ops.is_empty() {
+                let events = entry.scoring.apply_ops(&result.score_ops);
+                crate::app::user::has_downward_cross(&events)
+            } else {
+                false
+            };
+            (result, cross)
         };
+
+        if downward_cross && let Err(e) = self.check_and_initiate_score_removals(group_name).await {
+            error!(group = group_name, error = %e, "score-removal check failed (freeze finalize)");
+        }
 
         match finalize_result.outcome {
             FreezeOutcome::Applied { result, outbound } => {
@@ -152,7 +157,7 @@ where
                 // other than ourselves. Self-penalties are skipped — the
                 // node that failed to commit observes its own state directly
                 // and doesn't need to record a ScoreOp against itself.
-                let next_state = {
+                let (next_state, downward_cross) = {
                     let mut entry = entry_arc.write().await;
 
                     if has_proposals {
@@ -180,20 +185,29 @@ where
                             }
                             None => None,
                         };
-                        if let Some(steward_id) = accuse_target {
-                            let _events = entry.scoring.apply_op(&ScoreOp {
+                        let cross = if let Some(steward_id) = accuse_target {
+                            let events = entry.scoring.apply_op(&ScoreOp {
                                 member_id: steward_id,
                                 event: ScoreEvent::CensorshipInactivity,
                             });
-                        }
+                            crate::app::user::has_downward_cross(&events)
+                        } else {
+                            false
+                        };
 
-                        GroupState::Reelection
+                        (GroupState::Reelection, cross)
                     } else {
                         entry.group.clear_freeze_round();
                         entry.state_machine.start_working();
-                        GroupState::Working
+                        (GroupState::Working, false)
                     }
                 };
+
+                if downward_cross
+                    && let Err(e) = self.check_and_initiate_score_removals(group_name).await
+                {
+                    error!(group = group_name, error = %e, "score-removal check failed (freeze timeout)");
+                }
 
                 let entered_reelection = next_state == GroupState::Reelection;
                 self.state_handler

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -5,8 +5,8 @@ use tracing::{error, info};
 use crate::{
     app::{FreezeTimeoutStatus, GroupState, StateChangeHandler, User, UserError},
     core::{
-        DeMlsProvider, FreezeFinalizeResult, FreezeOutcome, GroupEventHandler, ScoreEvent, ScoreOp,
-        create_commit_candidate, finalize_freeze_round, group_members,
+        DeMlsProvider, FreezeFinalizeResult, FreezeOutcome, GroupEventHandler, PeerScoringPlugin,
+        ScoreEvent, ScoreOp, create_commit_candidate, finalize_freeze_round, group_members,
     },
     ds::WELCOME_SUBTOPIC,
     mls_crypto::{IdentityProvider, MlsService},
@@ -109,9 +109,12 @@ where
             // Apply locally-observed score events before releasing the
             // entry lock. These come from dropped candidates in the
             // phase-3 loop (RFC §Peer Scoring: direct local observation,
-            // no ECP needed).
+            // no ECP needed). Threshold-cross events from this apply
+            // belong to the steward coordinator's event drain; this
+            // commit ignores them. Wired into removal triggers in the
+            // next commit.
             if !result.score_ops.is_empty() {
-                entry.scoring.apply_ops(&result.score_ops);
+                let _events = entry.scoring.apply_ops(&result.score_ops);
             }
             result
         };
@@ -178,7 +181,7 @@ where
                             None => None,
                         };
                         if let Some(steward_id) = accuse_target {
-                            entry.scoring.apply_op(&ScoreOp {
+                            let _events = entry.scoring.apply_op(&ScoreOp {
                                 member_id: steward_id,
                                 event: ScoreEvent::CensorshipInactivity,
                             });

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -167,7 +167,7 @@ where
         };
         self.handler.on_outbound(name, packet).await?;
         self.handler.on_joined_group(name).await?;
-        self.sync_scoring_members(name, &mls_members);
+        self.sync_scoring_members(name, &mls_members).await;
 
         let state = {
             let mut entry = entry_arc.write().await;
@@ -192,7 +192,7 @@ where
                     Vec::new()
                 }
             };
-            self.sync_scoring_members(group_name, &mls_members);
+            self.sync_scoring_members(group_name, &mls_members).await;
         }
         self.prune_pending_updates_after_commit(group_name).await?;
 
@@ -259,11 +259,12 @@ where
         if let Some(entry) = entry {
             // Drop MLS state for the departing group: take the service out
             // of the Group so its `delete()` runs before the entry drops.
+            // Per-group scoring is dropped when the entry leaves the
+            // registry below.
             if let Some(mls) = entry.write().await.group.take_mls() {
                 let _ = mls.delete();
             }
         }
-        self.scoring().remove_group(group_name);
         self.cleanup_consensus_scope(group_name).await?;
         self.handler.on_leave_group(group_name).await?;
         Ok(())
@@ -346,13 +347,6 @@ where
         let sn = sync.steward_members.len();
         self.apply_group_sync_to_entry(group_name, &sync).await?;
 
-        if !sync.peer_scores.is_empty() {
-            let mut scoring = self.scoring();
-            for ps in &sync.peer_scores {
-                scoring.set_score(group_name, &ps.member_id, ps.score);
-            }
-        }
-
         info!(
             group = group_name,
             election_epoch = sync.election_epoch,
@@ -388,9 +382,10 @@ where
         entry
             .group
             .set_max_reelection_attempts(sync.max_reelection_attempts);
-        entry
-            .group
-            .set_threshold_peer_score(sync.threshold_peer_score);
+        entry.scoring.set_threshold(sync.threshold_peer_score);
+        for ps in &sync.peer_scores {
+            entry.scoring.set_score(&ps.member_id, ps.score);
+        }
         entry
             .group
             .set_liveness_criteria_yes(sync.liveness_criteria_yes);

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -391,9 +391,9 @@ where
                 .map(|ps| (ps.member_id.clone(), ps.score))
                 .collect(),
         };
-        // Events from this apply belong to the steward coordinator's
-        // event drain; this commit ignores them. Wired into removal
-        // triggers in the next commit.
+        // Joiners aren't stewards yet, so any downward crosses surfaced
+        // here will be acted on by an existing steward via their own
+        // event chain. Drop our events.
         let _events = entry.scoring.apply_snapshot(&snapshot);
         entry
             .group

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -10,8 +10,9 @@ use crate::{
         forward_incoming_vote,
     },
     core::{
-        DeMlsProvider, GroupEventHandler, ProcessResult, ProposalKind, ProtocolConfig, StewardList,
-        create_commit_candidate, group_members, member_set, process_inbound,
+        DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProcessResult, ProposalKind,
+        ProtocolConfig, ScoreSnapshot, StewardList, create_commit_candidate, group_members,
+        member_set, process_inbound,
     },
     ds::{APP_MSG_SUBTOPIC, InboundPacket, WELCOME_SUBTOPIC},
     mls_crypto::{IdentityProvider, MlsService, ShortId, key_package_bytes_from_json},
@@ -383,9 +384,17 @@ where
             .group
             .set_max_reelection_attempts(sync.max_reelection_attempts);
         entry.scoring.set_threshold(sync.threshold_peer_score);
-        for ps in &sync.peer_scores {
-            entry.scoring.set_score(&ps.member_id, ps.score);
-        }
+        let snapshot = ScoreSnapshot {
+            diverged: sync
+                .peer_scores
+                .iter()
+                .map(|ps| (ps.member_id.clone(), ps.score))
+                .collect(),
+        };
+        // Events from this apply belong to the steward coordinator's
+        // event drain; this commit ignores them. Wired into removal
+        // triggers in the next commit.
+        let _events = entry.scoring.apply_snapshot(&snapshot);
         entry
             .group
             .set_liveness_criteria_yes(sync.liveness_criteria_yes);

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -25,9 +25,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -392,9 +392,11 @@ where
                 .map(|ps| (ps.member_id.clone(), ps.score))
                 .collect(),
         };
-        // Joiners aren't stewards yet, so any downward crosses surfaced
-        // here will be acted on by an existing steward via their own
-        // event chain. Drop our events.
+        // The GroupSync sender (an existing steward) holds the same
+        // scores and is the canonical actor for any below-threshold
+        // member in this snapshot — they'll submit
+        // `SCORE_BELOW_THRESHOLD` from their own event chain. Drop our
+        // events to avoid duplicate proposals from joiners.
         let _events = entry.scoring.apply_snapshot(&snapshot);
         entry
             .group

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -48,7 +48,6 @@ where
         }
 
         let max_reelection_attempts = config.max_reelection_attempts;
-        let threshold_peer_score = config.threshold_peer_score;
         let liveness_criteria_yes = config.liveness_criteria_yes;
         let pending_update_max_epochs = config.pending_update_max_epochs;
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
@@ -60,7 +59,7 @@ where
                 config.protocol.clone(),
                 mls,
             )?;
-            let state_machine = GroupStateMachine::new_as_member_with_config(config);
+            let state_machine = GroupStateMachine::new_as_member_with_config(config.clone());
             (group, state_machine)
         } else {
             let group: Group<M> = Group::prepare_to_join(
@@ -68,13 +67,18 @@ where
                 self_identity_bytes.clone(),
                 config.protocol.clone(),
             );
-            let state_machine = GroupStateMachine::new_as_pending_join_with_config(config);
+            let state_machine = GroupStateMachine::new_as_pending_join_with_config(config.clone());
             (group, state_machine)
         };
         group.set_max_reelection_attempts(max_reelection_attempts);
-        group.set_threshold_peer_score(threshold_peer_score);
         group.set_liveness_criteria_yes(liveness_criteria_yes);
         group.set_pending_update_max_epochs(pending_update_max_epochs);
+
+        let mut scoring = self.make_scoring_service();
+        // Joiners start tracked at `JoinedGroup` time (once members are known).
+        if is_creation {
+            scoring.add_member(&self_identity_bytes);
+        }
 
         let initial_state = state_machine.current_state();
         if initial_state == GroupState::PendingJoin {
@@ -86,14 +90,9 @@ where
         }
         groups.insert(
             group_name.to_string(),
-            Arc::new(RwLock::new(GroupEntry::new(group, state_machine))),
+            Arc::new(RwLock::new(GroupEntry::new(group, state_machine, scoring))),
         );
         drop(groups);
-
-        // Joiners start tracked at `JoinedGroup` time (once members are known).
-        if is_creation {
-            self.scoring().add_member(group_name, &self_identity_bytes);
-        }
 
         self.state_handler
             .on_state_changed(group_name, initial_state)

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -20,9 +20,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -10,7 +10,9 @@ use crate::{
         GroupConfig, GroupState, GroupStateMachine, ProposalParams, StateChangeHandler, User,
         UserError, submit_self_leave_proposal, user::GroupEntry,
     },
-    core::{DeMlsProvider, Group, GroupEventHandler, auto_approved_leave_proposal_id},
+    core::{
+        DeMlsProvider, Group, GroupEventHandler, PeerScoringPlugin, auto_approved_leave_proposal_id,
+    },
     mls_crypto::{IdentityProvider, MlsService, parse_wallet_to_bytes},
     protos::de_mls::messages::v1::{GroupUpdateRequest, RemoveMember, group_update_request},
 };

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -80,7 +80,10 @@ where
         let mut scoring = self.make_scoring_service();
         // Joiners start tracked at `JoinedGroup` time (once members are known).
         if is_creation {
-            scoring.add_member(&self_identity_bytes);
+            // Creator is self at `default_score`; under standard config
+            // (`default > threshold`) no cross event fires, so we drop
+            // the return value here.
+            let _events = scoring.add_member(&self_identity_bytes);
         }
 
         let initial_state = state_machine.current_state();

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     app::{GroupState, StateChangeHandler, User, UserError},
-    core::{DeMlsProvider, GroupEventHandler, build_key_package_message},
+    core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, build_key_package_message},
     mls_crypto::{MlsService, parse_wallet_to_bytes},
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, ConversationMessage, GroupUpdateRequest, RemoveMember,
@@ -13,9 +13,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -95,6 +95,19 @@ impl<M: MlsService> GroupEntry<M> {
     }
 }
 
+/// `true` iff `events` contains at least one downward threshold cross —
+/// the signal coordinators react to by chaining into score-removal
+/// initiation. Helper kept here so every callsite uses the same
+/// triggering rule.
+pub(crate) fn has_downward_cross(events: &[crate::core::PeerScoringEvent]) -> bool {
+    events.iter().any(|e| {
+        matches!(
+            e,
+            crate::core::PeerScoringEvent::ThresholdCrossedDown { .. }
+        )
+    })
+}
+
 /// Registry of outstanding auto-vote timers, keyed by
 /// `(group_name, proposal_id)`. Cancelled on manual vote, consensus
 /// resolution, or group leave. Outer key is the group name (`Arc<str>` so

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -23,11 +23,11 @@ use tokio::{sync::RwLock, task::JoinHandle};
 use crate::{
     app::{
         FixedScoringProvider, GroupConfig, GroupStateMachine, InMemoryPeerScoreStorage,
-        PeerScoringService, StateChangeHandler, UserError,
+        StateChangeHandler, UserError,
     },
     core::{
-        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, ProposalId, ProviderConsensus,
-        ScoringConfig,
+        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringService, ProposalId,
+        ProviderConsensus, ScoringConfig,
     },
     mls_crypto::{
         IdentityProvider, KeyPackageBytes, MemoryDeMlsStorage, MlsError, MlsService,

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -127,7 +127,9 @@ pub type MlsWelcomeFactory<M> =
 pub type KeyPackageGenerator =
     Arc<dyn Fn() -> Result<KeyPackageBytes, MlsError> + Send + Sync + 'static>;
 /// Factory closure that builds a [`PeerScoringPlugin`] instance for a
-/// fresh group, using the user's default scoring config.
+/// fresh group. Currently invoked with the user's default
+/// [`ScoringConfig`] derived from `default_group_config`; the parameter
+/// is forward-looking for per-group config overrides.
 pub type ScoringFactory<Sc> = Arc<dyn Fn(&ScoringConfig) -> Sc + Send + Sync + 'static>;
 
 pub struct User<

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -26,8 +26,8 @@ use crate::{
         StateChangeHandler, UserError,
     },
     core::{
-        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringPlugin,
-        PeerScoringService, ProposalId, ProviderConsensus, ScoringConfig,
+        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringEvent,
+        PeerScoringPlugin, PeerScoringService, ProposalId, ProviderConsensus, ScoringConfig,
     },
     mls_crypto::{
         IdentityProvider, KeyPackageBytes, MemoryDeMlsStorage, MlsError, MlsService,
@@ -95,13 +95,10 @@ impl<M: MlsService, Sc: PeerScoringPlugin> GroupEntry<M, Sc> {
 /// the signal coordinators react to by chaining into score-removal
 /// initiation. Helper kept here so every callsite uses the same
 /// triggering rule.
-pub(crate) fn has_downward_cross(events: &[crate::core::PeerScoringEvent]) -> bool {
-    events.iter().any(|e| {
-        matches!(
-            e,
-            crate::core::PeerScoringEvent::ThresholdCrossedDown { .. }
-        )
-    })
+pub(crate) fn has_downward_cross(events: &[PeerScoringEvent]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, PeerScoringEvent::ThresholdCrossedDown { .. }))
 }
 
 /// Registry of outstanding auto-vote timers, keyed by

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -26,8 +26,8 @@ use crate::{
         StateChangeHandler, UserError,
     },
     core::{
-        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringService, ProposalId,
-        ProviderConsensus, ScoringConfig,
+        DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringPlugin,
+        PeerScoringService, ProposalId, ProviderConsensus, ScoringConfig,
     },
     mls_crypto::{
         IdentityProvider, KeyPackageBytes, MemoryDeMlsStorage, MlsError, MlsService,
@@ -49,17 +49,17 @@ mod steward;
 /// concern only; protocol logic in `core::Group` is history-agnostic.
 const MAX_EPOCH_HISTORY: usize = 10;
 
-pub(crate) struct GroupEntry<M: MlsService> {
+pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin> {
     /// `Group<M>` owns the per-group MLS service inside its own
     /// `Option<M>` slot — joiners in `PendingJoin` carry `None` until a
     /// welcome arrives, at which point the User attaches the service via
     /// [`Group::attach_mls`].
     group: Group<M>,
     state_machine: GroupStateMachine,
-    /// Per-group peer-score tracker. Lives next to `state_machine` as
+    /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
     /// `RwLock`, no separate `Mutex` needed.
-    scoring: PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>,
+    scoring: Sc,
     /// Per-group rolling history of committed batches, most recent last.
     /// Bounded at [`MAX_EPOCH_HISTORY`]. Populated by
     /// [`GroupEntry::archive_committed_batch`] from the snapshot
@@ -67,14 +67,10 @@ pub(crate) struct GroupEntry<M: MlsService> {
     epoch_history: VecDeque<HashMap<ProposalId, GroupUpdateRequest>>,
 }
 
-impl<M: MlsService> GroupEntry<M> {
+impl<M: MlsService, Sc: PeerScoringPlugin> GroupEntry<M, Sc> {
     /// Build a fresh entry. Internal-only auxiliary state (epoch
     /// history, future per-entry caches) starts empty.
-    pub(crate) fn new(
-        group: Group<M>,
-        state_machine: GroupStateMachine,
-        scoring: PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>,
-    ) -> Self {
+    pub(crate) fn new(group: Group<M>, state_machine: GroupStateMachine, scoring: Sc) -> Self {
         Self {
             group,
             state_machine,
@@ -117,7 +113,7 @@ type AutoVoteTimers = Arc<Mutex<HashMap<Arc<str>, HashMap<u32, JoinHandle<()>>>>
 /// Per-user registry of group entries, with one outer lock for map CRUD
 /// and one inner lock per entry so writes on one group don't block reads
 /// on another.
-type GroupRegistry<M> = Arc<RwLock<HashMap<String, Arc<RwLock<GroupEntry<M>>>>>>;
+type GroupRegistry<M, Sc> = Arc<RwLock<HashMap<String, Arc<RwLock<GroupEntry<M, Sc>>>>>>;
 
 /// Factory closure that builds an [`MlsService`] for a fresh group.
 pub type MlsCreatorFactory<M> = Arc<dyn Fn(String) -> Result<M, MlsError> + Send + Sync + 'static>;
@@ -130,9 +126,17 @@ pub type MlsWelcomeFactory<M> =
 /// joiner can publish a key package before joining.
 pub type KeyPackageGenerator =
     Arc<dyn Fn() -> Result<KeyPackageBytes, MlsError> + Send + Sync + 'static>;
+/// Factory closure that builds a [`PeerScoringPlugin`] instance for a
+/// fresh group, using the user's default scoring config.
+pub type ScoringFactory<Sc> = Arc<dyn Fn(&ScoringConfig) -> Sc + Send + Sync + 'static>;
 
-pub struct User<P: DeMlsProvider, M: MlsService, H: GroupEventHandler, SCH: StateChangeHandler>
-where
+pub struct User<
+    P: DeMlsProvider,
+    M: MlsService,
+    Sc: PeerScoringPlugin,
+    H: GroupEventHandler,
+    SCH: StateChangeHandler,
+> where
     M::Identity: Clone,
 {
     /// Local identity, shared with every per-group MLS service this user
@@ -145,12 +149,14 @@ where
     mls_welcome_factory: MlsWelcomeFactory<M>,
     /// Generate a single-use key package using the user's storage + identity.
     kp_generator: KeyPackageGenerator,
+    /// Build a fresh peer-scoring plug-in for a new group entry.
+    scoring_factory: ScoringFactory<Sc>,
     /// Outer lock: map CRUD (insert / remove / iterate names).
     /// Inner per-entry lock: per-group reads and mutations. A write on
     /// group A doesn't block reads on group B. Per-group peer scoring
     /// lives inside the entry, so scoring access is guarded by the same
     /// `RwLock` — no separate scoring lock.
-    groups: GroupRegistry<M>,
+    groups: GroupRegistry<M, Sc>,
     consensus_service: Arc<ProviderConsensus<P>>,
     eth_signer: PrivateKeySigner,
     handler: Arc<H>,
@@ -165,8 +171,13 @@ where
     auto_vote_timers: AutoVoteTimers,
 }
 
-impl<P: DeMlsProvider, M: MlsService, H: GroupEventHandler, SCH: StateChangeHandler> Clone
-    for User<P, M, H, SCH>
+impl<
+    P: DeMlsProvider,
+    M: MlsService,
+    Sc: PeerScoringPlugin,
+    H: GroupEventHandler,
+    SCH: StateChangeHandler,
+> Clone for User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {
@@ -176,6 +187,7 @@ where
             mls_creator_factory: Arc::clone(&self.mls_creator_factory),
             mls_welcome_factory: Arc::clone(&self.mls_welcome_factory),
             kp_generator: Arc::clone(&self.kp_generator),
+            scoring_factory: Arc::clone(&self.scoring_factory),
             groups: Arc::clone(&self.groups),
             consensus_service: Arc::clone(&self.consensus_service),
             eth_signer: self.eth_signer.clone(),
@@ -191,9 +203,10 @@ where
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {
@@ -203,6 +216,7 @@ where
         mls_creator_factory: MlsCreatorFactory<M>,
         mls_welcome_factory: MlsWelcomeFactory<M>,
         kp_generator: KeyPackageGenerator,
+        scoring_factory: ScoringFactory<Sc>,
         consensus_service: Arc<ProviderConsensus<P>>,
         eth_signer: PrivateKeySigner,
         handler: Arc<H>,
@@ -214,6 +228,7 @@ where
             mls_creator_factory,
             mls_welcome_factory,
             kp_generator,
+            scoring_factory,
             groups: Arc::new(RwLock::new(HashMap::new())),
             consensus_service,
             eth_signer,
@@ -225,21 +240,15 @@ where
         }
     }
 
-    /// Build a fresh per-group [`PeerScoringService`] from the user's
-    /// default scoring config. Used by entry construction in lifecycle /
-    /// welcome paths.
-    pub(crate) fn make_scoring_service(
-        &self,
-    ) -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
+    /// Build a fresh per-group scoring plug-in from the user's default
+    /// scoring config. Used by entry construction in lifecycle / welcome
+    /// paths.
+    pub(crate) fn make_scoring_service(&self) -> Sc {
         let scoring_config = ScoringConfig {
             default_score: self.default_group_config.default_peer_score,
             threshold: self.default_group_config.threshold_peer_score,
         };
-        PeerScoringService::new(
-            InMemoryPeerScoreStorage::new(),
-            FixedScoringProvider::with_default_deltas(),
-            scoring_config,
-        )
+        (self.scoring_factory)(&scoring_config)
     }
 
     /// Look up a group entry. Returns `None` when the entry isn't present.
@@ -248,7 +257,7 @@ where
     pub(crate) async fn lookup_entry(
         &self,
         group_name: &str,
-    ) -> Option<Arc<RwLock<GroupEntry<M>>>> {
+    ) -> Option<Arc<RwLock<GroupEntry<M, Sc>>>> {
         self.groups.read().await.get(group_name).cloned()
     }
 
@@ -257,7 +266,7 @@ where
     pub(crate) async fn with_entry<R>(
         &self,
         group_name: &str,
-        f: impl FnOnce(&GroupEntry<M>) -> R,
+        f: impl FnOnce(&GroupEntry<M, Sc>) -> R,
     ) -> Option<R> {
         let entry_arc = self.lookup_entry(group_name).await?;
         let entry = entry_arc.read().await;
@@ -302,8 +311,13 @@ where
 /// `Arc<I>: IdentityProvider` blanket impls make this work).
 pub type DefaultMlsService = OpenMlsService<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>;
 
+/// Peer-scoring plug-in type for the default-config `User`: the
+/// reference [`PeerScoringService`] over in-memory storage and a
+/// fixed-table provider.
+pub type DefaultPeerScoring = PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>;
+
 impl<H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
-    User<DefaultProvider, DefaultMlsService, H, SCH>
+    User<DefaultProvider, DefaultMlsService, DefaultPeerScoring, H, SCH>
 {
     /// Construct a `User` on [`DefaultProvider`] with the default config.
     pub fn with_private_key(
@@ -362,12 +376,21 @@ impl<H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
                 )
             })
         };
+        let scoring_factory: ScoringFactory<DefaultPeerScoring> =
+            Arc::new(|cfg: &ScoringConfig| {
+                PeerScoringService::new(
+                    InMemoryPeerScoreStorage::new(),
+                    FixedScoringProvider::with_default_deltas(),
+                    cfg.clone(),
+                )
+            });
 
         Ok(Self::new_with_config(
             identity,
             mls_creator_factory,
             mls_welcome_factory,
             kp_generator,
+            scoring_factory,
             consensus_service,
             signer,
             handler,

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -1,10 +1,11 @@
 //! [`User`] — multi-group facade over core. One node owns one `User`, which
-//! holds the MLS service, consensus service, event handler, peer-scoring
-//! service, and per-group state map. Methods split across the submodules:
-//! `lifecycle` (create/leave), `query` (read-only getters), `messaging`
-//! (send/ban), `consensus` (voting), `consensus_events` (outcome dispatch),
-//! `inbound` (packet dispatch), `freeze` (timers), `steward` (steward-side
-//! housekeeping).
+//! holds the consensus service, event handler, and per-group state map.
+//! Each group's MLS service and peer-scoring service live on the
+//! [`GroupEntry`] (one instance per group). Methods split across the
+//! submodules: `lifecycle` (create/leave), `query` (read-only getters),
+//! `messaging` (send/ban), `consensus` (voting), `consensus_events`
+//! (outcome dispatch), `inbound` (packet dispatch), `freeze` (timers),
+//! `steward` (steward-side housekeeping).
 //!
 //! `User` is `Clone` — all fields are `Arc` or cheap `Clone` — so background
 //! tasks just take their own handle via `self.clone()`.
@@ -55,6 +56,10 @@ pub(crate) struct GroupEntry<M: MlsService> {
     /// [`Group::attach_mls`].
     group: Group<M>,
     state_machine: GroupStateMachine,
+    /// Per-group peer-score tracker. Lives next to `state_machine` as
+    /// app-layer wiring; protocol decisions read it via the entry's
+    /// `RwLock`, no separate `Mutex` needed.
+    scoring: PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>,
     /// Per-group rolling history of committed batches, most recent last.
     /// Bounded at [`MAX_EPOCH_HISTORY`]. Populated by
     /// [`GroupEntry::archive_committed_batch`] from the snapshot
@@ -65,10 +70,15 @@ pub(crate) struct GroupEntry<M: MlsService> {
 impl<M: MlsService> GroupEntry<M> {
     /// Build a fresh entry. Internal-only auxiliary state (epoch
     /// history, future per-entry caches) starts empty.
-    pub(crate) fn new(group: Group<M>, state_machine: GroupStateMachine) -> Self {
+    pub(crate) fn new(
+        group: Group<M>,
+        state_machine: GroupStateMachine,
+        scoring: PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>,
+    ) -> Self {
         Self {
             group,
             state_machine,
+            scoring,
             epoch_history: VecDeque::new(),
         }
     }
@@ -124,12 +134,9 @@ where
     kp_generator: KeyPackageGenerator,
     /// Outer lock: map CRUD (insert / remove / iterate names).
     /// Inner per-entry lock: per-group reads and mutations. A write on
-    /// group A doesn't block reads on group B.
-    ///
-    /// Lock-order convention with [`Self::scoring_service`]: never hold
-    /// the scoring `Mutex` guard across `lookup_entry` or any acquisition
-    /// of the inner entry `RwLock`. Acquire `scoring()` in a single
-    /// statement and let the guard drop at the semicolon.
+    /// group A doesn't block reads on group B. Per-group peer scoring
+    /// lives inside the entry, so scoring access is guarded by the same
+    /// `RwLock` — no separate scoring lock.
     groups: GroupRegistry<M>,
     consensus_service: Arc<ProviderConsensus<P>>,
     eth_signer: PrivateKeySigner,
@@ -139,7 +146,6 @@ where
     /// Per-instance UUID embedded in every outbound packet. Inbound packets
     /// carrying our `app_id` are self-echoes and silently dropped.
     app_id: Vec<u8>,
-    scoring_service: Arc<Mutex<PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>>>,
     /// Per-proposal auto-vote timers. Spawned when a proposal first becomes
     /// visible locally (own submit or peer inbound); cancelled on manual
     /// vote, consensus resolution, or group leave.
@@ -164,7 +170,6 @@ where
             state_handler: Arc::clone(&self.state_handler),
             default_group_config: self.default_group_config.clone(),
             app_id: self.app_id.clone(),
-            scoring_service: Arc::clone(&self.scoring_service),
             auto_vote_timers: Arc::clone(&self.auto_vote_timers),
         }
     }
@@ -191,9 +196,6 @@ where
         state_handler: Arc<SCH>,
         default_group_config: GroupConfig,
     ) -> Self {
-        let scoring_config = ScoringConfig {
-            default_score: default_group_config.default_peer_score,
-        };
         Self {
             identity,
             mls_creator_factory,
@@ -205,24 +207,26 @@ where
             handler,
             state_handler,
             default_group_config,
-            scoring_service: Arc::new(Mutex::new(PeerScoringService::new(
-                InMemoryPeerScoreStorage::new(),
-                FixedScoringProvider::with_default_deltas(),
-                scoring_config,
-            ))),
             app_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
             auto_vote_timers: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Lock the scoring service, recovering from a poisoned mutex.
-    fn scoring(
+    /// Build a fresh per-group [`PeerScoringService`] from the user's
+    /// default scoring config. Used by entry construction in lifecycle /
+    /// welcome paths.
+    pub(crate) fn make_scoring_service(
         &self,
-    ) -> std::sync::MutexGuard<'_, PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>>
-    {
-        self.scoring_service
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+    ) -> PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider> {
+        let scoring_config = ScoringConfig {
+            default_score: self.default_group_config.default_peer_score,
+            threshold: self.default_group_config.threshold_peer_score,
+        };
+        PeerScoringService::new(
+            InMemoryPeerScoreStorage::new(),
+            FixedScoringProvider::with_default_deltas(),
+            scoring_config,
+        )
     }
 
     /// Look up a group entry. Returns `None` when the entry isn't present.

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     app::{GroupState, MemberRole, StateChangeHandler, User, UserError},
-    core::{DeMlsProvider, GroupEventHandler, group_members},
+    core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, group_members},
     mls_crypto::{MlsService, format_wallet_address},
     protos::de_mls::messages::v1::GroupUpdateRequest,
 };

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -10,9 +10,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -87,12 +87,17 @@ where
             .collect())
     }
 
-    pub fn get_member_scores(&self, group_name: &str) -> Vec<(Vec<u8>, i64)> {
-        self.scoring().all_members_with_scores(group_name)
+    pub async fn get_member_scores(&self, group_name: &str) -> Vec<(Vec<u8>, i64)> {
+        match self.lookup_entry(group_name).await {
+            Some(entry_arc) => entry_arc.read().await.scoring.all_members_with_scores(),
+            None => Vec::new(),
+        }
     }
 
-    pub fn get_member_score(&self, group_name: &str, member_id: &[u8]) -> Option<i64> {
-        self.scoring().score_for(group_name, member_id)
+    pub async fn get_member_score(&self, group_name: &str, member_id: &[u8]) -> Option<i64> {
+        let entry_arc = self.lookup_entry(group_name).await?;
+        let entry = entry_arc.read().await;
+        entry.scoring.score_for(member_id)
     }
 
     /// Identities that have an in-flight self-leave request. Used by the UI

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -441,43 +441,38 @@ where
             .await
             .ok_or(UserError::GroupNotFound)?;
         let self_id = self.identity().identity_bytes();
-        let (is_steward, epoch, targets): (bool, u64, Vec<(Vec<u8>, i64)>) = {
-            let entry = entry_arc.read().await;
+
+        // Reactive entry: callers chain into this after a scoring apply
+        // emitted a downward cross, so we expect at least one tracked
+        // member to be at-or-below threshold. The scan is the source of
+        // truth — events just trigger the look.
+        let (is_steward, epoch, to_remove): (bool, u64, Vec<(Vec<u8>, i64)>) = {
+            let mut entry = entry_arc.write().await;
             let mls = entry.group.expect_mls()?;
             let is_steward = entry.group.is_steward();
             let epoch = mls.current_epoch()?;
-            let targets = if is_steward {
-                entry
-                    .scoring
-                    .members_below_threshold()
-                    .into_iter()
-                    .filter(|id| *id != self_id)
-                    .map(|id| {
-                        let score = entry.scoring.score_for(&id).unwrap_or(0);
-                        (id, score)
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            (is_steward, epoch, targets)
+            if !is_steward {
+                return Ok(());
+            }
+            let to_remove = entry
+                .scoring
+                .members_below_threshold()
+                .into_iter()
+                .filter(|id| *id != self_id)
+                .filter(|id| !entry.group.has_pending_removal(id))
+                .filter_map(|id| {
+                    let score = entry.scoring.score_for(&id)?;
+                    Some((id, score))
+                })
+                .collect::<Vec<_>>();
+            for (id, _) in &to_remove {
+                entry.group.observe_pending_removal(id.clone());
+            }
+            (is_steward, epoch, to_remove)
         };
 
         if !is_steward {
             return Ok(());
-        }
-
-        // Mark all targets pending under a single write-lock, then submit
-        // proposals outside the lock to avoid holding it across `.await`.
-        let mut to_remove = Vec::new();
-        if let Some(entry_arc) = self.lookup_entry(group_name).await {
-            let mut entry = entry_arc.write().await;
-            for (target_id, current_score) in targets {
-                if !entry.group.has_pending_removal(&target_id) {
-                    entry.group.observe_pending_removal(target_id.clone());
-                    to_remove.push((target_id, current_score));
-                }
-            }
         }
 
         // Submit proposals without holding the lock.

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -43,7 +43,11 @@ where
             .collect();
         let diff = scoring_member_diff(&scored, mls_members);
         for member_id in &diff.to_add {
-            entry.scoring.add_member(member_id);
+            // Under the standard config (`default > threshold`) this
+            // returns no events; an exotic config could surface a fresh
+            // member as below-threshold, but the score-removal chain
+            // doesn't fire on membership-sync ticks today.
+            let _events = entry.scoring.add_member(member_id);
         }
         for member_id in &diff.to_remove {
             entry.scoring.remove_member(member_id);
@@ -368,9 +372,15 @@ where
             .ok_or(UserError::GroupNotFound)?;
         let packet = {
             let entry = entry_arc.read().await;
+            // Sparse snapshot — only members whose score has diverged
+            // from `default_score`. Joiners init every member at default
+            // via membership sync before applying the snapshot, so
+            // missing entries imply default. Saves wire size at scale
+            // (Waku message budget concern past ~1k members).
             let scores: Vec<PeerScore> = entry
                 .scoring
-                .all_members_with_scores()
+                .snapshot()
+                .diverged
                 .into_iter()
                 .map(|(id, score)| PeerScore {
                     member_id: id,

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -465,12 +465,24 @@ where
             if !is_steward {
                 return Ok(());
             }
+            // Two dedup gates:
+            //   - `has_pending_removal` — there's an in-flight ECP for
+            //     this target (live consensus session).
+            //   - `is_pending_removal` — `RemoveMember(target)` is
+            //     already queued in `approved_proposals` waiting for
+            //     the next commit. Without this gate, a just-resolved
+            //     SCORE_BELOW_THRESHOLD ECP (which clears
+            //     `pending_removal_targets` on resolve, but leaves the
+            //     target in `approved_proposals` with their score still
+            //     ≤ threshold) would re-fire a duplicate ECP for the
+            //     same target before the RemoveMember commits.
             let to_remove = entry
                 .scoring
                 .members_below_threshold()
                 .into_iter()
                 .filter(|id| *id != self_id)
                 .filter(|id| !entry.group.has_pending_removal(id))
+                .filter(|id| !entry.group.is_pending_removal(id))
                 .filter_map(|id| {
                     let score = entry.scoring.score_for(&id)?;
                     Some((id, score))

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -27,23 +27,25 @@ where
     M::Identity: Clone,
 {
     /// Add any MLS members not yet tracked in scoring, and drop scored
-    /// entries for identities no longer in MLS. Takes `mls_members`
-    /// pre-fetched so the caller can release any group-entry guard
-    /// before the scoring mutex is acquired. Diffing is delegated to
+    /// entries for identities no longer in MLS. Diffing is delegated to
     /// [`scoring_member_diff`]; this method only applies the diff.
-    pub fn sync_scoring_members(&self, group_name: &str, mls_members: &[Vec<u8>]) {
-        let mut scoring = self.scoring();
-        let scored: Vec<Vec<u8>> = scoring
-            .all_members_with_scores(group_name)
+    pub async fn sync_scoring_members(&self, group_name: &str, mls_members: &[Vec<u8>]) {
+        let Some(entry_arc) = self.lookup_entry(group_name).await else {
+            return;
+        };
+        let mut entry = entry_arc.write().await;
+        let scored: Vec<Vec<u8>> = entry
+            .scoring
+            .all_members_with_scores()
             .into_iter()
             .map(|(id, _)| id)
             .collect();
         let diff = scoring_member_diff(&scored, mls_members);
         for member_id in &diff.to_add {
-            scoring.add_member(group_name, member_id);
+            entry.scoring.add_member(member_id);
         }
         for member_id in &diff.to_remove {
-            scoring.remove_member(group_name, member_id);
+            entry.scoring.remove_member(member_id);
         }
     }
 
@@ -359,25 +361,21 @@ where
     /// commit so new joiners can fully participate. Idempotent for members
     /// who already have a steward list.
     pub async fn send_group_sync(&self, group_name: &str) -> Result<(), UserError> {
-        // Read scores under the sync Mutex first — no `.await` held across it.
-        let scores: Vec<PeerScore> = {
-            let scoring = self.scoring();
-            scoring
-                .all_members_with_scores(group_name)
-                .into_iter()
-                .map(|(id, score)| PeerScore {
-                    member_id: id,
-                    score,
-                })
-                .collect()
-        };
-
         let entry_arc = self
             .lookup_entry(group_name)
             .await
             .ok_or(UserError::GroupNotFound)?;
         let packet = {
             let entry = entry_arc.read().await;
+            let scores: Vec<PeerScore> = entry
+                .scoring
+                .all_members_with_scores()
+                .into_iter()
+                .map(|(id, score)| PeerScore {
+                    member_id: id,
+                    score,
+                })
+                .collect();
 
             let list = match entry.group.steward_list() {
                 Some(l) => l,
@@ -418,7 +416,7 @@ where
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.group.max_reelection_attempts(),
                 liveness_criteria_yes: entry.group.liveness_criteria_yes(),
-                threshold_peer_score: entry.group.threshold_peer_score(),
+                threshold_peer_score: entry.scoring.config().threshold,
                 pending_update_max_epochs: entry.group.pending_update_max_epochs(),
             };
 
@@ -442,33 +440,32 @@ where
             .lookup_entry(group_name)
             .await
             .ok_or(UserError::GroupNotFound)?;
-        let (is_steward, threshold, epoch) = {
+        let self_id = self.identity().identity_bytes();
+        let (is_steward, epoch, targets): (bool, u64, Vec<(Vec<u8>, i64)>) = {
             let entry = entry_arc.read().await;
             let mls = entry.group.expect_mls()?;
-            (
-                entry.group.is_steward(),
-                entry.group.threshold_peer_score(),
-                mls.current_epoch()?,
-            )
+            let is_steward = entry.group.is_steward();
+            let epoch = mls.current_epoch()?;
+            let targets = if is_steward {
+                entry
+                    .scoring
+                    .members_below_threshold()
+                    .into_iter()
+                    .filter(|id| *id != self_id)
+                    .map(|id| {
+                        let score = entry.scoring.score_for(&id).unwrap_or(0);
+                        (id, score)
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            (is_steward, epoch, targets)
         };
-        let self_id = self.identity().identity_bytes();
 
         if !is_steward {
             return Ok(());
         }
-
-        let targets: Vec<(Vec<u8>, i64)> = {
-            let scoring = self.scoring();
-            scoring
-                .members_below_threshold(group_name, threshold)
-                .into_iter()
-                .filter(|id| *id != self_id) // self-removal handled separately
-                .map(|id| {
-                    let score = scoring.score_for(group_name, &id).unwrap_or(0);
-                    (id, score)
-                })
-                .collect()
-        };
 
         // Mark all targets pending under a single write-lock, then submit
         // proposals outside the lock to avoid holding it across `.await`.

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -20,9 +20,10 @@ use crate::{
 impl<
     P: DeMlsProvider,
     M: MlsService,
+    Sc: PeerScoringPlugin,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, H, SCH>
+> User<P, M, Sc, H, SCH>
 where
     M::Identity: Clone,
 {
@@ -416,7 +417,7 @@ where
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.group.max_reelection_attempts(),
                 liveness_criteria_yes: entry.group.liveness_criteria_yes(),
-                threshold_peer_score: entry.scoring.config().threshold,
+                threshold_peer_score: entry.scoring.threshold(),
                 pending_update_max_epochs: entry.group.pending_update_max_epochs(),
             };
 

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use crate::{
     app::{StateChangeHandler, User, UserError},
     core::{
-        DeMlsProvider, ElectionDecision, GroupEventHandler, StewardList,
+        DeMlsProvider, ElectionDecision, GroupEventHandler, PeerScoringPlugin, StewardList,
         evaluate_election_initiation, group_members, is_deadlock_ecp_proposer, member_set,
         scoring_member_diff, target_identity_of,
     },

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -156,9 +156,6 @@ pub struct Group<M: MlsService> {
     /// While `true`, `create_commit_candidate` bypasses the `is_steward()`
     /// gate so any member can produce the recovery commit.
     recovery_mode: bool,
-    /// At or below this score, a member is eligible for
-    /// `SCORE_BELOW_THRESHOLD` ECP removal (RFC §Peer Scoring).
-    threshold_peer_score: i64,
     /// Auto-vote default and consensus tie-break rule (RFC §Creating
     /// Voting Proposal).
     liveness_criteria_yes: bool,
@@ -171,8 +168,6 @@ pub struct Group<M: MlsService> {
 /// responsible proposer a second shot with a different list composition;
 /// beyond that human/policy intervention is expected.
 pub const DEFAULT_MAX_REELECTION_ATTEMPTS: u32 = 1;
-
-pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
 pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
 
@@ -204,7 +199,6 @@ impl<M: MlsService> Group<M> {
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
             recovery_mode: false,
-            threshold_peer_score: DEFAULT_THRESHOLD_PEER_SCORE,
             liveness_criteria_yes: DEFAULT_LIVENESS_CRITERIA_YES,
             pending_update_max_epochs: DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
         }
@@ -831,14 +825,6 @@ impl<M: MlsService> Group<M> {
 
     pub fn set_max_reelection_attempts(&mut self, max: u32) {
         self.max_reelection_attempts = max;
-    }
-
-    pub fn threshold_peer_score(&self) -> i64 {
-        self.threshold_peer_score
-    }
-
-    pub fn set_threshold_peer_score(&mut self, threshold: i64) {
-        self.threshold_peer_score = threshold;
     }
 
     pub fn liveness_criteria_yes(&self) -> bool {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,8 +34,8 @@ pub use api::{
 // ── Consensus result application (pure, synchronous) ──
 pub use consensus::{ConsensusApplyResult, apply_consensus_result};
 pub use peer_scoring::{
-    DEFAULT_THRESHOLD_PEER_SCORE, PeerScoreStorage, ScoreEvent, ScoreOp, ScoringConfig,
-    ScoringMemberDiff, ScoringProvider, emergency_score_ops, scoring_member_diff,
+    DEFAULT_THRESHOLD_PEER_SCORE, PeerScoreStorage, PeerScoringService, ScoreEvent, ScoreOp,
+    ScoringConfig, ScoringMemberDiff, ScoringProvider, emergency_score_ops, scoring_member_diff,
 };
 
 // ── Error type ──

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,8 +34,9 @@ pub use api::{
 // ── Consensus result application (pure, synchronous) ──
 pub use consensus::{ConsensusApplyResult, apply_consensus_result};
 pub use peer_scoring::{
-    DEFAULT_THRESHOLD_PEER_SCORE, PeerScoreStorage, PeerScoringService, ScoreEvent, ScoreOp,
-    ScoringConfig, ScoringMemberDiff, ScoringProvider, emergency_score_ops, scoring_member_diff,
+    DEFAULT_THRESHOLD_PEER_SCORE, PeerScoreStorage, PeerScoringEvent, PeerScoringPlugin,
+    PeerScoringService, ScoreEvent, ScoreOp, ScoreSnapshot, ScoringConfig, ScoringMemberDiff,
+    ScoringProvider, emergency_score_ops, scoring_member_diff,
 };
 
 // ── Error type ──

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,8 +34,8 @@ pub use api::{
 // ── Consensus result application (pure, synchronous) ──
 pub use consensus::{ConsensusApplyResult, apply_consensus_result};
 pub use peer_scoring::{
-    PeerScoreStorage, ScoreEvent, ScoreOp, ScoringConfig, ScoringMemberDiff, ScoringProvider,
-    emergency_score_ops, scoring_member_diff,
+    DEFAULT_THRESHOLD_PEER_SCORE, PeerScoreStorage, ScoreEvent, ScoreOp, ScoringConfig,
+    ScoringMemberDiff, ScoringProvider, emergency_score_ops, scoring_member_diff,
 };
 
 // ── Error type ──
@@ -48,8 +48,8 @@ pub use events::{CallbackError, GroupEventHandler};
 pub(crate) use group::member_set;
 pub use group::{
     DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_MAX_REELECTION_ATTEMPTS,
-    DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_THRESHOLD_PEER_SCORE, Group, PendingUpdate,
-    ProposalId, auto_approved_leave_proposal_id, target_identity_of,
+    DEFAULT_PENDING_UPDATE_MAX_EPOCHS, Group, PendingUpdate, ProposalId,
+    auto_approved_leave_proposal_id, target_identity_of,
 };
 
 // ── Proposal classification ──

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -192,7 +192,7 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
 /// at safe points and turns threshold crossings into protocol actions.
 /// The plug-in itself owns no I/O — storage backends and event
 /// publishing are caller concerns.
-pub trait PeerScoringPlugin {
+pub trait PeerScoringPlugin: Send + Sync + 'static {
     fn add_member(&mut self, member_id: &[u8]);
     fn remove_member(&mut self, member_id: &[u8]);
 
@@ -218,6 +218,9 @@ pub trait PeerScoringPlugin {
     fn members_below_threshold(&self) -> Vec<Vec<u8>>;
     fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)>;
 
+    /// Current removal threshold. Coordinator reads this when building
+    /// `GroupSync` so joiners adopt the same value.
+    fn threshold(&self) -> i64;
     fn set_threshold(&mut self, threshold: i64);
 }
 
@@ -256,7 +259,9 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
     }
 }
 
-impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringPlugin for PeerScoringService<S, P> {
+impl<S: PeerScoreStorage + Send + Sync + 'static, P: ScoringProvider + Send + Sync + 'static>
+    PeerScoringPlugin for PeerScoringService<S, P>
+{
     fn add_member(&mut self, member_id: &[u8]) {
         self.storage.set(member_id, self.config.default_score);
     }
@@ -341,6 +346,10 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringPlugin for PeerScoringS
 
     fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
         self.storage.all_scores()
+    }
+
+    fn threshold(&self) -> i64 {
+        self.config.threshold
     }
 
     fn set_threshold(&mut self, threshold: i64) {

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -5,6 +5,7 @@
 //! (e.g. [`crate::app::FixedScoringProvider`]) live in the app layer.
 
 use prost::Message;
+use std::collections::HashSet;
 
 use crate::protos::de_mls::messages::v1::{
     GroupUpdateRequest, ViolationEvidence, group_update_request::Payload,
@@ -124,8 +125,8 @@ pub struct ScoringMemberDiff {
 /// Pure diff between a scoring table snapshot and an MLS member roster.
 /// Caller applies the diff to its own [`PeerScoringService`].
 pub fn scoring_member_diff(scored: &[Vec<u8>], mls_members: &[Vec<u8>]) -> ScoringMemberDiff {
-    let scored_set: std::collections::HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();
-    let mls_set: std::collections::HashSet<&[u8]> = mls_members.iter().map(Vec::as_slice).collect();
+    let scored_set: HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();
+    let mls_set: HashSet<&[u8]> = mls_members.iter().map(Vec::as_slice).collect();
 
     let to_add = mls_members
         .iter()

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -1,7 +1,8 @@
-//! Types and traits core uses to describe scoring-relevant events plus
-//! pure score-derivation helpers. The scoring service itself lives in
-//! `crate::app::peer_scoring` and consumes the `Vec<ScoreOp>` that the
-//! helpers here return.
+//! Peer-scoring vocabulary, traits, reference [`PeerScoringService`],
+//! and pure score-derivation helpers. The service is storage- and
+//! policy-agnostic; concrete backends (e.g.
+//! [`crate::app::InMemoryPeerScoreStorage`]) and delta-table providers
+//! (e.g. [`crate::app::FixedScoringProvider`]) live in the app layer.
 
 use prost::Message;
 
@@ -92,8 +93,7 @@ pub struct ScoringMemberDiff {
 }
 
 /// Pure diff between a scoring table snapshot and an MLS member roster.
-/// Caller applies the diff to its own
-/// [`PeerScoringService`](crate::app::PeerScoringService).
+/// Caller applies the diff to its own [`PeerScoringService`].
 pub fn scoring_member_diff(scored: &[Vec<u8>], mls_members: &[Vec<u8>]) -> ScoringMemberDiff {
     let scored_set: std::collections::HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();
     let mls_set: std::collections::HashSet<&[u8]> = mls_members.iter().map(Vec::as_slice).collect();
@@ -155,10 +155,285 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
     }
 }
 
+// ── Reference scoring service ───────────────────────────────────────
+
+/// Per-group, per-member score tracker. One instance per group;
+/// threshold travels with [`ScoringConfig`]. Storage is abstracted via
+/// [`PeerScoreStorage`] so app-layer backends (in-memory, on-disk, …)
+/// plug in without touching this protocol logic.
+pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
+    storage: S,
+    provider: P,
+    config: ScoringConfig,
+}
+
+impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
+    pub fn new(storage: S, provider: P, config: ScoringConfig) -> Self {
+        Self {
+            storage,
+            provider,
+            config,
+        }
+    }
+
+    /// Start tracking a member with the default score.
+    pub fn add_member(&mut self, member_id: &[u8]) {
+        self.storage.set(member_id, self.config.default_score);
+    }
+
+    pub fn remove_member(&mut self, member_id: &[u8]) {
+        self.storage.remove(member_id);
+    }
+
+    /// Apply a single [`ScoreOp`] and return the target's new score, or
+    /// `None` if the target isn't tracked.
+    pub fn apply_op(&mut self, op: &ScoreOp) -> Option<i64> {
+        let current = self.storage.get(&op.member_id)?;
+        let delta = self.provider.score_delta(op.event);
+        let new_score = current.saturating_add(delta);
+        self.storage.set(&op.member_id, new_score);
+        Some(new_score)
+    }
+
+    /// Apply a batch of [`ScoreOp`]s. Untracked targets are skipped
+    /// silently (same semantics as [`Self::apply_op`]).
+    pub fn apply_ops(&mut self, ops: &[ScoreOp]) {
+        for op in ops {
+            self.apply_op(op);
+        }
+    }
+
+    pub fn score_for(&self, member_id: &[u8]) -> Option<i64> {
+        self.storage.get(member_id)
+    }
+
+    /// Force-set a score; used when applying a `GroupSync` from the steward.
+    pub fn set_score(&mut self, member_id: &[u8], score: i64) {
+        self.storage.set(member_id, score);
+    }
+
+    pub fn members_below_threshold(&self) -> Vec<Vec<u8>> {
+        let threshold = self.config.threshold;
+        self.storage
+            .all_scores()
+            .into_iter()
+            .filter(|(_, score)| *score <= threshold)
+            .map(|(id, _)| id)
+            .collect()
+    }
+
+    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
+        self.storage
+            .get(member_id)
+            .is_some_and(|s| s <= self.config.threshold)
+    }
+
+    pub fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
+        self.storage.all_scores()
+    }
+
+    pub fn config(&self) -> &ScoringConfig {
+        &self.config
+    }
+
+    pub fn set_threshold(&mut self, threshold: i64) {
+        self.config.threshold = threshold;
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::protos::de_mls::messages::v1::{EmergencyCriteriaProposal, ViolationType};
+
+    // ── Test scaffolding ────────────────────────────────────────────
+
+    /// Minimal in-memory storage for service tests. Production storage
+    /// lives in [`crate::app::InMemoryPeerScoreStorage`].
+    #[derive(Default)]
+    struct TestStorage(HashMap<Vec<u8>, i64>);
+
+    impl PeerScoreStorage for TestStorage {
+        fn get(&self, member_id: &[u8]) -> Option<i64> {
+            self.0.get(member_id).copied()
+        }
+        fn set(&mut self, member_id: &[u8], score: i64) {
+            self.0.insert(member_id.to_vec(), score);
+        }
+        fn remove(&mut self, member_id: &[u8]) {
+            self.0.remove(member_id);
+        }
+        fn all_scores(&self) -> Vec<(Vec<u8>, i64)> {
+            self.0.iter().map(|(k, v)| (k.clone(), *v)).collect()
+        }
+    }
+
+    /// HashMap-backed [`ScoringProvider`] with caller-supplied deltas.
+    /// Production deltas live in [`crate::app::FixedScoringProvider`].
+    struct TestProvider(HashMap<ScoreEvent, i64>);
+
+    impl ScoringProvider for TestProvider {
+        fn score_delta(&self, event: ScoreEvent) -> i64 {
+            self.0.get(&event).copied().unwrap_or(0)
+        }
+    }
+
+    fn make_service() -> PeerScoringService<TestStorage, TestProvider> {
+        let deltas = HashMap::from([
+            (ScoreEvent::EmergencyNoCreator, -50),
+            (ScoreEvent::EmergencyYesCreator, 20),
+            (ScoreEvent::BrokenCommit, -50),
+            (ScoreEvent::SuccessfulCommit, 10),
+            (ScoreEvent::MisbehavingCommit, -30),
+        ]);
+        PeerScoringService::new(
+            TestStorage::default(),
+            TestProvider(deltas),
+            ScoringConfig {
+                default_score: 100,
+                threshold: 0,
+            },
+        )
+    }
+
+    // ── Service tests ────────────────────────────────────────────────
+
+    #[test]
+    fn add_member_gets_default_score() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        assert_eq!(svc.score_for(b"alice"), Some(100));
+    }
+
+    #[test]
+    fn unknown_member_returns_none() {
+        let svc = make_service();
+        assert_eq!(svc.score_for(b"unknown"), None);
+    }
+
+    #[test]
+    fn remove_member_clears_score() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.remove_member(b"alice");
+        assert_eq!(svc.score_for(b"alice"), None);
+    }
+
+    #[test]
+    fn apply_event_decreases_score() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
+        assert_eq!(new_score, Some(50));
+        assert_eq!(svc.score_for(b"alice"), Some(50));
+    }
+
+    #[test]
+    fn apply_event_unknown_member_returns_none() {
+        let mut svc = make_service();
+        let result = svc.apply_op(&ScoreOp {
+            member_id: b"unknown".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn multiple_events_accumulate() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        for event in [
+            ScoreEvent::EmergencyNoCreator,
+            ScoreEvent::MisbehavingCommit,
+            ScoreEvent::SuccessfulCommit,
+        ] {
+            svc.apply_op(&ScoreOp {
+                member_id: b"alice".to_vec(),
+                event,
+            });
+        }
+        assert_eq!(svc.score_for(b"alice"), Some(30));
+    }
+
+    #[test]
+    fn members_below_threshold_filters_correctly() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.add_member(b"bob");
+        svc.add_member(b"charlie");
+        for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
+            svc.apply_op(&ScoreOp {
+                member_id: b"alice".to_vec(),
+                event,
+            });
+        }
+        for _ in 0..2 {
+            svc.apply_op(&ScoreOp {
+                member_id: b"charlie".to_vec(),
+                event: ScoreEvent::EmergencyNoCreator,
+            });
+        }
+        let below = svc.members_below_threshold();
+        assert!(below.contains(&b"alice".to_vec()));
+        assert!(below.contains(&b"charlie".to_vec()));
+        assert!(!below.contains(&b"bob".to_vec()));
+    }
+
+    #[test]
+    fn set_threshold_changes_below_threshold_set() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.set_score(b"alice", -10);
+
+        svc.set_threshold(-50);
+        assert!(!svc.members_below_threshold().contains(&b"alice".to_vec()));
+
+        svc.set_threshold(-5);
+        assert!(svc.members_below_threshold().contains(&b"alice".to_vec()));
+    }
+
+    #[test]
+    fn score_saturates_no_overflow() {
+        let mut svc = PeerScoringService::new(
+            TestStorage::default(),
+            TestProvider(HashMap::from([(ScoreEvent::SuccessfulCommit, i64::MAX)])),
+            ScoringConfig {
+                default_score: i64::MAX,
+                threshold: 0,
+            },
+        );
+        svc.add_member(b"alice");
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
+        assert_eq!(new_score, Some(i64::MAX));
+    }
+
+    #[test]
+    fn unknown_event_yields_zero_delta() {
+        let mut svc = PeerScoringService::new(
+            TestStorage::default(),
+            TestProvider(HashMap::from([(ScoreEvent::EmergencyNoCreator, -50)])),
+            ScoringConfig {
+                default_score: 100,
+                threshold: 0,
+            },
+        );
+        svc.add_member(b"alice");
+        let new_score = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
+        assert_eq!(new_score, Some(100));
+    }
+
+    // ── ECP score derivation tests ──────────────────────────────────
 
     fn ecp_payload(violation_type: i32, target: Vec<u8>, creator: Vec<u8>) -> Vec<u8> {
         let evidence = ViolationEvidence {

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -199,19 +199,29 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
 /// The plug-in itself owns no I/O — storage backends and event
 /// publishing are caller concerns.
 pub trait PeerScoringPlugin: Send + Sync + 'static {
-    /// Start tracking a member at the plug-in's default score. If the
-    /// default lands at-or-below threshold (unusual config), emits
-    /// [`PeerScoringEvent::ThresholdCrossedDown`]; otherwise no event.
+    /// Start tracking a member at the plug-in's default score.
+    ///
+    /// MUST be called at most once per member: a duplicate call resets
+    /// the score to default and discards any accumulated state. Callers
+    /// guard with [`Self::score_for`] or a roster diff (see
+    /// [`scoring_member_diff`]).
+    ///
+    /// Emits [`PeerScoringEvent::ThresholdCrossedDown`] iff the default
+    /// score lands at-or-below threshold (unusual config); otherwise no
+    /// event.
     #[must_use]
     fn add_member(&mut self, member_id: &[u8]) -> Vec<PeerScoringEvent>;
 
     /// Stop tracking a member. Emits no events — removal is a membership
-    /// change, not a score event.
+    /// change, not a score event. Idempotent: a no-op on an untracked
+    /// member.
     fn remove_member(&mut self, member_id: &[u8]);
 
-    /// Apply a single [`ScoreOp`]. Returns events only when the op
-    /// causes a threshold cross — repeated ops on a member already
-    /// at-or-below threshold do not re-emit.
+    /// Apply a single [`ScoreOp`]. Untracked members are no-ops (no
+    /// event, no auto-tracking — coordinators must call [`Self::add_member`]
+    /// before applying ops). Returns events only when the op causes a
+    /// threshold cross; repeated ops on a member already at-or-below
+    /// threshold do not re-emit.
     #[must_use]
     fn apply_op(&mut self, op: &ScoreOp) -> Vec<PeerScoringEvent>;
 
@@ -221,10 +231,17 @@ pub trait PeerScoringPlugin: Send + Sync + 'static {
     #[must_use]
     fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent>;
 
-    /// Apply a [`ScoreSnapshot`] (GroupSync receive). Each entry is a
-    /// state replacement: events fire only when the entry's prior state
-    /// was on the opposite side of threshold from the new score.
-    /// Idempotent — re-applying the same snapshot emits no events.
+    /// Apply a [`ScoreSnapshot`] (GroupSync receive). Each entry is an
+    /// absolute-score replacement that auto-tracks members not already
+    /// known to the plug-in (treating "untracked → tracked" as crossing
+    /// from above for cross-detection — see [`PeerScoringEvent`]). This
+    /// is the one mutator that diverges from [`Self::apply_op`]'s
+    /// no-track-on-unknown behaviour: snapshots are bootstrap payloads
+    /// and arrive before membership sync in some edge cases.
+    ///
+    /// Events fire only when the entry's prior state was on the
+    /// opposite side of threshold from the new score; re-applying an
+    /// unchanged snapshot emits nothing.
     #[must_use]
     fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent>;
 
@@ -238,6 +255,14 @@ pub trait PeerScoringPlugin: Send + Sync + 'static {
     /// Current removal threshold. Coordinator reads this when building
     /// `GroupSync` so joiners adopt the same value.
     fn threshold(&self) -> i64;
+
+    /// Update the threshold in place. Emits NO events — even though a
+    /// tightened threshold can re-classify members from above to
+    /// at-or-below, the plug-in does not retroactively scan and emit.
+    /// Event-driven coordinators MUST re-scan
+    /// [`Self::members_below_threshold`] after a `set_threshold` call,
+    /// or arrange for a subsequent apply that surfaces the affected
+    /// members through normal cross-detection.
     fn set_threshold(&mut self, threshold: i64);
 }
 

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -79,14 +79,21 @@ pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 /// member across the configured threshold. Plug-ins return events from
 /// every mutating call; the coordinator drains them at known safe
 /// points and turns them into protocol actions (e.g. submitting
-/// `SCORE_BELOW_THRESHOLD`).
+/// `SCORE_BELOW_THRESHOLD`). The `score` field carries the post-apply
+/// value at the time of the cross.
+///
+/// "Untracked → tracked" via [`PeerScoringPlugin::add_member`] or a
+/// [`PeerScoringPlugin::apply_snapshot`] entry counts as crossing from
+/// above for cross-detection — a fresh entry that lands at-or-below
+/// threshold emits `ThresholdCrossedDown`. Coordinators should treat
+/// the events the same regardless of source.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerScoringEvent {
     /// Member's score moved from above-threshold to at-or-below threshold.
     ThresholdCrossedDown { member_id: Vec<u8>, score: i64 },
     /// Member's score moved from at-or-below threshold back above it.
-    /// Reserved for recovery scoring; not currently emitted by the
-    /// reference [`PeerScoringService`].
+    /// Reserved for future recovery-scoring use cases — coordinators
+    /// today drop these silently.
     ThresholdCrossedUp { member_id: Vec<u8>, score: i64 },
 }
 
@@ -102,9 +109,8 @@ pub struct ScoreSnapshot {
     pub diverged: Vec<(Vec<u8>, i64)>,
 }
 
-/// Per-member score persistence for a single group. The app layer ships
-/// an in-memory default impl. One storage instance per group — no
-/// `group_id` keying.
+/// Per-member score persistence for a single group. One storage
+/// instance per group; the app layer ships an in-memory default impl.
 pub trait PeerScoreStorage {
     fn get(&self, member_id: &[u8]) -> Option<i64>;
     fn set(&mut self, member_id: &[u8], score: i64);
@@ -123,7 +129,7 @@ pub struct ScoringMemberDiff {
 }
 
 /// Pure diff between a scoring table snapshot and an MLS member roster.
-/// Caller applies the diff to its own [`PeerScoringService`].
+/// Caller applies the diff to its own [`PeerScoringPlugin`].
 pub fn scoring_member_diff(scored: &[Vec<u8>], mls_members: &[Vec<u8>]) -> ScoringMemberDiff {
     let scored_set: HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();
     let mls_set: HashSet<&[u8]> = mls_members.iter().map(Vec::as_slice).collect();
@@ -193,21 +199,32 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
 /// The plug-in itself owns no I/O — storage backends and event
 /// publishing are caller concerns.
 pub trait PeerScoringPlugin: Send + Sync + 'static {
-    fn add_member(&mut self, member_id: &[u8]);
+    /// Start tracking a member at the plug-in's default score. If the
+    /// default lands at-or-below threshold (unusual config), emits
+    /// [`PeerScoringEvent::ThresholdCrossedDown`]; otherwise no event.
+    #[must_use]
+    fn add_member(&mut self, member_id: &[u8]) -> Vec<PeerScoringEvent>;
+
+    /// Stop tracking a member. Emits no events — removal is a membership
+    /// change, not a score event.
     fn remove_member(&mut self, member_id: &[u8]);
 
-    /// Apply a single [`ScoreOp`]. Returns events for any threshold
-    /// crossings the op caused.
+    /// Apply a single [`ScoreOp`]. Returns events only when the op
+    /// causes a threshold cross — repeated ops on a member already
+    /// at-or-below threshold do not re-emit.
     #[must_use]
     fn apply_op(&mut self, op: &ScoreOp) -> Vec<PeerScoringEvent>;
 
     /// Apply a batch of [`ScoreOp`]s. Returns the concatenated events
-    /// for every op in order.
+    /// for every op in input order. A member crossing threshold twice
+    /// in one batch (down then up, say) yields two events in that order.
     #[must_use]
     fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent>;
 
-    /// Apply a [`ScoreSnapshot`] (GroupSync receive). Returns events
-    /// for any member who lands at-or-below threshold after the apply.
+    /// Apply a [`ScoreSnapshot`] (GroupSync receive). Each entry is a
+    /// state replacement: events fire only when the entry's prior state
+    /// was on the opposite side of threshold from the new score.
+    /// Idempotent — re-applying the same snapshot emits no events.
     #[must_use]
     fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent>;
 
@@ -222,6 +239,33 @@ pub trait PeerScoringPlugin: Send + Sync + 'static {
     /// `GroupSync` so joiners adopt the same value.
     fn threshold(&self) -> i64;
     fn set_threshold(&mut self, threshold: i64);
+}
+
+/// Compute the [`PeerScoringEvent`] for a transition from `prior` to
+/// `new_score`. `prior == None` (untracked) is treated as "above
+/// threshold" so a fresh entry landing at-or-below threshold emits a
+/// downward cross. Returns `None` when no cross occurred.
+fn cross_event(
+    member_id: &[u8],
+    prior: Option<i64>,
+    new_score: i64,
+    threshold: i64,
+) -> Option<PeerScoringEvent> {
+    let was_above = prior.is_none_or(|p| p > threshold);
+    let now_below = new_score <= threshold;
+    if was_above && now_below {
+        Some(PeerScoringEvent::ThresholdCrossedDown {
+            member_id: member_id.to_vec(),
+            score: new_score,
+        })
+    } else if !was_above && new_score > threshold {
+        Some(PeerScoringEvent::ThresholdCrossedUp {
+            member_id: member_id.to_vec(),
+            score: new_score,
+        })
+    } else {
+        None
+    }
 }
 
 // ── Reference scoring service ───────────────────────────────────────
@@ -245,25 +289,27 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
             config,
         }
     }
-
-    pub fn config(&self) -> &ScoringConfig {
-        &self.config
-    }
-
-    /// Test-only: returns whether `member_id` is at-or-below threshold.
-    #[cfg(test)]
-    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
-        self.storage
-            .get(member_id)
-            .is_some_and(|s| s <= self.config.threshold)
-    }
 }
 
 impl<S: PeerScoreStorage + Send + Sync + 'static, P: ScoringProvider + Send + Sync + 'static>
     PeerScoringPlugin for PeerScoringService<S, P>
 {
-    fn add_member(&mut self, member_id: &[u8]) {
-        self.storage.set(member_id, self.config.default_score);
+    fn add_member(&mut self, member_id: &[u8]) -> Vec<PeerScoringEvent> {
+        let default = self.config.default_score;
+        self.storage.set(member_id, default);
+        // "Untracked → tracked" treated as "above → new state" for
+        // cross-detection purposes, so an unusual config with
+        // `default_score <= threshold` still surfaces the new member as
+        // a downward cross. The standard config (default 100, threshold
+        // 0) silently produces no event.
+        if default <= self.config.threshold {
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: member_id.to_vec(),
+                score: default,
+            }]
+        } else {
+            Vec::new()
+        }
     }
 
     fn remove_member(&mut self, member_id: &[u8]) {
@@ -277,23 +323,14 @@ impl<S: PeerScoreStorage + Send + Sync + 'static, P: ScoringProvider + Send + Sy
         let delta = self.provider.score_delta(op.event);
         let new_score = current.saturating_add(delta);
         self.storage.set(&op.member_id, new_score);
-
-        let threshold = self.config.threshold;
-        let was_above = current > threshold;
-        let now_below = new_score <= threshold;
-        if was_above && now_below {
-            vec![PeerScoringEvent::ThresholdCrossedDown {
-                member_id: op.member_id.clone(),
-                score: new_score,
-            }]
-        } else if !was_above && new_score > threshold {
-            vec![PeerScoringEvent::ThresholdCrossedUp {
-                member_id: op.member_id.clone(),
-                score: new_score,
-            }]
-        } else {
-            Vec::new()
-        }
+        cross_event(
+            &op.member_id,
+            Some(current),
+            new_score,
+            self.config.threshold,
+        )
+        .into_iter()
+        .collect()
     }
 
     fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent> {
@@ -307,13 +344,11 @@ impl<S: PeerScoreStorage + Send + Sync + 'static, P: ScoringProvider + Send + Sy
     fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent> {
         let threshold = self.config.threshold;
         let mut events = Vec::new();
-        for (member_id, score) in &snapshot.diverged {
-            self.storage.set(member_id, *score);
-            if *score <= threshold {
-                events.push(PeerScoringEvent::ThresholdCrossedDown {
-                    member_id: member_id.clone(),
-                    score: *score,
-                });
+        for (member_id, new_score) in &snapshot.diverged {
+            let prior = self.storage.get(member_id);
+            self.storage.set(member_id, *new_score);
+            if let Some(ev) = cross_event(member_id, prior, *new_score, threshold) {
+                events.push(ev);
             }
         }
         events
@@ -419,8 +454,29 @@ mod tests {
     #[test]
     fn add_member_gets_default_score() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let events = svc.add_member(b"alice");
+        assert!(events.is_empty(), "default 100 > threshold 0, no cross");
         assert_eq!(svc.score_for(b"alice"), Some(100));
+    }
+
+    #[test]
+    fn add_member_with_default_below_threshold_emits_down_event() {
+        let mut svc = PeerScoringService::new(
+            TestStorage::default(),
+            TestProvider(HashMap::new()),
+            ScoringConfig {
+                default_score: -10,
+                threshold: 0,
+            },
+        );
+        let events = svc.add_member(b"alice");
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: b"alice".to_vec(),
+                score: -10,
+            }]
+        );
     }
 
     #[test]
@@ -432,7 +488,7 @@ mod tests {
     #[test]
     fn remove_member_clears_score() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         svc.remove_member(b"alice");
         assert_eq!(svc.score_for(b"alice"), None);
     }
@@ -440,7 +496,7 @@ mod tests {
     #[test]
     fn apply_event_decreases_score() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         let events = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::EmergencyNoCreator,
@@ -462,7 +518,7 @@ mod tests {
     #[test]
     fn multiple_events_accumulate() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         for event in [
             ScoreEvent::EmergencyNoCreator,
             ScoreEvent::MisbehavingCommit,
@@ -477,9 +533,33 @@ mod tests {
     }
 
     #[test]
+    fn apply_op_emits_threshold_crossed_up_on_recovery() {
+        let mut svc = make_service();
+        let _ = svc.add_member(b"alice");
+        // 100 → 50 → 0 (down), 0 → 20 (up via EmergencyYesCreator).
+        for _ in 0..2 {
+            let _ = svc.apply_op(&ScoreOp {
+                member_id: b"alice".to_vec(),
+                event: ScoreEvent::EmergencyNoCreator,
+            });
+        }
+        let events = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::EmergencyYesCreator,
+        });
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedUp {
+                member_id: b"alice".to_vec(),
+                score: 20,
+            }]
+        );
+    }
+
+    #[test]
     fn threshold_cross_down_emits_event() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
 
         // 100 → 50, still above threshold 0.
         let events = svc.apply_op(&ScoreOp {
@@ -512,8 +592,8 @@ mod tests {
     #[test]
     fn apply_ops_concatenates_events_in_order() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.add_member(b"bob");
+        let _ = svc.add_member(b"alice");
+        let _ = svc.add_member(b"bob");
         // Drop alice across threshold (-50 + -50 = 0 ≤ 0) and bob too in
         // the same batch.
         let ops = vec![
@@ -549,9 +629,9 @@ mod tests {
     #[test]
     fn snapshot_includes_only_diverged_scores() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.add_member(b"bob");
-        svc.add_member(b"charlie");
+        let _ = svc.add_member(b"alice");
+        let _ = svc.add_member(b"bob");
+        let _ = svc.add_member(b"charlie");
         let _ = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::SuccessfulCommit,
@@ -563,10 +643,10 @@ mod tests {
     }
 
     #[test]
-    fn apply_snapshot_emits_events_for_below_threshold_entries() {
+    fn apply_snapshot_emits_event_only_on_actual_cross() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.add_member(b"bob");
+        let _ = svc.add_member(b"alice");
+        let _ = svc.add_member(b"bob");
         let snap = ScoreSnapshot {
             diverged: vec![(b"alice".to_vec(), -10), (b"bob".to_vec(), 50)],
         };
@@ -583,11 +663,65 @@ mod tests {
     }
 
     #[test]
+    fn apply_snapshot_idempotent_on_repeat() {
+        let mut svc = make_service();
+        let _ = svc.add_member(b"alice");
+        let snap = ScoreSnapshot {
+            diverged: vec![(b"alice".to_vec(), -10)],
+        };
+        let first = svc.apply_snapshot(&snap);
+        assert_eq!(first.len(), 1, "first apply emits the cross");
+        let second = svc.apply_snapshot(&snap);
+        assert!(
+            second.is_empty(),
+            "second apply on unchanged state emits nothing"
+        );
+    }
+
+    #[test]
+    fn apply_snapshot_emits_threshold_crossed_up_on_recovery() {
+        let mut svc = make_service();
+        let _ = svc.add_member(b"alice");
+        // First push alice below threshold.
+        let _ = svc.apply_snapshot(&ScoreSnapshot {
+            diverged: vec![(b"alice".to_vec(), -10)],
+        });
+        // Now snapshot her back above.
+        let events = svc.apply_snapshot(&ScoreSnapshot {
+            diverged: vec![(b"alice".to_vec(), 50)],
+        });
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedUp {
+                member_id: b"alice".to_vec(),
+                score: 50,
+            }]
+        );
+    }
+
+    #[test]
+    fn apply_snapshot_for_untracked_below_threshold_emits_down() {
+        // Untracked → tracked (below threshold) treated as a downward
+        // cross from "above-by-default."
+        let mut svc = make_service();
+        let events = svc.apply_snapshot(&ScoreSnapshot {
+            diverged: vec![(b"newcomer".to_vec(), -10)],
+        });
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: b"newcomer".to_vec(),
+                score: -10,
+            }]
+        );
+    }
+
+    #[test]
     fn members_below_threshold_filters_correctly() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
-        svc.add_member(b"bob");
-        svc.add_member(b"charlie");
+        let _ = svc.add_member(b"alice");
+        let _ = svc.add_member(b"bob");
+        let _ = svc.add_member(b"charlie");
         for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
             let _ = svc.apply_op(&ScoreOp {
                 member_id: b"alice".to_vec(),
@@ -609,7 +743,7 @@ mod tests {
     #[test]
     fn set_threshold_changes_below_threshold_set() {
         let mut svc = make_service();
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         // Apply via snapshot to set an absolute score without going
         // through the delta provider.
         let _ = svc.apply_snapshot(&ScoreSnapshot {
@@ -633,7 +767,7 @@ mod tests {
                 threshold: 0,
             },
         );
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         let _ = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::SuccessfulCommit,
@@ -651,7 +785,7 @@ mod tests {
                 threshold: 0,
             },
         );
-        svc.add_member(b"alice");
+        let _ = svc.add_member(b"alice");
         let _ = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::SuccessfulCommit,

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -63,21 +63,22 @@ pub trait ScoringProvider {
 pub struct ScoringConfig {
     /// Score assigned to newly added members.
     pub default_score: i64,
+    /// At or below this score, a member is eligible for
+    /// `SCORE_BELOW_THRESHOLD` ECP removal (RFC §Peer Scoring).
+    pub threshold: i64,
 }
 
-/// Per-(group, member) score persistence. The app layer ships an
-/// in-memory default impl.
-pub trait PeerScoreStorage {
-    fn get(&self, group_id: &str, member_id: &[u8]) -> Option<i64>;
-    fn set(&mut self, group_id: &str, member_id: &[u8], score: i64);
-    fn remove(&mut self, group_id: &str, member_id: &[u8]);
-    fn all_scores(&self, group_id: &str) -> Vec<(Vec<u8>, i64)>;
+/// Default removal threshold (RFC §Peer Scoring `threshold_peer_score`).
+pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
-    /// Drop every score entry for `group_id`. Called on leave so a future
-    /// rejoin starts from a clean per-group table populated by the new
-    /// `GroupSync` rather than carrying stale entries from the prior
-    /// session.
-    fn remove_group(&mut self, group_id: &str);
+/// Per-member score persistence for a single group. The app layer ships
+/// an in-memory default impl. One storage instance per group — no
+/// `group_id` keying.
+pub trait PeerScoreStorage {
+    fn get(&self, member_id: &[u8]) -> Option<i64>;
+    fn set(&mut self, member_id: &[u8], score: i64);
+    fn remove(&mut self, member_id: &[u8]);
+    fn all_scores(&self) -> Vec<(Vec<u8>, i64)>;
 }
 
 // ── Scoring-member diff ─────────────────────────────────────────────

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -72,6 +72,35 @@ pub struct ScoringConfig {
 /// Default removal threshold (RFC §Peer Scoring `threshold_peer_score`).
 pub const DEFAULT_THRESHOLD_PEER_SCORE: i64 = 0;
 
+// ── Plug-in events ──────────────────────────────────────────────────
+
+/// Event emitted by a [`PeerScoringPlugin`] when an apply call moves a
+/// member across the configured threshold. Plug-ins return events from
+/// every mutating call; the coordinator drains them at known safe
+/// points and turns them into protocol actions (e.g. submitting
+/// `SCORE_BELOW_THRESHOLD`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerScoringEvent {
+    /// Member's score moved from above-threshold to at-or-below threshold.
+    ThresholdCrossedDown { member_id: Vec<u8>, score: i64 },
+    /// Member's score moved from at-or-below threshold back above it.
+    /// Reserved for recovery scoring; not currently emitted by the
+    /// reference [`PeerScoringService`].
+    ThresholdCrossedUp { member_id: Vec<u8>, score: i64 },
+}
+
+// ── GroupSync snapshot ──────────────────────────────────────────────
+
+/// Sparse snapshot of per-member scores for joiner bootstrap. Carries
+/// only members whose score has diverged from `default_score`; the
+/// recipient initialises every member at default via membership sync
+/// before applying the snapshot, so missing entries imply default.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScoreSnapshot {
+    /// Members whose score `!= default_score`. Absolute scores, not deltas.
+    pub diverged: Vec<(Vec<u8>, i64)>,
+}
+
 /// Per-member score persistence for a single group. The app layer ships
 /// an in-memory default impl. One storage instance per group — no
 /// `group_id` keying.
@@ -155,12 +184,49 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
     }
 }
 
+// ── Plug-in trait ───────────────────────────────────────────────────
+
+/// Per-group peer-scoring plug-in. Mutating methods return any
+/// [`PeerScoringEvent`]s the call produced; the coordinator drains them
+/// at safe points and turns threshold crossings into protocol actions.
+/// The plug-in itself owns no I/O — storage backends and event
+/// publishing are caller concerns.
+pub trait PeerScoringPlugin {
+    fn add_member(&mut self, member_id: &[u8]);
+    fn remove_member(&mut self, member_id: &[u8]);
+
+    /// Apply a single [`ScoreOp`]. Returns events for any threshold
+    /// crossings the op caused.
+    #[must_use]
+    fn apply_op(&mut self, op: &ScoreOp) -> Vec<PeerScoringEvent>;
+
+    /// Apply a batch of [`ScoreOp`]s. Returns the concatenated events
+    /// for every op in order.
+    #[must_use]
+    fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent>;
+
+    /// Apply a [`ScoreSnapshot`] (GroupSync receive). Returns events
+    /// for any member who lands at-or-below threshold after the apply.
+    #[must_use]
+    fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent>;
+
+    /// Sparse snapshot of non-default scores for GroupSync send.
+    fn snapshot(&self) -> ScoreSnapshot;
+
+    fn score_for(&self, member_id: &[u8]) -> Option<i64>;
+    fn members_below_threshold(&self) -> Vec<Vec<u8>>;
+    fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)>;
+
+    fn set_threshold(&mut self, threshold: i64);
+}
+
 // ── Reference scoring service ───────────────────────────────────────
 
-/// Per-group, per-member score tracker. One instance per group;
-/// threshold travels with [`ScoringConfig`]. Storage is abstracted via
-/// [`PeerScoreStorage`] so app-layer backends (in-memory, on-disk, …)
-/// plug in without touching this protocol logic.
+/// Per-group, per-member score tracker. Reference [`PeerScoringPlugin`]
+/// implementation. One instance per group; threshold travels with
+/// [`ScoringConfig`]. Storage is abstracted via [`PeerScoreStorage`] so
+/// app-layer backends (in-memory, on-disk, …) plug in without touching
+/// this protocol logic.
 pub struct PeerScoringService<S: PeerScoreStorage, P: ScoringProvider> {
     storage: S,
     provider: P,
@@ -176,43 +242,93 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
         }
     }
 
-    /// Start tracking a member with the default score.
-    pub fn add_member(&mut self, member_id: &[u8]) {
+    pub fn config(&self) -> &ScoringConfig {
+        &self.config
+    }
+
+    /// Test-only: returns whether `member_id` is at-or-below threshold.
+    #[cfg(test)]
+    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
+        self.storage
+            .get(member_id)
+            .is_some_and(|s| s <= self.config.threshold)
+    }
+}
+
+impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringPlugin for PeerScoringService<S, P> {
+    fn add_member(&mut self, member_id: &[u8]) {
         self.storage.set(member_id, self.config.default_score);
     }
 
-    pub fn remove_member(&mut self, member_id: &[u8]) {
+    fn remove_member(&mut self, member_id: &[u8]) {
         self.storage.remove(member_id);
     }
 
-    /// Apply a single [`ScoreOp`] and return the target's new score, or
-    /// `None` if the target isn't tracked.
-    pub fn apply_op(&mut self, op: &ScoreOp) -> Option<i64> {
-        let current = self.storage.get(&op.member_id)?;
+    fn apply_op(&mut self, op: &ScoreOp) -> Vec<PeerScoringEvent> {
+        let Some(current) = self.storage.get(&op.member_id) else {
+            return Vec::new();
+        };
         let delta = self.provider.score_delta(op.event);
         let new_score = current.saturating_add(delta);
         self.storage.set(&op.member_id, new_score);
-        Some(new_score)
-    }
 
-    /// Apply a batch of [`ScoreOp`]s. Untracked targets are skipped
-    /// silently (same semantics as [`Self::apply_op`]).
-    pub fn apply_ops(&mut self, ops: &[ScoreOp]) {
-        for op in ops {
-            self.apply_op(op);
+        let threshold = self.config.threshold;
+        let was_above = current > threshold;
+        let now_below = new_score <= threshold;
+        if was_above && now_below {
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: op.member_id.clone(),
+                score: new_score,
+            }]
+        } else if !was_above && new_score > threshold {
+            vec![PeerScoringEvent::ThresholdCrossedUp {
+                member_id: op.member_id.clone(),
+                score: new_score,
+            }]
+        } else {
+            Vec::new()
         }
     }
 
-    pub fn score_for(&self, member_id: &[u8]) -> Option<i64> {
+    fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent> {
+        let mut events = Vec::new();
+        for op in ops {
+            events.extend(self.apply_op(op));
+        }
+        events
+    }
+
+    fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent> {
+        let threshold = self.config.threshold;
+        let mut events = Vec::new();
+        for (member_id, score) in &snapshot.diverged {
+            self.storage.set(member_id, *score);
+            if *score <= threshold {
+                events.push(PeerScoringEvent::ThresholdCrossedDown {
+                    member_id: member_id.clone(),
+                    score: *score,
+                });
+            }
+        }
+        events
+    }
+
+    fn snapshot(&self) -> ScoreSnapshot {
+        let default = self.config.default_score;
+        let diverged = self
+            .storage
+            .all_scores()
+            .into_iter()
+            .filter(|(_, score)| *score != default)
+            .collect();
+        ScoreSnapshot { diverged }
+    }
+
+    fn score_for(&self, member_id: &[u8]) -> Option<i64> {
         self.storage.get(member_id)
     }
 
-    /// Force-set a score; used when applying a `GroupSync` from the steward.
-    pub fn set_score(&mut self, member_id: &[u8], score: i64) {
-        self.storage.set(member_id, score);
-    }
-
-    pub fn members_below_threshold(&self) -> Vec<Vec<u8>> {
+    fn members_below_threshold(&self) -> Vec<Vec<u8>> {
         let threshold = self.config.threshold;
         self.storage
             .all_scores()
@@ -222,21 +338,11 @@ impl<S: PeerScoreStorage, P: ScoringProvider> PeerScoringService<S, P> {
             .collect()
     }
 
-    pub fn is_below_threshold(&self, member_id: &[u8]) -> bool {
-        self.storage
-            .get(member_id)
-            .is_some_and(|s| s <= self.config.threshold)
-    }
-
-    pub fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
+    fn all_members_with_scores(&self) -> Vec<(Vec<u8>, i64)> {
         self.storage.all_scores()
     }
 
-    pub fn config(&self) -> &ScoringConfig {
-        &self.config
-    }
-
-    pub fn set_threshold(&mut self, threshold: i64) {
+    fn set_threshold(&mut self, threshold: i64) {
         self.config.threshold = threshold;
     }
 }
@@ -325,22 +431,22 @@ mod tests {
     fn apply_event_decreases_score() {
         let mut svc = make_service();
         svc.add_member(b"alice");
-        let new_score = svc.apply_op(&ScoreOp {
+        let events = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::EmergencyNoCreator,
         });
-        assert_eq!(new_score, Some(50));
+        assert!(events.is_empty(), "100 → 50 stays above threshold 0");
         assert_eq!(svc.score_for(b"alice"), Some(50));
     }
 
     #[test]
-    fn apply_event_unknown_member_returns_none() {
+    fn apply_event_unknown_member_returns_no_events() {
         let mut svc = make_service();
-        let result = svc.apply_op(&ScoreOp {
+        let events = svc.apply_op(&ScoreOp {
             member_id: b"unknown".to_vec(),
             event: ScoreEvent::EmergencyNoCreator,
         });
-        assert_eq!(result, None);
+        assert!(events.is_empty());
     }
 
     #[test]
@@ -352,12 +458,118 @@ mod tests {
             ScoreEvent::MisbehavingCommit,
             ScoreEvent::SuccessfulCommit,
         ] {
-            svc.apply_op(&ScoreOp {
+            let _ = svc.apply_op(&ScoreOp {
                 member_id: b"alice".to_vec(),
                 event,
             });
         }
         assert_eq!(svc.score_for(b"alice"), Some(30));
+    }
+
+    #[test]
+    fn threshold_cross_down_emits_event() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+
+        // 100 → 50, still above threshold 0.
+        let events = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
+        assert!(events.is_empty(), "above threshold, no event");
+
+        // 50 → 0, crosses to at-or-below threshold.
+        let events = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::EmergencyNoCreator,
+        });
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: b"alice".to_vec(),
+                score: 0,
+            }]
+        );
+
+        // 0 → -50, already below — no further event.
+        let events = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::BrokenCommit,
+        });
+        assert!(events.is_empty(), "already below threshold, no event");
+    }
+
+    #[test]
+    fn apply_ops_concatenates_events_in_order() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.add_member(b"bob");
+        // Drop alice across threshold (-50 + -50 = 0 ≤ 0) and bob too in
+        // the same batch.
+        let ops = vec![
+            ScoreOp {
+                member_id: b"alice".to_vec(),
+                event: ScoreEvent::BrokenCommit,
+            },
+            ScoreOp {
+                member_id: b"alice".to_vec(),
+                event: ScoreEvent::BrokenCommit,
+            },
+            ScoreOp {
+                member_id: b"bob".to_vec(),
+                event: ScoreEvent::BrokenCommit,
+            },
+            ScoreOp {
+                member_id: b"bob".to_vec(),
+                event: ScoreEvent::BrokenCommit,
+            },
+        ];
+        let events = svc.apply_ops(&ops);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            PeerScoringEvent::ThresholdCrossedDown { ref member_id, .. } if member_id == b"alice"
+        ));
+        assert!(matches!(
+            events[1],
+            PeerScoringEvent::ThresholdCrossedDown { ref member_id, .. } if member_id == b"bob"
+        ));
+    }
+
+    #[test]
+    fn snapshot_includes_only_diverged_scores() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.add_member(b"bob");
+        svc.add_member(b"charlie");
+        let _ = svc.apply_op(&ScoreOp {
+            member_id: b"alice".to_vec(),
+            event: ScoreEvent::SuccessfulCommit,
+        });
+        let snap = svc.snapshot();
+        let ids: Vec<&[u8]> = snap.diverged.iter().map(|(id, _)| id.as_slice()).collect();
+        assert_eq!(ids, vec![b"alice".as_slice()]);
+        assert_eq!(snap.diverged[0].1, 110);
+    }
+
+    #[test]
+    fn apply_snapshot_emits_events_for_below_threshold_entries() {
+        let mut svc = make_service();
+        svc.add_member(b"alice");
+        svc.add_member(b"bob");
+        let snap = ScoreSnapshot {
+            diverged: vec![(b"alice".to_vec(), -10), (b"bob".to_vec(), 50)],
+        };
+        let events = svc.apply_snapshot(&snap);
+        assert_eq!(
+            events,
+            vec![PeerScoringEvent::ThresholdCrossedDown {
+                member_id: b"alice".to_vec(),
+                score: -10,
+            }]
+        );
+        assert_eq!(svc.score_for(b"alice"), Some(-10));
+        assert_eq!(svc.score_for(b"bob"), Some(50));
     }
 
     #[test]
@@ -367,13 +579,13 @@ mod tests {
         svc.add_member(b"bob");
         svc.add_member(b"charlie");
         for event in [ScoreEvent::EmergencyNoCreator, ScoreEvent::BrokenCommit] {
-            svc.apply_op(&ScoreOp {
+            let _ = svc.apply_op(&ScoreOp {
                 member_id: b"alice".to_vec(),
                 event,
             });
         }
         for _ in 0..2 {
-            svc.apply_op(&ScoreOp {
+            let _ = svc.apply_op(&ScoreOp {
                 member_id: b"charlie".to_vec(),
                 event: ScoreEvent::EmergencyNoCreator,
             });
@@ -388,7 +600,11 @@ mod tests {
     fn set_threshold_changes_below_threshold_set() {
         let mut svc = make_service();
         svc.add_member(b"alice");
-        svc.set_score(b"alice", -10);
+        // Apply via snapshot to set an absolute score without going
+        // through the delta provider.
+        let _ = svc.apply_snapshot(&ScoreSnapshot {
+            diverged: vec![(b"alice".to_vec(), -10)],
+        });
 
         svc.set_threshold(-50);
         assert!(!svc.members_below_threshold().contains(&b"alice".to_vec()));
@@ -408,11 +624,11 @@ mod tests {
             },
         );
         svc.add_member(b"alice");
-        let new_score = svc.apply_op(&ScoreOp {
+        let _ = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::SuccessfulCommit,
         });
-        assert_eq!(new_score, Some(i64::MAX));
+        assert_eq!(svc.score_for(b"alice"), Some(i64::MAX));
     }
 
     #[test]
@@ -426,11 +642,11 @@ mod tests {
             },
         );
         svc.add_member(b"alice");
-        let new_score = svc.apply_op(&ScoreOp {
+        let _ = svc.apply_op(&ScoreOp {
             member_id: b"alice".to_vec(),
             event: ScoreEvent::SuccessfulCommit,
         });
-        assert_eq!(new_score, Some(100));
+        assert_eq!(svc.score_for(b"alice"), Some(100));
     }
 
     // ── ECP score derivation tests ──────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,7 +13,8 @@ use std::sync::{
 
 use async_trait::async_trait;
 
-use de_mls::app::{FixedScoringProvider, InMemoryPeerScoreStorage, PeerScoringService};
+use de_mls::app::{FixedScoringProvider, InMemoryPeerScoreStorage};
+use de_mls::core::PeerScoringService;
 use de_mls::core::{
     CallbackError, FreezeOutcome, Group, GroupEventHandler, ProcessResult, ProtocolConfig,
     ScoringConfig, build_key_package_message, create_commit_candidate, finalize_freeze_round,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -368,6 +368,7 @@ pub fn make_scoring() -> PeerScoringService<InMemoryPeerScoreStorage, FixedScori
         FixedScoringProvider::with_default_deltas(),
         ScoringConfig {
             default_score: DEFAULT_SCORE,
+            threshold: 0,
         },
     )
 }

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -625,11 +625,9 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut steward_handle = setup_steward_with_config(group_name, steward_hex, steward_protocol);
     let mut joiner = setup_joiner_with_config(group_name, joiner_hex, default_steward_config());
 
-    steward_handle.set_threshold_peer_score(STEWARD_THRESHOLD);
     steward_handle.set_liveness_criteria_yes(STEWARD_LIVENESS_YES);
     steward_handle.set_pending_update_max_epochs(STEWARD_PENDING_MAX_EPOCHS);
 
-    assert_ne!(joiner.group.threshold_peer_score(), STEWARD_THRESHOLD);
     assert_ne!(joiner.group.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
     assert_ne!(
         joiner.group.pending_update_max_epochs(),
@@ -664,7 +662,7 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         retry_round: steward_list.retry_round(),
         max_reelection_attempts: steward_handle.max_reelection_attempts(),
         liveness_criteria_yes: steward_handle.liveness_criteria_yes(),
-        threshold_peer_score: steward_handle.threshold_peer_score(),
+        threshold_peer_score: STEWARD_THRESHOLD,
         pending_update_max_epochs: steward_handle.pending_update_max_epochs(),
     };
     let app_msg: AppMessage = sync.clone().into();
@@ -696,15 +694,11 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     joiner.group.set_protocol_config(applied_protocol);
     joiner
         .group
-        .set_threshold_peer_score(received.threshold_peer_score);
-    joiner
-        .group
         .set_liveness_criteria_yes(received.liveness_criteria_yes);
     joiner
         .group
         .set_pending_update_max_epochs(received.pending_update_max_epochs);
 
-    assert_eq!(joiner.group.threshold_peer_score(), STEWARD_THRESHOLD);
     assert_eq!(joiner.group.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
     assert_eq!(
         joiner.group.pending_update_max_epochs(),
@@ -716,30 +710,29 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut scoring = PeerScoringService::new(
         InMemoryPeerScoreStorage::new(),
         de_mls::app::FixedScoringProvider::with_default_deltas(),
-        ScoringConfig { default_score: 100 },
-    );
-    for ps in &received.peer_scores {
-        scoring.set_score(group_name, &ps.member_id, ps.score);
-    }
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: alice.clone(),
-            event: ScoreEvent::SuccessfulCommit,
+        ScoringConfig {
+            default_score: 100,
+            threshold: 0,
         },
     );
-    let below = scoring.members_below_threshold(group_name, joiner.group.threshold_peer_score());
+    scoring.set_threshold(received.threshold_peer_score);
+    for ps in &received.peer_scores {
+        scoring.set_score(&ps.member_id, ps.score);
+    }
+    scoring.apply_op(&ScoreOp {
+        member_id: alice.clone(),
+        event: ScoreEvent::SuccessfulCommit,
+    });
+    let below = scoring.members_below_threshold();
     assert!(
         below.contains(&alice),
-        "alice (score {}) is below the synced threshold {}",
+        "alice (score {}) is below the synced threshold {STEWARD_THRESHOLD}",
         STEWARD_THRESHOLD - 10 + 10,
-        joiner.group.threshold_peer_score()
     );
     assert!(
         !below.contains(&bob),
-        "bob (score {}) is above the synced threshold {}",
+        "bob (score {}) is above the synced threshold {STEWARD_THRESHOLD}",
         STEWARD_THRESHOLD + 10,
-        joiner.group.threshold_peer_score()
     );
 }
 

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -608,7 +608,7 @@ fn test_group_sync_roundtrip() {
 #[test]
 fn test_group_sync_propagates_divergent_per_group_config() {
     use de_mls::app::InMemoryPeerScoreStorage;
-    use de_mls::core::PeerScoringService;
+    use de_mls::core::{PeerScoringPlugin, PeerScoringService, ScoreSnapshot};
     use de_mls::core::{ScoreEvent, ScoreOp, ScoringConfig};
     use de_mls::protos::de_mls::messages::v1::{GroupSync, PeerScore};
 
@@ -717,10 +717,14 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         },
     );
     scoring.set_threshold(received.threshold_peer_score);
-    for ps in &received.peer_scores {
-        scoring.set_score(&ps.member_id, ps.score);
-    }
-    scoring.apply_op(&ScoreOp {
+    let _ = scoring.apply_snapshot(&ScoreSnapshot {
+        diverged: received
+            .peer_scores
+            .iter()
+            .map(|ps| (ps.member_id.clone(), ps.score))
+            .collect(),
+    });
+    let _ = scoring.apply_op(&ScoreOp {
         member_id: alice.clone(),
         event: ScoreEvent::SuccessfulCommit,
     });

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -607,7 +607,8 @@ fn test_group_sync_roundtrip() {
 
 #[test]
 fn test_group_sync_propagates_divergent_per_group_config() {
-    use de_mls::app::{InMemoryPeerScoreStorage, PeerScoringService};
+    use de_mls::app::InMemoryPeerScoreStorage;
+    use de_mls::core::PeerScoringService;
     use de_mls::core::{ScoreEvent, ScoreOp, ScoringConfig};
     use de_mls::protos::de_mls::messages::v1::{GroupSync, PeerScore};
 

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -62,7 +62,8 @@ const BOB_KEY: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6
 const CHARLIE_KEY: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const DAVE_KEY: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
-type TU = User<DefaultProvider, de_mls::app::DefaultMlsService, H, SH>;
+type TU =
+    User<DefaultProvider, de_mls::app::DefaultMlsService, de_mls::app::DefaultPeerScoring, H, SH>;
 
 fn make(key: &str, cs: Arc<DefaultConsensusService>, cfg: GroupConfig) -> (TU, H) {
     let h = H::new();

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -5,8 +5,8 @@
 use prost::Message;
 
 use de_mls::core::{
-    Group, PeerScoringService, ScoreEvent, ScoreOp, apply_consensus_result, emergency_score_ops,
-    group_members,
+    Group, PeerScoringPlugin, PeerScoringService, ScoreEvent, ScoreOp, apply_consensus_result,
+    emergency_score_ops, group_members,
 };
 use de_mls::ds::WELCOME_SUBTOPIC;
 
@@ -85,7 +85,7 @@ fn test_new_joiner_starts_with_default_scores() {
     // Alice's scoring has her at a non-default score (simulating prior events).
     let mut alice_scoring = make_scoring();
     alice_scoring.add_member(&alice_id);
-    alice_scoring.apply_op(&ScoreOp {
+    let _ = alice_scoring.apply_op(&ScoreOp {
         member_id: alice_id.clone(),
         event: ScoreEvent::EmergencyYesCreator,
     });

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -17,7 +17,10 @@ use common::{
 
 /// Sync the scoring service's member list with the MLS group's actual members.
 /// Mirrors `User::sync_scoring_members`.
-fn sync_scoring_members<S: de_mls::core::PeerScoreStorage, P: de_mls::core::ScoringProvider>(
+fn sync_scoring_members<
+    S: de_mls::core::PeerScoreStorage + Send + Sync + 'static,
+    P: de_mls::core::ScoringProvider + Send + Sync + 'static,
+>(
     scoring: &mut PeerScoringService<S, P>,
     group: &Group<TestMls>,
 ) {

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -19,23 +19,22 @@ use common::{
 /// Mirrors `User::sync_scoring_members`.
 fn sync_scoring_members<S: de_mls::core::PeerScoreStorage, P: de_mls::core::ScoringProvider>(
     scoring: &mut PeerScoringService<S, P>,
-    group_name: &str,
     group: &Group<TestMls>,
 ) {
     let mls_members = group_members(group).unwrap();
-    let scored = scoring.all_members_with_scores(group_name);
+    let scored = scoring.all_members_with_scores();
     let scored_ids: std::collections::HashSet<Vec<u8>> =
         scored.iter().map(|(id, _)| id.clone()).collect();
     let mls_ids: std::collections::HashSet<Vec<u8>> = mls_members.into_iter().collect();
 
     for member_id in &mls_ids {
         if !scored_ids.contains(member_id) {
-            scoring.add_member(group_name, member_id);
+            scoring.add_member(member_id);
         }
     }
     for member_id in &scored_ids {
         if !mls_ids.contains(member_id) {
-            scoring.remove_member(group_name, member_id);
+            scoring.remove_member(member_id);
         }
     }
 }
@@ -85,18 +84,12 @@ fn test_new_joiner_starts_with_default_scores() {
 
     // Alice's scoring has her at a non-default score (simulating prior events).
     let mut alice_scoring = make_scoring();
-    alice_scoring.add_member(group_name, &alice_id);
-    alice_scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: alice_id.clone(),
-            event: ScoreEvent::EmergencyYesCreator,
-        },
-    );
-    assert_eq!(
-        alice_scoring.score_for(group_name, &alice_id),
-        Some(DEFAULT_SCORE + 20)
-    );
+    alice_scoring.add_member(&alice_id);
+    alice_scoring.apply_op(&ScoreOp {
+        member_id: alice_id.clone(),
+        event: ScoreEvent::EmergencyYesCreator,
+    });
+    assert_eq!(alice_scoring.score_for(&alice_id), Some(DEFAULT_SCORE + 20));
 
     // Bob joins.
     let mut bob = setup_joiner(group_name, bob_hex);
@@ -108,10 +101,7 @@ fn test_new_joiner_starts_with_default_scores() {
 
     // Bob builds his scoring from MLS members — gets defaults.
     let mut bob_scoring = make_scoring();
-    sync_scoring_members(&mut bob_scoring, group_name, &bob.group);
+    sync_scoring_members(&mut bob_scoring, &bob.group);
 
-    assert_eq!(
-        bob_scoring.score_for(group_name, &alice_id),
-        Some(DEFAULT_SCORE),
-    );
+    assert_eq!(bob_scoring.score_for(&alice_id), Some(DEFAULT_SCORE));
 }

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -4,9 +4,9 @@
 
 use prost::Message;
 
-use de_mls::app::PeerScoringService;
 use de_mls::core::{
-    Group, ScoreEvent, ScoreOp, apply_consensus_result, emergency_score_ops, group_members,
+    Group, PeerScoringService, ScoreEvent, ScoreOp, apply_consensus_result, emergency_score_ops,
+    group_members,
 };
 use de_mls::ds::WELCOME_SUBTOPIC;
 

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -32,7 +32,7 @@ fn sync_scoring_members<
 
     for member_id in &mls_ids {
         if !scored_ids.contains(member_id) {
-            scoring.add_member(member_id);
+            let _ = scoring.add_member(member_id);
         }
     }
     for member_id in &scored_ids {
@@ -87,7 +87,7 @@ fn test_new_joiner_starts_with_default_scores() {
 
     // Alice's scoring has her at a non-default score (simulating prior events).
     let mut alice_scoring = make_scoring();
-    alice_scoring.add_member(&alice_id);
+    let _ = alice_scoring.add_member(&alice_id);
     let _ = alice_scoring.apply_op(&ScoreOp {
         member_id: alice_id.clone(),
         event: ScoreEvent::EmergencyYesCreator,

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -137,8 +137,8 @@ fn test_full_pipeline_penalties_to_removal() {
     let target_id = vec![0xDD];
 
     let mut scoring = make_scoring();
-    scoring.add_member(&steward_id);
-    scoring.add_member(&target_id);
+    let _ = scoring.add_member(&steward_id);
+    let _ = scoring.add_member(&target_id);
 
     // Apply penalties until target drops below threshold
     // 100 - 50 = 50 (BrokenCommit)
@@ -219,8 +219,8 @@ fn test_steward_skips_self_for_removal() {
     let steward_id = vec![0x01];
     let other_id = vec![0x02];
 
-    scoring.add_member(&steward_id);
-    scoring.add_member(&other_id);
+    let _ = scoring.add_member(&steward_id);
+    let _ = scoring.add_member(&other_id);
 
     // Drop both below threshold
     for event in [ScoreEvent::BrokenCommit, ScoreEvent::EmergencyNoCreator] {
@@ -259,9 +259,9 @@ fn test_members_below_threshold_uses_per_group_value() {
     let carol = vec![0xCC];
 
     let mut scoring = make_scoring();
-    scoring.add_member(&alice);
-    scoring.add_member(&bob);
-    scoring.add_member(&carol);
+    let _ = scoring.add_member(&alice);
+    let _ = scoring.add_member(&bob);
+    let _ = scoring.add_member(&carol);
     let _ = scoring.apply_snapshot(&ScoreSnapshot {
         diverged: vec![
             (alice.clone(), -10),

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -127,6 +127,54 @@ fn test_score_below_threshold_no_penalizes_creator() {
     assert_eq!(group.approved_proposals_count(), 0);
 }
 
+/// Regression: after a SCORE_BELOW_THRESHOLD ECP resolves YES, the
+/// target is queued in `approved_proposals` as `RemoveMember(target)`
+/// but `pending_removal_targets` is cleared (the in-flight ECP is
+/// done). Their score has not changed and is still ≤ threshold. The
+/// steward MUST NOT submit a fresh duplicate ECP for the same target
+/// before the RemoveMember commits — `is_pending_removal` (queued in
+/// `approved_proposals`) plus `has_pending_removal` (in-flight ECP)
+/// together gate the next-pass scan.
+#[test]
+fn test_below_threshold_target_queued_for_removal_is_not_re_proposed() {
+    let group_name = "removal-no-duplicate";
+    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    let mut group = setup_steward(group_name, alice_hex);
+    let steward_id = group.self_identity().to_vec();
+    let target_id = vec![0xEE];
+
+    // Stand the target at threshold (score == 0).
+    let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, 0)
+        .with_creator(steward_id.clone());
+    let request = evidence.into_update_request().unwrap();
+    let payload = request.encode_to_vec();
+    let proposal_id = 300;
+    group.store_voting_proposal(proposal_id, request);
+    group.observe_pending_removal(target_id.clone());
+    apply_consensus_result(&mut group, proposal_id, true, &payload).unwrap();
+
+    // Mirror the User layer: clear the in-flight dedup on resolution.
+    group.resolve_pending_removal(&target_id);
+
+    // The target is queued for removal — `is_pending_removal` must say so.
+    assert!(
+        group.is_pending_removal(&target_id),
+        "RemoveMember should be queued in approved_proposals"
+    );
+    // The ECP-in-flight dedup is cleared (mirrors handle_emergency_scored).
+    assert!(
+        !group.has_pending_removal(&target_id),
+        "in-flight ECP dedup is cleared once the ECP resolves"
+    );
+    // Both gates together must keep the steward from re-proposing.
+    let would_re_propose =
+        !group.has_pending_removal(&target_id) && !group.is_pending_removal(&target_id);
+    assert!(
+        !would_re_propose,
+        "steward must skip a target already queued in approved_proposals"
+    );
+}
+
 /// Full pipeline: penalties → below threshold → ECP → YES → RemoveMember in queue.
 #[test]
 fn test_full_pipeline_penalties_to_removal() {

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -6,7 +6,10 @@
 
 use prost::Message;
 
-use de_mls::core::{ScoreEvent, ScoreOp, apply_consensus_result, emergency_score_ops};
+use de_mls::core::{
+    PeerScoringPlugin, ScoreEvent, ScoreOp, ScoreSnapshot, apply_consensus_result,
+    emergency_score_ops,
+};
 use de_mls::protos::de_mls::messages::v1::{
     ViolationEvidence, ViolationType, group_update_request,
 };
@@ -139,18 +142,18 @@ fn test_full_pipeline_penalties_to_removal() {
 
     // Apply penalties until target drops below threshold
     // 100 - 50 = 50 (BrokenCommit)
-    scoring.apply_op(&ScoreOp {
+    let _ = scoring.apply_op(&ScoreOp {
         member_id: target_id.clone(),
         event: ScoreEvent::BrokenCommit,
     });
-    assert!(!scoring.is_below_threshold(&target_id));
+    assert!(!scoring.members_below_threshold().contains(&target_id));
 
     // 50 - 50 = 0 (EmergencyNoCreator)
-    scoring.apply_op(&ScoreOp {
+    let _ = scoring.apply_op(&ScoreOp {
         member_id: target_id.clone(),
         event: ScoreEvent::EmergencyNoCreator,
     });
-    assert!(scoring.is_below_threshold(&target_id));
+    assert!(scoring.members_below_threshold().contains(&target_id));
 
     // Now steward creates SCORE_BELOW_THRESHOLD ECP
     let below = scoring.members_below_threshold();
@@ -170,7 +173,7 @@ fn test_full_pipeline_penalties_to_removal() {
     let score_ops = emergency_score_ops(&payload, true);
 
     // Apply score ops
-    scoring.apply_ops(&score_ops);
+    let _ = scoring.apply_ops(&score_ops);
 
     // RemoveMember should be in approved queue
     assert_eq!(group.approved_proposals_count(), 1);
@@ -221,18 +224,19 @@ fn test_steward_skips_self_for_removal() {
 
     // Drop both below threshold
     for event in [ScoreEvent::BrokenCommit, ScoreEvent::EmergencyNoCreator] {
-        scoring.apply_op(&ScoreOp {
+        let _ = scoring.apply_op(&ScoreOp {
             member_id: steward_id.clone(),
             event,
         });
-        scoring.apply_op(&ScoreOp {
+        let _ = scoring.apply_op(&ScoreOp {
             member_id: other_id.clone(),
             event,
         });
     }
 
-    assert!(scoring.is_below_threshold(&steward_id));
-    assert!(scoring.is_below_threshold(&other_id));
+    let below = scoring.members_below_threshold();
+    assert!(below.contains(&steward_id));
+    assert!(below.contains(&other_id));
 
     // Filter as the steward would
     let targets: Vec<Vec<u8>> = scoring
@@ -258,9 +262,13 @@ fn test_members_below_threshold_uses_per_group_value() {
     scoring.add_member(&alice);
     scoring.add_member(&bob);
     scoring.add_member(&carol);
-    scoring.set_score(&alice, -10);
-    scoring.set_score(&bob, -30);
-    scoring.set_score(&carol, -60);
+    let _ = scoring.apply_snapshot(&ScoreSnapshot {
+        diverged: vec![
+            (alice.clone(), -10),
+            (bob.clone(), -30),
+            (carol.clone(), -60),
+        ],
+    });
 
     // Strict threshold (-50): only Carol qualifies for removal.
     scoring.set_threshold(-50);

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -7,8 +7,8 @@
 use prost::Message;
 
 use de_mls::core::{
-    PeerScoringPlugin, ScoreEvent, ScoreOp, ScoreSnapshot, apply_consensus_result,
-    emergency_score_ops,
+    PeerScoringEvent, PeerScoringPlugin, ScoreEvent, ScoreOp, ScoreSnapshot,
+    apply_consensus_result, emergency_score_ops,
 };
 use de_mls::protos::de_mls::messages::v1::{
     ViolationEvidence, ViolationType, group_update_request,
@@ -247,6 +247,51 @@ fn test_steward_skips_self_for_removal() {
 
     assert_eq!(targets.len(), 1);
     assert_eq!(targets[0], other_id);
+}
+
+/// `apply_ops` emits `ThresholdCrossedDown` exactly when a member
+/// crosses the threshold downward, and `members_below_threshold`
+/// surfaces them. This is the trigger condition the User layer chains
+/// into [`check_and_initiate_score_removals`] on, in `freeze.rs` and
+/// `consensus_events.rs`.
+#[test]
+fn test_apply_ops_emits_event_and_marks_below_threshold() {
+    let target = vec![0xAA];
+    let bystander = vec![0xBB];
+
+    let mut scoring = make_scoring();
+    let _ = scoring.add_member(&target);
+    let _ = scoring.add_member(&bystander);
+
+    // 100 → 50 (BrokenCommit) — still above threshold 0, no event.
+    let events = scoring.apply_ops(&[ScoreOp {
+        member_id: target.clone(),
+        event: ScoreEvent::BrokenCommit,
+    }]);
+    assert!(events.is_empty(), "above threshold, no event");
+    assert!(!scoring.members_below_threshold().contains(&target));
+
+    // 50 → 0 (EmergencyNoCreator) — crosses to at-or-below threshold.
+    let events = scoring.apply_ops(&[ScoreOp {
+        member_id: target.clone(),
+        event: ScoreEvent::EmergencyNoCreator,
+    }]);
+    assert_eq!(events.len(), 1, "exactly one cross event");
+    assert!(matches!(
+        events[0],
+        PeerScoringEvent::ThresholdCrossedDown { ref member_id, score: 0 }
+            if *member_id == target
+    ));
+    assert!(scoring.members_below_threshold().contains(&target));
+    assert!(!scoring.members_below_threshold().contains(&bystander));
+
+    // Re-applying ops on an already-below member emits no further
+    // event — coordinator dedup at this layer keeps the chain quiet.
+    let events = scoring.apply_ops(&[ScoreOp {
+        member_id: target.clone(),
+        event: ScoreEvent::BrokenCommit,
+    }]);
+    assert!(events.is_empty(), "already below threshold, no re-fire");
 }
 
 /// `members_below_threshold` honours the threshold stored in the

--- a/tests/steward_triggered_removal.rs
+++ b/tests/steward_triggered_removal.rs
@@ -133,37 +133,30 @@ fn test_full_pipeline_penalties_to_removal() {
     let steward_id = group.self_identity().to_vec();
     let target_id = vec![0xDD];
 
-    let threshold = group.threshold_peer_score();
     let mut scoring = make_scoring();
-    scoring.add_member(group_name, &steward_id);
-    scoring.add_member(group_name, &target_id);
+    scoring.add_member(&steward_id);
+    scoring.add_member(&target_id);
 
     // Apply penalties until target drops below threshold
     // 100 - 50 = 50 (BrokenCommit)
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: target_id.clone(),
-            event: ScoreEvent::BrokenCommit,
-        },
-    );
-    assert!(!scoring.is_below_threshold(group_name, &target_id, threshold));
+    scoring.apply_op(&ScoreOp {
+        member_id: target_id.clone(),
+        event: ScoreEvent::BrokenCommit,
+    });
+    assert!(!scoring.is_below_threshold(&target_id));
 
     // 50 - 50 = 0 (EmergencyNoCreator)
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: target_id.clone(),
-            event: ScoreEvent::EmergencyNoCreator,
-        },
-    );
-    assert!(scoring.is_below_threshold(group_name, &target_id, threshold));
+    scoring.apply_op(&ScoreOp {
+        member_id: target_id.clone(),
+        event: ScoreEvent::EmergencyNoCreator,
+    });
+    assert!(scoring.is_below_threshold(&target_id));
 
     // Now steward creates SCORE_BELOW_THRESHOLD ECP
-    let below = scoring.members_below_threshold(group_name, threshold);
+    let below = scoring.members_below_threshold();
     assert!(below.contains(&target_id));
 
-    let current_score = scoring.score_for(group_name, &target_id).unwrap();
+    let current_score = scoring.score_for(&target_id).unwrap();
     let evidence = ViolationEvidence::score_below_threshold(target_id.clone(), 0, current_score)
         .with_creator(steward_id.clone());
     let request = evidence.into_update_request().unwrap();
@@ -177,7 +170,7 @@ fn test_full_pipeline_penalties_to_removal() {
     let score_ops = emergency_score_ops(&payload, true);
 
     // Apply score ops
-    scoring.apply_ops(group_name, &score_ops);
+    scoring.apply_ops(&score_ops);
 
     // RemoveMember should be in approved queue
     assert_eq!(group.approved_proposals_count(), 1);
@@ -216,53 +209,34 @@ fn test_dedup_pending_removal_targets() {
 fn test_steward_skips_self_for_removal() {
     let group_name = "removal-self-guard";
     let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-    let group = setup_steward(group_name, alice_hex);
-    let threshold = group.threshold_peer_score();
+    let _group = setup_steward(group_name, alice_hex);
 
     let mut scoring = make_scoring();
 
     let steward_id = vec![0x01];
     let other_id = vec![0x02];
 
-    scoring.add_member(group_name, &steward_id);
-    scoring.add_member(group_name, &other_id);
+    scoring.add_member(&steward_id);
+    scoring.add_member(&other_id);
 
     // Drop both below threshold
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
+    for event in [ScoreEvent::BrokenCommit, ScoreEvent::EmergencyNoCreator] {
+        scoring.apply_op(&ScoreOp {
             member_id: steward_id.clone(),
-            event: ScoreEvent::BrokenCommit,
-        },
-    );
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: steward_id.clone(),
-            event: ScoreEvent::EmergencyNoCreator,
-        },
-    );
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
+            event,
+        });
+        scoring.apply_op(&ScoreOp {
             member_id: other_id.clone(),
-            event: ScoreEvent::BrokenCommit,
-        },
-    );
-    scoring.apply_op(
-        group_name,
-        &ScoreOp {
-            member_id: other_id.clone(),
-            event: ScoreEvent::EmergencyNoCreator,
-        },
-    );
+            event,
+        });
+    }
 
-    assert!(scoring.is_below_threshold(group_name, &steward_id, threshold));
-    assert!(scoring.is_below_threshold(group_name, &other_id, threshold));
+    assert!(scoring.is_below_threshold(&steward_id));
+    assert!(scoring.is_below_threshold(&other_id));
 
     // Filter as the steward would
     let targets: Vec<Vec<u8>> = scoring
-        .members_below_threshold(group_name, threshold)
+        .members_below_threshold()
         .into_iter()
         .filter(|id| *id != steward_id)
         .collect();
@@ -271,39 +245,34 @@ fn test_steward_skips_self_for_removal() {
     assert_eq!(targets[0], other_id);
 }
 
-/// `members_below_threshold` selects against the threshold passed in,
-/// not a global default.
+/// `members_below_threshold` honours the threshold stored in the
+/// service's [`ScoringConfig`], including post-construction updates via
+/// `set_threshold`.
 #[test]
 fn test_members_below_threshold_uses_per_group_value() {
-    let group_name = "per-group-threshold";
-    let alice_hex = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-    let group = setup_steward(group_name, alice_hex);
-    assert_eq!(
-        group.threshold_peer_score(),
-        de_mls::core::DEFAULT_THRESHOLD_PEER_SCORE
-    );
-
     let alice = vec![0xAA];
     let bob = vec![0xBB];
     let carol = vec![0xCC];
 
     let mut scoring = make_scoring();
-    scoring.add_member(group_name, &alice);
-    scoring.add_member(group_name, &bob);
-    scoring.add_member(group_name, &carol);
-    scoring.set_score(group_name, &alice, -10);
-    scoring.set_score(group_name, &bob, -30);
-    scoring.set_score(group_name, &carol, -60);
+    scoring.add_member(&alice);
+    scoring.add_member(&bob);
+    scoring.add_member(&carol);
+    scoring.set_score(&alice, -10);
+    scoring.set_score(&bob, -30);
+    scoring.set_score(&carol, -60);
 
     // Strict threshold (-50): only Carol qualifies for removal.
-    let strict = scoring.members_below_threshold(group_name, -50);
+    scoring.set_threshold(-50);
+    let strict = scoring.members_below_threshold();
     assert!(strict.contains(&carol));
     assert!(!strict.contains(&bob));
     assert!(!strict.contains(&alice));
 
     // Loose threshold (-25, e.g. after a GroupSync reduced strictness):
     // both Bob and Carol qualify; Alice still safe.
-    let loose = scoring.members_below_threshold(group_name, -25);
+    scoring.set_threshold(-25);
+    let loose = scoring.members_below_threshold();
     assert!(loose.contains(&bob));
     assert!(loose.contains(&carol));
     assert!(!loose.contains(&alice));


### PR DESCRIPTION
Second plug-in extraction following the MlsService pattern from #76. PeerScoring becomes a per-group `PeerScoringPlugin` with threshold-cross events; the coordinator chains into
`check_and_initiate_score_removals` after each downward cross.

- `PeerScoringPlugin` trait + `PeerScoringEvent` + `ScoreSnapshot` live in core. The reference `PeerScoringService<S, P>` impls the trait; storage (`InMemoryPeerScoreStorage`) and policy provider
(`FixedScoringProvider`) stay in app as swappable choices.
- `User<P, M, Sc, H, SCH>` is generic over `Sc: PeerScoringPlugin`; `GroupEntry<M, Sc>` carries one instance per group; a `ScoringFactory<Sc>` closure builds them on demand. `DefaultPeerScoring = PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>` is the convenience alias for the bundled impl.
- Threshold lives on `ScoringConfig`, not on `Group<M>`. Mutators (`apply_op`, `apply_ops`, `apply_snapshot`, `add_member`) return `Vec<PeerScoringEvent>`; coordinators react to `ThresholdCrossedDown` by chaining
into the existing scan-based removal pass — `members_below_threshold` stays the source of truth, no persistent event queue.
- `GroupSync` wire payload is sparse (only members diverged from `default_score`). `apply_snapshot` is idempotent on repeat and emits symmetric `ThresholdCrossedUp` on recovery. A `cross_event` helper unifies
transition logic across `apply_op` and `apply_snapshot`.
- Bug fix: `check_and_initiate_score_removals` filters by `is_pending_removal` (approved-queue dedup) in addition to `has_pending_removal` (in-flight ECP dedup), preventing a duplicate SCORE_BELOW_THRESHOLD ECP
from firing for a target already queued for removal.