### PR TITLE
refactor(identity): split Identity from MLS state

### DIFF
--- a/apps/de_mls_desktop_ui/src/main.rs
+++ b/apps/de_mls_desktop_ui/src/main.rs
@@ -12,7 +12,7 @@ use std::{
 
 use de_mls::{
     app::format_group_request,
-    mls_crypto::parse_wallet_address,
+    identity::parse_wallet_address,
     protos::de_mls::messages::v1::{ConversationMessage, GroupUpdateRequest, VotePayload},
 };
 use de_mls_gateway::{GATEWAY, bootstrap_core_from_env};

--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, atomic::Ordering};
 
 use de_mls::{
-    app::format_group_request, ds::WakuDeliveryService, mls_crypto::format_wallet_address,
+    app::format_group_request, ds::WakuDeliveryService, identity::format_wallet_address,
     protos::de_mls::messages::v1::GroupUpdateRequest,
 };
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo};

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -37,15 +37,16 @@ pub use crate::bootstrap::{
 /// Type alias for the user reference stored in the gateway.
 ///
 /// Uses [`de_mls::app::DefaultMlsService`] — `OpenMlsService` over
-/// `Arc<MemoryDeMlsStorage>` + `Arc<WalletIdentity>` — so the per-group
-/// services share one storage and one identity (the `Arc<S>: DeMlsStorage`
-/// and `Arc<I>: IdentityProvider` blanket impls make this work).
+/// `Arc<MemoryDeMlsStorage>` — so per-group services share one storage
+/// (the `Arc<S>: DeMlsStorage` blanket impl makes this work). MLS
+/// credentials live on `User` and are passed in at service construction.
 type UserRef = Arc<
     tokio::sync::RwLock<
         User<
             DefaultProvider,
             de_mls::app::DefaultMlsService,
             de_mls::app::DefaultPeerScoring,
+            de_mls::identity::WalletIdentity,
             GatewayEventHandler<WakuDeliveryService>,
             GatewayEventHandler<WakuDeliveryService>,
         >,

--- a/src/app/display.rs
+++ b/src/app/display.rs
@@ -1,7 +1,7 @@
 //! Display helpers for rendering protobuf types in the UI.
 
 use crate::{
-    mls_crypto::format_wallet_address,
+    identity::format_wallet_address,
     protos::de_mls::messages::v1::{
         GroupUpdateRequest, ViolationEvidence, ViolationType, app_message, group_update_request,
     },

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -19,7 +19,8 @@ use crate::{
         DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProposalKind, group_members,
         target_identity_of,
     },
-    mls_crypto::{IdentityProvider, MlsService},
+    identity::Identity,
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{AppMessage, GroupUpdateRequest, VotePayload},
 };
 
@@ -44,11 +45,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Check that the group state allows creating a proposal of this kind and
     /// return the expected voter count.

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -13,6 +13,7 @@ use crate::{
         DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProposalKind, ScoreOp,
         apply_consensus_result, emergency_score_ops, group_members, target_identity_of,
     },
+    identity::Identity,
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         GroupUpdateRequest, StewardElectionProposal, group_update_request,
@@ -23,11 +24,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Entry point from the consensus service: decode the proposal, apply the
     /// result to the group, and dispatch to the correct follow-up handler

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -9,7 +9,8 @@ use crate::{
         ScoreEvent, ScoreOp, create_commit_candidate, finalize_freeze_round, group_members,
     },
     ds::WELCOME_SUBTOPIC,
-    mls_crypto::{IdentityProvider, MlsService},
+    identity::Identity,
+    mls_crypto::MlsService,
 };
 
 use super::has_downward_cross;
@@ -18,11 +19,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Poll a `PendingJoin` group. Returns `true` while still waiting,
     /// `false` once joined or once the join attempt has been torn down

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -15,7 +15,8 @@ use crate::{
         member_set, process_inbound,
     },
     ds::{APP_MSG_SUBTOPIC, InboundPacket, WELCOME_SUBTOPIC},
-    mls_crypto::{IdentityProvider, MlsService, ShortId, key_package_bytes_from_json},
+    identity::{Identity, ShortId},
+    mls_crypto::{MlsService, key_package_bytes_from_json},
     protos::de_mls::messages::v1::{
         AppMessage, ConversationMessage, GroupSync, GroupUpdateRequest, InviteMember,
         WelcomeMessage, group_update_request, welcome_message,
@@ -26,11 +27,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Dispatches a single ProcessResult to the appropriate handler/consensus/state-machine action.
     pub async fn dispatch_inbound_result(

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -13,7 +13,8 @@ use crate::{
     core::{
         DeMlsProvider, Group, GroupEventHandler, PeerScoringPlugin, auto_approved_leave_proposal_id,
     },
-    mls_crypto::{IdentityProvider, MlsService, parse_wallet_to_bytes},
+    identity::Identity,
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{GroupUpdateRequest, RemoveMember, group_update_request},
 };
 
@@ -21,11 +22,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Create (`is_creation = true`) or join (`false`) a group using the
     /// user's default config.
@@ -129,7 +129,7 @@ where
             return Ok(());
         }
 
-        let self_identity = parse_wallet_to_bytes(&self.identity_string())?;
+        let self_identity = self.identity().identity_bytes().to_vec();
 
         // Idempotent: a second click after a successful submit finds the
         // approved entry and short-circuits.

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -3,7 +3,8 @@
 use crate::{
     app::{GroupState, StateChangeHandler, User, UserError},
     core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, build_key_package_message},
-    mls_crypto::{MlsService, parse_wallet_to_bytes},
+    identity::{Identity, parse_wallet_to_bytes},
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, ConversationMessage, GroupUpdateRequest, RemoveMember,
         group_update_request,
@@ -14,11 +15,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Broadcast our key-package on the welcome subtopic so the steward
     /// can invite us.

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -29,9 +29,9 @@ use crate::{
         DeMlsProvider, DefaultProvider, Group, GroupEventHandler, PeerScoringEvent,
         PeerScoringPlugin, PeerScoringService, ProposalId, ProviderConsensus, ScoringConfig,
     },
+    identity::{Identity, WalletIdentity},
     mls_crypto::{
-        IdentityProvider, KeyPackageBytes, MemoryDeMlsStorage, MlsError, MlsService,
-        OpenMlsService, WalletIdentity,
+        KeyPackageBytes, MemoryDeMlsStorage, MlsCredentials, MlsError, MlsService, OpenMlsService,
     },
     protos::de_mls::messages::v1::GroupUpdateRequest,
 };
@@ -133,20 +133,20 @@ pub struct User<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler,
     SCH: StateChangeHandler,
-> where
-    M::Identity: Clone,
-{
-    /// Local identity, shared with every per-group MLS service this user
-    /// runs. Source of truth for "who am I" at the User level — call sites
-    /// must read this rather than reaching into a per-group service.
-    identity: M::Identity,
+> {
+    /// Local user-level identity, shared across all this user's groups.
+    /// Source of truth for "who am I"; MLS state lives in the per-group
+    /// service, MLS credentials are captured by the factories below
+    /// (built once from this identity at User init).
+    identity: Arc<I>,
     /// Build an MLS service for a brand-new group as its sole creator.
     mls_creator_factory: MlsCreatorFactory<M>,
     /// Try to build an MLS service from a serialized welcome.
     mls_welcome_factory: MlsWelcomeFactory<M>,
-    /// Generate a single-use key package using the user's storage + identity.
+    /// Generate a single-use key package using the user's storage + credentials.
     kp_generator: KeyPackageGenerator,
     /// Build a fresh peer-scoring plug-in for a new group entry.
     scoring_factory: ScoringFactory<Sc>,
@@ -174,15 +174,14 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler,
     SCH: StateChangeHandler,
-> Clone for User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> Clone for User<P, M, Sc, I, H, SCH>
 {
     fn clone(&self) -> Self {
         Self {
-            identity: self.identity.clone(),
+            identity: Arc::clone(&self.identity),
             mls_creator_factory: Arc::clone(&self.mls_creator_factory),
             mls_welcome_factory: Arc::clone(&self.mls_welcome_factory),
             kp_generator: Arc::clone(&self.kp_generator),
@@ -203,15 +202,14 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     #[allow(clippy::too_many_arguments)]
     fn new_with_config(
-        identity: M::Identity,
+        identity: Arc<I>,
         mls_creator_factory: MlsCreatorFactory<M>,
         mls_welcome_factory: MlsWelcomeFactory<M>,
         kp_generator: KeyPackageGenerator,
@@ -274,7 +272,7 @@ where
 
     /// Borrow the local identity. Source of truth for "who am I" at the
     /// User level.
-    pub(crate) fn identity(&self) -> &M::Identity {
+    pub(crate) fn identity(&self) -> &I {
         &self.identity
     }
 
@@ -305,10 +303,10 @@ where
 // ─────────────────────────── DefaultProvider Convenience ───────────────────────────
 
 /// MLS service type for the default `DefaultProvider`-backed `User`. Uses
-/// in-memory storage and a wallet-keyed identity, both shared across every
-/// per-group service via `Arc` (the `Arc<S>: DeMlsStorage` and
-/// `Arc<I>: IdentityProvider` blanket impls make this work).
-pub type DefaultMlsService = OpenMlsService<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>;
+/// in-memory storage shared across every per-group service via `Arc` (the
+/// `Arc<S>: DeMlsStorage` blanket impl makes this work). MLS credentials
+/// live separately on `User` and are passed in at service construction.
+pub type DefaultMlsService = OpenMlsService<Arc<MemoryDeMlsStorage>>;
 
 /// Peer-scoring plug-in type for the default-config `User`: the
 /// reference [`PeerScoringService`] over in-memory storage and a
@@ -316,7 +314,7 @@ pub type DefaultMlsService = OpenMlsService<Arc<MemoryDeMlsStorage>, Arc<WalletI
 pub type DefaultPeerScoring = PeerScoringService<InMemoryPeerScoreStorage, FixedScoringProvider>;
 
 impl<H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
-    User<DefaultProvider, DefaultMlsService, DefaultPeerScoring, H, SCH>
+    User<DefaultProvider, DefaultMlsService, DefaultPeerScoring, WalletIdentity, H, SCH>
 {
     /// Construct a `User` on [`DefaultProvider`] with the default config.
     pub fn with_private_key(
@@ -345,33 +343,39 @@ impl<H: GroupEventHandler + 'static, SCH: StateChangeHandler + 'static>
         let signer = PrivateKeySigner::from_str(private_key)?;
         let user_address = signer.address();
 
-        let identity = Arc::new(WalletIdentity::from_wallet(user_address)?);
+        let identity = Arc::new(WalletIdentity::from_wallet(user_address));
+        let mls_credentials = Arc::new(MlsCredentials::from_identity(identity.as_ref())?);
         let storage = Arc::new(MemoryDeMlsStorage::new());
 
         let mls_creator_factory: MlsCreatorFactory<DefaultMlsService> = {
             let storage = Arc::clone(&storage);
-            let identity = Arc::clone(&identity);
+            let credentials = Arc::clone(&mls_credentials);
             Arc::new(move |group_id: String| {
                 OpenMlsService::new_as_creator(
                     group_id,
                     Arc::clone(&storage),
-                    Arc::clone(&identity),
+                    Arc::clone(&credentials),
                 )
             })
         };
         let mls_welcome_factory: MlsWelcomeFactory<DefaultMlsService> = {
             let storage = Arc::clone(&storage);
-            let identity = Arc::clone(&identity);
+            let credentials = Arc::clone(&mls_credentials);
             Arc::new(move |bytes: &[u8]| {
-                OpenMlsService::new_from_welcome(bytes, Arc::clone(&storage), Arc::clone(&identity))
+                OpenMlsService::new_from_welcome(
+                    bytes,
+                    Arc::clone(&storage),
+                    Arc::clone(&credentials),
+                )
             })
         };
         let kp_generator: KeyPackageGenerator = {
             let storage = Arc::clone(&storage);
-            let identity = Arc::clone(&identity);
+            let credentials = Arc::clone(&mls_credentials);
             Arc::new(move || {
-                OpenMlsService::<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>::generate_key_package(
-                    &storage, &identity,
+                OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(
+                    &storage,
+                    &credentials,
                 )
             })
         };

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -3,7 +3,8 @@
 use crate::{
     app::{GroupState, MemberRole, StateChangeHandler, User, UserError},
     core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, group_members},
-    mls_crypto::{MlsService, format_wallet_address},
+    identity::{Identity, format_wallet_address},
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::GroupUpdateRequest,
 };
 
@@ -11,11 +12,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     pub async fn get_group_state(&self, group_name: &str) -> Result<GroupState, UserError> {
         self.with_entry(group_name, |e| e.state_machine.current_state())

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -10,7 +10,8 @@ use crate::{
         evaluate_election_initiation, group_members, is_deadlock_ecp_proposer, member_set,
         scoring_member_diff, target_identity_of,
     },
-    mls_crypto::{IdentityProvider, MlsService, ShortId},
+    identity::{Identity, ShortId},
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         AppMessage, GroupSync, GroupUpdateRequest, PeerScore, StewardElectionProposal,
         TimingConfig, ViolationEvidence, group_update_request,
@@ -21,11 +22,10 @@ impl<
     P: DeMlsProvider,
     M: MlsService,
     Sc: PeerScoringPlugin,
+    I: Identity,
     H: GroupEventHandler + 'static,
     SCH: StateChangeHandler + 'static,
-> User<P, M, Sc, H, SCH>
-where
-    M::Identity: Clone,
+> User<P, M, Sc, I, H, SCH>
 {
     /// Add any MLS members not yet tracked in scoring, and drop scored
     /// entries for identities no longer in MLS. Diffing is delegated to

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -11,9 +11,7 @@ use crate::{
         api::lifecycle::build_invitation_packet, group::BufferedCommitCandidate,
     },
     ds::OutboundPacket,
-    mls_crypto::{
-        IdentityProvider, MlsMessageKind, MlsProposalOutput, MlsService, StagedCandidateResult,
-    },
+    mls_crypto::{MlsMessageKind, MlsProposalOutput, MlsService, StagedCandidateResult},
     protos::de_mls::messages::v1::{
         CommitCandidate, GroupUpdateRequest, ViolationEvidence, group_update_request::Payload,
     },
@@ -224,7 +222,7 @@ impl RoundContext {
         M: MlsService,
     {
         let mls = group.expect_mls()?;
-        let self_identity = mls.identity().identity_bytes().to_vec();
+        let self_identity = group.self_identity().to_vec();
 
         let mut mls_actions: Vec<MlsProposalOutput> = Vec::new();
         let mut self_remove_pending = false;

--- a/src/core/api/inbound.rs
+++ b/src/core/api/inbound.rs
@@ -13,7 +13,8 @@ use crate::{
         api::process_commit_candidate, error::CoreError, group::Group,
         process_result::ProcessResult,
     },
-    mls_crypto::{DecryptResult, MlsService, ShortId, parse_wallet_to_bytes},
+    identity::{ShortId, parse_wallet_to_bytes},
+    mls_crypto::{DecryptResult, MlsService},
     protos::de_mls::messages::v1::{
         AppMessage, GroupUpdateRequest, app_message, group_update_request,
     },

--- a/src/core/api/steward.rs
+++ b/src/core/api/steward.rs
@@ -13,8 +13,7 @@ use crate::{
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     mls_crypto::{
-        CommitCandidate as MlsCommitCandidate, IdentityProvider, KeyPackageBytes, MlsCommitInput,
-        MlsService,
+        CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MlsCommitInput, MlsService,
     },
     protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request},
 };
@@ -50,7 +49,7 @@ where
     // MLS forbids committing one's own removal. If the approved batch contains
     // RemoveMember(self), skip local candidate creation — another steward will
     // commit the batch (including this node's removal) once they enter freeze.
-    let self_identity = mls.identity().identity_bytes();
+    let self_identity = group.self_identity();
     let self_removal_pending = group.approved_proposals().values().any(|req| {
         matches!(
             req.payload.as_ref(),
@@ -145,7 +144,7 @@ where
         group_name: group.group_name_bytes().to_vec(),
         mls_proposals,
         commit_message: commit,
-        steward_identity: mls.identity().identity_bytes().to_vec(),
+        steward_identity: group.self_identity().to_vec(),
     };
 
     // Welcome bytes are deferred: sent from finalize_freeze_round after the

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -13,7 +13,8 @@ use tracing::info;
 
 use crate::{
     core::{CoreError, Group},
-    mls_crypto::{MlsService, ShortId},
+    identity::ShortId,
+    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         GroupUpdateRequest, RemoveMember, StewardElectionProposal, ViolationEvidence,
         ViolationType, group_update_request,

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -972,59 +972,30 @@ impl ResolvedProposalCache {
 /// Test-only stubs shared across `core/`'s unit-test modules.
 #[cfg(test)]
 pub(crate) mod test_stubs {
-    use openmls::prelude::CredentialWithKey;
-    use openmls_basic_credential::SignatureKeyPair;
-
     use crate::ds::OutboundPacket;
     use crate::mls_crypto::{
-        CommitCandidate as MlsCommitCandidate, DecryptResult, IdentityProvider, MlsCommitInput,
-        MlsError, MlsMessageKind, MlsService, StagedCandidateResult,
+        CommitCandidate as MlsCommitCandidate, DecryptResult, MlsCommitInput, MlsError,
+        MlsMessageKind, MlsService, StagedCandidateResult,
     };
     use crate::protos::de_mls::messages::v1::AppMessage;
-
-    /// Test-only no-op identity; only `identity_bytes` and `identity_display`
-    /// are ever called from `Group`'s pure-state tests, so the credential
-    /// and signer accessors are stubbed with `unreachable!()`.
-    pub(crate) struct NoopIdentity;
-
-    impl IdentityProvider for NoopIdentity {
-        fn identity_bytes(&self) -> &[u8] {
-            &[]
-        }
-        fn identity_display(&self) -> &str {
-            "noop"
-        }
-        fn credential(&self) -> &CredentialWithKey {
-            unreachable!("NoopIdentity::credential is not used in pure-state Group tests")
-        }
-        fn signer(&self) -> &SignatureKeyPair {
-            unreachable!("NoopIdentity::signer is not used in pure-state Group tests")
-        }
-    }
 
     /// Test-only no-op MLS service. `Group`'s pure-state tests never call
     /// MLS operations, so every protocol method is a stub. If a test
     /// reaches one of these, it's the wrong test and the panic message
     /// will say so.
     pub(crate) struct NoopMls {
-        identity: NoopIdentity,
         group_id: String,
     }
 
     impl NoopMls {
         pub(crate) fn new(group_id: &str) -> Self {
             Self {
-                identity: NoopIdentity,
                 group_id: group_id.to_string(),
             }
         }
     }
 
     impl MlsService for NoopMls {
-        type Identity = NoopIdentity;
-        fn identity(&self) -> &Self::Identity {
-            &self.identity
-        }
         fn group_id(&self) -> &str {
             &self.group_id
         }

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -8,7 +8,7 @@ use hashgraph_like_consensus::{
 
 use crate::{
     core::{CoreError, ScoreEvent, ScoreOp},
-    mls_crypto::parse_wallet_to_bytes,
+    identity::parse_wallet_to_bytes,
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, CommitCandidate, ConversationMessage, EmergencyCriteriaProposal,
         GroupSync, GroupUpdateRequest, InvitationToJoin, Outcome, ProposalAdded, RemoveMember,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,109 +1,69 @@
-//! Identity sources for DE-MLS.
+//! User-level identity, decoupled from MLS state.
 //!
-//! [`IdentityProvider`] is the swap point for identity sources. The default
-//! impl is [`WalletIdentity`], which derives MLS credentials from an
-//! Ethereum wallet address. Future impls (libchat-style `AccountId`, etc.)
-//! plug in by implementing the trait without touching the MLS service.
+//! The `Identity` trait defines a user — the bytes that name them and a
+//! display form. MLS-specific binding (signing keypair, credential)
+//! lives in `MlsCredentials` under [`crate::mls_crypto`], constructed
+//! *from* an `Identity` at User init and held shared (one per user, not
+//! per group). This split mirrors libchat's `MlsContext`: identity is
+//! its own concept, MLS is one of many systems that consumes it.
+//!
+//! The default impl is [`crate::identity::WalletIdentity`], which derives
+//! the canonical identity bytes from a 20-byte Ethereum address. Future
+//! impls (libchat-style `AccountId`, etc.) plug in by implementing the
+//! trait; they do not need to know anything about MLS.
 
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use alloy::{hex, primitives::Address};
-use openmls::credentials::{BasicCredential, CredentialWithKey};
-use openmls_basic_credential::SignatureKeyPair;
 
-use crate::mls_crypto::{MlsError, service::CIPHERSUITE};
+use crate::mls_crypto::MlsError;
 
-/// Pluggable identity source.
+/// Pluggable user identity.
 ///
-/// Identity bridges an authenticated user (wallet address, account id, …)
-/// to the MLS credential system. The trait exposes the canonical identity
-/// bytes plus a display form, and gives the OpenMLS-backed service access
-/// to the credential and signer it needs.
-///
-/// All methods take `&self` so the trait stays object-safe; the
-/// OpenMLS-backed service binds it as a generic field for monomorphization.
-pub trait IdentityProvider: Send + Sync + 'static {
-    /// Canonical identity bytes — what the credential's serialized content
-    /// holds (e.g. wallet address bytes).
+/// Bridges an authenticated user (wallet, account id, …) to anything
+/// downstream that needs to name them. Methods take `&self` so the
+/// trait stays object-safe; callers usually hold an `Arc<I>` so one
+/// identity can back many User-level subsystems (peer scoring, UI,
+/// transport addressing). The MLS service does *not* consume `Identity`
+/// directly — it consumes `MlsCredentials` built once from this
+/// identity at User init.
+pub trait Identity: Send + Sync + 'static {
+    /// Canonical identity bytes — the unique on-the-wire identifier
+    /// used by the MLS credential's serialized content, scoring keys,
+    /// member-id comparisons, and so on.
     fn identity_bytes(&self) -> &[u8];
 
-    /// Display form (e.g. checksummed `0x…` hex). Stable for the lifetime
-    /// of the identity.
+    /// Display form (e.g. checksummed `0x…` hex). Stable for the
+    /// lifetime of the identity; intended for logs and UI.
     fn identity_display(&self) -> &str;
-
-    /// MLS credential bundle — public part of the identity, embedded in
-    /// every signed MLS message we produce.
-    fn credential(&self) -> &CredentialWithKey;
-
-    /// MLS signing key pair — owns the private key used to sign MLS
-    /// messages and proposals.
-    fn signer(&self) -> &SignatureKeyPair;
 }
 
-/// Wallet-based identity. The default [`IdentityProvider`] impl: derives an
-/// MLS credential from a 20-byte Ethereum address, and generates a fresh
-/// MLS signature key pair.
-#[derive(Debug)]
+/// Wallet-based identity. The default [`Identity`] impl: holds a 20-byte
+/// Ethereum address and its checksummed hex form. No MLS state — that
+/// lives in [`crate::mls_crypto::MlsCredentials`].
+#[derive(Debug, Clone)]
 pub struct WalletIdentity {
     wallet_bytes: Vec<u8>,
     wallet_hex: String,
-    credential: CredentialWithKey,
-    signer: SignatureKeyPair,
 }
 
 impl WalletIdentity {
-    /// Build a wallet identity from an Ethereum address. Generates a fresh
-    /// signing keypair and bundles it with a basic credential containing the
-    /// wallet bytes. Does not touch any MLS storage — the signer is held
-    /// in-memory and passed explicitly into MLS calls that need it.
-    pub fn from_wallet(wallet: Address) -> Result<Self, MlsError> {
-        let credential = BasicCredential::new(wallet.as_slice().to_vec());
-        let signer = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
-        Ok(Self {
+    /// Build a wallet identity from an Ethereum address.
+    pub fn from_wallet(wallet: Address) -> Self {
+        Self {
             wallet_bytes: wallet.as_slice().to_vec(),
             wallet_hex: wallet.to_checksum(None),
-            credential: CredentialWithKey {
-                credential: credential.into(),
-                signature_key: signer.to_public_vec().into(),
-            },
-            signer,
-        })
+        }
     }
 }
 
-impl IdentityProvider for WalletIdentity {
+impl Identity for WalletIdentity {
     fn identity_bytes(&self) -> &[u8] {
         &self.wallet_bytes
     }
 
     fn identity_display(&self) -> &str {
         &self.wallet_hex
-    }
-
-    fn credential(&self) -> &CredentialWithKey {
-        &self.credential
-    }
-
-    fn signer(&self) -> &SignatureKeyPair {
-        &self.signer
-    }
-}
-
-/// Sharing impl: every `Arc<I>` over an [`IdentityProvider`] is itself an
-/// [`IdentityProvider`]. Lets one logical identity back many MLS services
-/// (one per group) without cloning the underlying signing key.
-impl<I: IdentityProvider + ?Sized> IdentityProvider for Arc<I> {
-    fn identity_bytes(&self) -> &[u8] {
-        (**self).identity_bytes()
-    }
-    fn identity_display(&self) -> &str {
-        (**self).identity_display()
-    }
-    fn credential(&self) -> &CredentialWithKey {
-        (**self).credential()
-    }
-    fn signer(&self) -> &SignatureKeyPair {
-        (**self).signer()
     }
 }
 
@@ -145,12 +105,6 @@ pub fn parse_wallet_address(address: &str) -> Result<Address, MlsError> {
 /// This is the inverse of `parse_wallet_address`. MLS credentials
 /// store wallet addresses as raw 20-byte arrays; this formats them
 /// for display.
-///
-/// # Examples
-/// ```ignore
-/// let bytes = [0x11, 0x22, ...]; // 20 bytes
-/// let hex = format_wallet_address(&bytes); // "0x1122..."
-/// ```
 pub fn format_wallet_address(raw: &[u8]) -> String {
     if raw.is_empty() {
         String::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,11 @@
 //! use de_mls::core::{DefaultProvider, GroupEventHandler, ProcessResult};
 //! use de_mls::app::User;
 //!
-//! // Create a user with an Ethereum private key
-//! let user: User<DefaultProvider, _, _, _> = User::with_private_key(
+//! // Create a user with an Ethereum private key. The convenience
+//! // constructor anchors all six User generics, so type inference
+//! // picks up the right defaults — no annotation needed at the
+//! // call site.
+//! let user = User::with_private_key(
 //!     "0xac0974...",   // Private key
 //!     consensus,       // Consensus service
 //!     event_handler,   // Your GroupEventHandler implementation
@@ -75,6 +78,9 @@ pub mod ds;
 
 /// MLS cryptographic operations: OpenMLS wrapper for encryption/decryption.
 pub mod mls_crypto;
+
+/// User-level identity, decoupled from MLS state.
+pub mod identity;
 
 /// Protobuf message definitions.
 pub mod protos {

--- a/src/mls_crypto/credentials.rs
+++ b/src/mls_crypto/credentials.rs
@@ -1,0 +1,123 @@
+//! MLS-specific credential bundle: signing keypair + credential.
+//!
+//! Built once per user from an [`crate::identity::Identity`] at User init
+//! and shared across every per-group `MlsService` via
+//! `Arc<MlsCredentials>`. The signing key is the long-lived MLS identity;
+//! the credential's serialized content is the user's identity bytes —
+//! the link back to whatever real-world identifier the
+//! [`crate::identity::Identity`] represents.
+
+use openmls::credentials::{BasicCredential, CredentialWithKey};
+use openmls_basic_credential::SignatureKeyPair;
+
+use crate::{
+    identity::Identity,
+    mls_crypto::{MlsError, service::CIPHERSUITE},
+};
+
+/// MLS credential + signing keypair for one user, shared across all
+/// groups they belong to.
+#[derive(Debug)]
+pub struct MlsCredentials {
+    credential: CredentialWithKey,
+    signer: SignatureKeyPair,
+}
+
+impl MlsCredentials {
+    /// Build credentials from an [`Identity`]. Generates a fresh
+    /// signing keypair (held only in this struct, not stored in MLS
+    /// keystore until consumed by a service / KP build) and bundles it
+    /// with a basic credential whose serialized content is
+    /// `identity.identity_bytes()`.
+    pub fn from_identity<I: Identity + ?Sized>(identity: &I) -> Result<Self, MlsError> {
+        let credential = BasicCredential::new(identity.identity_bytes().to_vec());
+        let signer = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
+        Ok(Self {
+            credential: CredentialWithKey {
+                credential: credential.into(),
+                signature_key: signer.to_public_vec().into(),
+            },
+            signer,
+        })
+    }
+
+    /// MLS credential bundle — public part of the identity, embedded in
+    /// every signed MLS message we produce.
+    pub fn credential(&self) -> &CredentialWithKey {
+        &self.credential
+    }
+
+    /// MLS signing keypair — owns the private key used to sign MLS
+    /// messages and proposals.
+    pub fn signer(&self) -> &SignatureKeyPair {
+        &self.signer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal test-only [`Identity`] impl — pure bytes, no wallet
+    /// machinery. Verifies `from_identity` doesn't depend on
+    /// `WalletIdentity` specifically.
+    struct TestIdentity {
+        bytes: Vec<u8>,
+        display: String,
+    }
+
+    impl Identity for TestIdentity {
+        fn identity_bytes(&self) -> &[u8] {
+            &self.bytes
+        }
+        fn identity_display(&self) -> &str {
+            &self.display
+        }
+    }
+
+    fn test_identity(bytes: &[u8]) -> TestIdentity {
+        TestIdentity {
+            bytes: bytes.to_vec(),
+            display: format!("test:{}", bytes.len()),
+        }
+    }
+
+    /// Load-bearing invariant: the credential's serialized content
+    /// equals `identity.identity_bytes()`. Membership comparisons,
+    /// score keys, and "is this commit from me" checks all rely on
+    /// this round-trip — if it ever drifts, downstream comparisons
+    /// silently misbehave.
+    #[test]
+    fn credential_serialized_content_equals_identity_bytes() {
+        let identity = test_identity(b"alice-bytes");
+        let creds = MlsCredentials::from_identity(&identity).unwrap();
+        assert_eq!(
+            creds.credential().credential.serialized_content(),
+            b"alice-bytes",
+        );
+    }
+
+    /// Each `from_identity` call must mint a fresh signing keypair —
+    /// no static keys leaking through `Default` impls or shared
+    /// crypto state.
+    #[test]
+    fn fresh_keypair_per_call() {
+        let identity = test_identity(b"alice");
+        let a = MlsCredentials::from_identity(&identity).unwrap();
+        let b = MlsCredentials::from_identity(&identity).unwrap();
+        assert_ne!(a.signer().to_public_vec(), b.signer().to_public_vec());
+    }
+
+    /// The credential's public `signature_key` must match the
+    /// signer's public part — otherwise commits we sign won't
+    /// verify under the credential we publish.
+    #[test]
+    fn credential_signature_key_matches_signer_public() {
+        let identity = test_identity(b"alice");
+        let creds = MlsCredentials::from_identity(&identity).unwrap();
+        assert_eq!(
+            creds.credential().signature_key.as_slice(),
+            creds.signer().public(),
+        );
+    }
+}

--- a/src/mls_crypto/mod.rs
+++ b/src/mls_crypto/mod.rs
@@ -4,19 +4,32 @@
 //! `MlsService` trait defines the per-group surface; constructors for the
 //! OpenMLS impl live as inherent methods on `OpenMlsService`.
 //!
+//! Identity and MLS credentials are split: [`crate::identity::Identity`]
+//! is the user-level abstraction (just `identity_bytes` + display);
+//! `MlsCredentials` (re-exported here) holds the MLS-specific signing keypair and
+//! credential, built from an `Identity` at User init and shared across
+//! every per-group service.
+//!
 //! # Quick Start
 //!
 //! ```ignore
-//! use de_mls::mls_crypto::{OpenMlsService, MemoryDeMlsStorage, MlsService,
-//!     WalletIdentity, parse_wallet_address};
+//! use std::sync::Arc;
+//! use de_mls::identity::{WalletIdentity, parse_wallet_address};
+//! use de_mls::mls_crypto::{
+//!     MemoryDeMlsStorage, MlsCredentials, MlsService, OpenMlsService,
+//! };
 //!
-//! // Identity + storage are constructor inputs, shared across groups.
 //! let wallet = parse_wallet_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")?;
-//! let identity = WalletIdentity::from_wallet(wallet)?;
+//! let identity = WalletIdentity::from_wallet(wallet);
+//! let credentials = Arc::new(MlsCredentials::from_identity(&identity)?);
 //! let storage = MemoryDeMlsStorage::new();
 //!
 //! // Create a fresh group as its sole initial member.
-//! let mls = OpenMlsService::new_as_creator("my-chat".into(), storage, identity)?;
+//! let mls = OpenMlsService::new_as_creator(
+//!     "my-chat".into(),
+//!     storage,
+//!     Arc::clone(&credentials),
+//! )?;
 //!
 //! // Encrypt a message.
 //! let ciphertext = mls.encrypt(b"Hello!")?;
@@ -28,17 +41,14 @@
 //! Use `MemoryDeMlsStorage` for development or implement your own for
 //! persistence. Storage may be shared across services via `Arc<S>`.
 
+mod credentials;
 mod error;
-mod identity;
 mod service;
 pub mod storage;
 mod types;
 
+pub use credentials::MlsCredentials;
 pub use error::MlsError;
-pub use identity::{
-    IdentityProvider, ShortId, WalletIdentity, format_wallet_address, parse_wallet_address,
-    parse_wallet_to_bytes,
-};
 pub use service::{CIPHERSUITE, MlsService, OpenMlsService};
 pub use storage::{DeMlsStorage, MemoryDeMlsStorage};
 pub use types::{

--- a/src/mls_crypto/service/api.rs
+++ b/src/mls_crypto/service/api.rs
@@ -2,8 +2,9 @@
 //!
 //! [`MlsService`] is the swap point for MLS implementations. The default
 //! impl is [`OpenMlsService`](super::OpenMlsService). One service instance
-//! corresponds to one MLS group; identity and group id are set at
-//! construction and every method operates on that implicit group.
+//! corresponds to one MLS group; the user's MLS credentials and group id
+//! are set at construction and every method operates on that implicit
+//! group.
 //!
 //! Group construction is intentionally *not* on the trait — concrete impls
 //! expose their own constructors (e.g. `OpenMlsService::new_as_creator` /
@@ -12,15 +13,16 @@
 //!
 //! The trait surface uses only opaque boundary types: no `openmls::*`
 //! types appear here, so swapping in a different MLS engine is purely a
-//! matter of writing a new impl. Identity is exposed through the
-//! associated [`MlsService::Identity`] type.
+//! matter of writing a new impl. Identity is a separate User-level
+//! concept ([`crate::identity::Identity`]) — the MLS service consumes
+//! credentials built from it but does not own the identity itself.
 
 use openmls::prelude::Ciphersuite;
 
 use crate::{
     ds::OutboundPacket,
     mls_crypto::{
-        CommitCandidate, DecryptResult, IdentityProvider, MlsCommitInput, MlsError, MlsMessageKind,
+        CommitCandidate, DecryptResult, MlsCommitInput, MlsError, MlsMessageKind,
         StagedCandidateResult,
     },
     protos::de_mls::messages::v1::AppMessage,
@@ -31,13 +33,6 @@ pub const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_
 
 /// Per-group MLS backend. Each instance corresponds to one MLS group.
 pub trait MlsService: Send + Sync + 'static {
-    /// Identity attached to this service. Set at construction and
-    /// immutable thereafter.
-    type Identity: IdentityProvider;
-
-    /// The signing identity for every MLS message this service produces.
-    fn identity(&self) -> &Self::Identity;
-
     /// The group id this service is scoped to.
     fn group_id(&self) -> &str;
 

--- a/src/mls_crypto/service/backend.rs
+++ b/src/mls_crypto/service/backend.rs
@@ -19,9 +19,8 @@ use prost::Message;
 use crate::{
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     mls_crypto::{
-        CommitCandidate, DeMlsStorage, DecryptResult, IdentityProvider, MlsCommitInput, MlsError,
-        MlsMessageKind, MlsProposalOutput, OpenMlsService, StagedCandidateResult,
-        service::api::MlsService,
+        CommitCandidate, DeMlsStorage, DecryptResult, MlsCommitInput, MlsError, MlsMessageKind,
+        MlsProposalOutput, OpenMlsService, StagedCandidateResult, service::api::MlsService,
     },
     protos::de_mls::messages::v1::AppMessage,
 };
@@ -56,10 +55,9 @@ impl<'a, T: StorageProvider<1>> OpenMlsProvider for MlsProvider<'a, T> {
     }
 }
 
-impl<S, I> OpenMlsService<S, I>
+impl<S> OpenMlsService<S>
 where
     S: DeMlsStorage,
-    I: IdentityProvider,
 {
     fn make_provider(&self) -> MlsProvider<'_, S::MlsStorage> {
         MlsProvider {
@@ -95,17 +93,10 @@ where
     }
 }
 
-impl<S, I> MlsService for OpenMlsService<S, I>
+impl<S> MlsService for OpenMlsService<S>
 where
     S: DeMlsStorage + Send + Sync + 'static,
-    I: IdentityProvider,
 {
-    type Identity = I;
-
-    fn identity(&self) -> &Self::Identity {
-        &self.identity
-    }
-
     fn group_id(&self) -> &str {
         &self.group_id
     }
@@ -155,7 +146,7 @@ where
         updates: &[MlsCommitInput],
     ) -> Result<CommitCandidate, MlsError> {
         let provider = self.make_provider();
-        let signer = self.identity.signer();
+        let signer = self.credentials.signer();
 
         let mut group = self.mls_group.write()?;
         let mut mls_proposals = Vec::new();
@@ -365,7 +356,7 @@ where
 
     fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, MlsError> {
         let provider = self.make_provider();
-        let signer = self.identity.signer();
+        let signer = self.credentials.signer();
 
         let mut group = self.mls_group.write()?;
         let message = group.create_message(&provider, signer, plaintext)?;
@@ -466,7 +457,7 @@ where
             )),
             ProcessedMessageContent::ProposalMessage(proposal) => {
                 let action =
-                    OpenMlsService::<S, I>::extract_proposal_action(&group, proposal.proposal())?;
+                    OpenMlsService::<S>::extract_proposal_action(&group, proposal.proposal())?;
 
                 group
                     .store_pending_proposal(provider.storage(), proposal.as_ref().clone())

--- a/src/mls_crypto/service/mod.rs
+++ b/src/mls_crypto/service/mod.rs
@@ -1,6 +1,6 @@
 //! OpenMLS-backed implementation of [`MlsService`].
 
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use openmls::{
     group::{
@@ -12,7 +12,7 @@ use openmls::{
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
 
-use crate::mls_crypto::{DeMlsStorage, IdentityProvider, KeyPackageBytes, MlsError};
+use crate::mls_crypto::{DeMlsStorage, KeyPackageBytes, MlsCredentials, MlsError};
 
 mod api;
 mod backend;
@@ -23,21 +23,26 @@ use backend::MlsProvider;
 /// OpenMLS-backed MLS service, scoped to a single group.
 ///
 /// The service owns one `MlsGroup` plus an optional staged-commit slot
-/// for the inbound stage→merge/discard pipeline. Identity and storage are
-/// supplied at construction and immutable for the service's lifetime.
-/// The implementation of [`MlsService`] for this type lives in `backend.rs`.
-pub struct OpenMlsService<S: DeMlsStorage, I: IdentityProvider> {
+/// for the inbound stage→merge/discard pipeline. MLS credentials and
+/// storage are supplied at construction. Credentials are
+/// `Arc<MlsCredentials>` so one user's credentials back every per-group
+/// service without copying the signing key.
+pub struct OpenMlsService<S: DeMlsStorage> {
     pub(super) storage: S,
     pub(super) crypto: RustCrypto,
-    pub(super) identity: I,
+    pub(super) credentials: Arc<MlsCredentials>,
     pub(super) group_id: String,
     pub(super) mls_group: RwLock<MlsGroup>,
     pub(super) pending_staged_commit: RwLock<Option<StagedCommit>>,
 }
 
-impl<S: DeMlsStorage, I: IdentityProvider> OpenMlsService<S, I> {
+impl<S: DeMlsStorage> OpenMlsService<S> {
     /// Create a fresh MLS group as the sole initial member ("creator").
-    pub fn new_as_creator(group_id: String, storage: S, identity: I) -> Result<Self, MlsError> {
+    pub fn new_as_creator(
+        group_id: String,
+        storage: S,
+        credentials: Arc<MlsCredentials>,
+    ) -> Result<Self, MlsError> {
         let crypto = RustCrypto::default();
         let group = {
             let provider = MlsProvider::new(&crypto, storage.mls_storage());
@@ -46,17 +51,17 @@ impl<S: DeMlsStorage, I: IdentityProvider> OpenMlsService<S, I> {
                 .build();
             MlsGroup::new_with_group_id(
                 &provider,
-                identity.signer(),
+                credentials.signer(),
                 &config,
                 GroupId::from_slice(group_id.as_bytes()),
-                identity.credential().clone(),
+                credentials.credential().clone(),
             )?
         };
 
         Ok(Self {
             storage,
             crypto,
-            identity,
+            credentials,
             group_id,
             mls_group: RwLock::new(group),
             pending_staged_commit: RwLock::new(None),
@@ -72,7 +77,7 @@ impl<S: DeMlsStorage, I: IdentityProvider> OpenMlsService<S, I> {
     pub fn new_from_welcome(
         welcome_bytes: &[u8],
         storage: S,
-        identity: I,
+        credentials: Arc<MlsCredentials>,
     ) -> Result<Option<Self>, MlsError> {
         let crypto = RustCrypto::default();
 
@@ -108,28 +113,31 @@ impl<S: DeMlsStorage, I: IdentityProvider> OpenMlsService<S, I> {
         Ok(Some(Self {
             storage,
             crypto,
-            identity,
+            credentials,
             group_id,
             mls_group: RwLock::new(group),
             pending_staged_commit: RwLock::new(None),
         }))
     }
 
-    /// Generate a single-use key package for `identity` backed by `storage`.
+    /// Generate a single-use key package for `credentials` backed by `storage`.
     ///
-    /// This intentionally takes only storage + identity rather than `&self`,
+    /// This intentionally takes only storage + credentials rather than `&self`,
     /// so a joiner can publish a key package before any MLS group has been
     /// created. The resulting hash ref is registered in `storage` so a
     /// later `new_from_welcome` can identify the welcome as "for us".
-    pub fn generate_key_package(storage: &S, identity: &I) -> Result<KeyPackageBytes, MlsError> {
+    pub fn generate_key_package(
+        storage: &S,
+        credentials: &MlsCredentials,
+    ) -> Result<KeyPackageBytes, MlsError> {
         let crypto = RustCrypto::default();
         let provider = MlsProvider::new(&crypto, storage.mls_storage());
 
         let kp_bundle = KeyPackage::builder().build(
             CIPHERSUITE,
             &provider,
-            identity.signer(),
-            identity.credential().clone(),
+            credentials.signer(),
+            credentials.credential().clone(),
         )?;
 
         let kp = kp_bundle.key_package();
@@ -138,9 +146,12 @@ impl<S: DeMlsStorage, I: IdentityProvider> OpenMlsService<S, I> {
 
         storage.store_key_package_ref(&hash_ref)?;
 
-        Ok(KeyPackageBytes::new(
-            bytes,
-            identity.identity_bytes().to_vec(),
-        ))
+        let identity_bytes = credentials
+            .credential()
+            .credential
+            .serialized_content()
+            .to_vec();
+
+        Ok(KeyPackageBytes::new(bytes, identity_bytes))
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,9 +21,9 @@ use de_mls::core::{
     process_inbound,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, OutboundPacket, WELCOME_SUBTOPIC};
+use de_mls::identity::{Identity, WalletIdentity, parse_wallet_address};
 use de_mls::mls_crypto::{
-    IdentityProvider, MemoryDeMlsStorage, MlsService, OpenMlsService, WalletIdentity,
-    key_package_bytes_from_json, parse_wallet_address,
+    MemoryDeMlsStorage, MlsCredentials, MlsService, OpenMlsService, key_package_bytes_from_json,
 };
 use de_mls::protos::de_mls::messages::v1::{
     AppMessage, GroupUpdateRequest, InviteMember, WelcomeMessage, group_update_request,
@@ -31,9 +31,11 @@ use de_mls::protos::de_mls::messages::v1::{
 };
 use prost::Message as _;
 
-/// Test-side MLS service: storage and identity are `Arc`-shared so a single
-/// helper can build many per-group services from one identity.
-pub type TestMls = OpenMlsService<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>;
+/// Test-side MLS service: storage is `Arc`-shared so a single helper can
+/// build many per-group services from one identity. MLS credentials live
+/// at the test-fixture level (one per identity), passed in via
+/// `Arc<MlsCredentials>`.
+pub type TestMls = OpenMlsService<Arc<MemoryDeMlsStorage>>;
 
 pub const DEFAULT_SCORE: i64 = 100;
 
@@ -132,13 +134,21 @@ pub fn default_steward_config() -> ProtocolConfig {
     ProtocolConfig::new(1, 5).unwrap()
 }
 
-/// Build a fresh identity + storage pair, both Arc-shared so a later helper
-/// can construct multiple per-group services from one logical identity.
-pub fn setup_identity_storage(wallet_hex: &str) -> (Arc<WalletIdentity>, Arc<MemoryDeMlsStorage>) {
+/// Build a fresh identity, MLS credentials, and storage. Both
+/// credentials and storage are `Arc`-shared so a later helper can
+/// construct multiple per-group services from one logical identity.
+pub fn setup_identity_storage(
+    wallet_hex: &str,
+) -> (
+    Arc<WalletIdentity>,
+    Arc<MlsCredentials>,
+    Arc<MemoryDeMlsStorage>,
+) {
     let wallet = parse_wallet_address(wallet_hex).unwrap();
-    let identity = Arc::new(WalletIdentity::from_wallet(wallet).unwrap());
+    let identity = Arc::new(WalletIdentity::from_wallet(wallet));
+    let credentials = Arc::new(MlsCredentials::from_identity(identity.as_ref()).unwrap());
     let storage = Arc::new(MemoryDeMlsStorage::new());
-    (identity, storage)
+    (identity, credentials, storage)
 }
 
 /// Build an [`OpenMlsService`] for a fresh group with a default test id.
@@ -153,8 +163,8 @@ pub fn setup_mls(wallet_hex: &str) -> TestMls {
 /// test asserts something about the MLS-tracked group id or when two
 /// services share a group.
 pub fn setup_mls_for_group(group_name: &str, wallet_hex: &str) -> TestMls {
-    let (identity, storage) = setup_identity_storage(wallet_hex);
-    OpenMlsService::new_as_creator(group_name.to_string(), storage, identity).unwrap()
+    let (_, credentials, storage) = setup_identity_storage(wallet_hex);
+    OpenMlsService::new_as_creator(group_name.to_string(), storage, credentials).unwrap()
 }
 
 /// Compat shim that mirrors the pre-refactor `core::process_inbound`
@@ -220,19 +230,20 @@ pub fn setup_steward_with_config(
     wallet_hex: &str,
     config: ProtocolConfig,
 ) -> Group<TestMls> {
-    let (identity, storage) = setup_identity_storage(wallet_hex);
+    let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
     let mls =
-        OpenMlsService::new_as_creator(group_name.to_string(), storage, Arc::clone(&identity))
+        OpenMlsService::new_as_creator(group_name.to_string(), storage, Arc::clone(&credentials))
             .unwrap();
     Group::create_group(group_name, identity.identity_bytes().to_vec(), config, mls).unwrap()
 }
 
 /// Pre-join handle for a joiner: the joiner has no MLS service yet (they
-/// haven't accepted a welcome), so test code keeps `identity` and `storage`
-/// to build one via [`OpenMlsService::new_from_welcome`] when a welcome
-/// arrives. KP generation uses the same storage/identity pair.
+/// haven't accepted a welcome), so test code keeps `credentials` and
+/// `storage` to build one via [`OpenMlsService::new_from_welcome`] when a
+/// welcome arrives. KP generation uses the same storage/credentials pair.
 pub struct JoinerHandle {
     pub identity: Arc<WalletIdentity>,
+    pub credentials: Arc<MlsCredentials>,
     pub storage: Arc<MemoryDeMlsStorage>,
     pub group: Group<TestMls>,
     pub kp_packet: OutboundPacket,
@@ -249,7 +260,7 @@ impl JoinerHandle {
         OpenMlsService::new_from_welcome(
             welcome_bytes,
             Arc::clone(&self.storage),
-            Arc::clone(&self.identity),
+            Arc::clone(&self.credentials),
         )
     }
 
@@ -280,17 +291,16 @@ pub fn setup_joiner_with_config(
     wallet_hex: &str,
     config: ProtocolConfig,
 ) -> JoinerHandle {
-    let (identity, storage) = setup_identity_storage(wallet_hex);
+    let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
     let group: Group<TestMls> =
         Group::prepare_to_join(group_name, identity.identity_bytes().to_vec(), config);
     let key_package =
-        OpenMlsService::<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>::generate_key_package(
-            &storage, &identity,
-        )
-        .unwrap();
+        OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(&storage, &credentials)
+            .unwrap();
     let kp_packet = build_key_package_message(group_name, key_package, b"test-app-id");
     JoinerHandle {
         identity,
+        credentials,
         storage,
         group,
         kp_packet,

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -14,10 +14,8 @@ use de_mls::core::{
     build_key_package_message, create_commit_candidate, finalize_freeze_round, group_members,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC};
-use de_mls::mls_crypto::{
-    IdentityProvider, MemoryDeMlsStorage, MlsService, OpenMlsService, WalletIdentity,
-    parse_wallet_address,
-};
+use de_mls::identity::{Identity, parse_wallet_address};
+use de_mls::mls_crypto::{MemoryDeMlsStorage, MlsService, OpenMlsService};
 use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationMessage, GroupUpdateRequest, app_message,
 };
@@ -45,7 +43,7 @@ fn test_process_inbound_invalid_subtopic() {
 #[test]
 fn test_process_inbound_app_msg_before_mls_init() {
     // Joiner-side handle with no MLS service attached yet.
-    let (identity, _storage): (Arc<WalletIdentity>, Arc<MemoryDeMlsStorage>) =
+    let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     let mut group: Group<TestMls> = Group::prepare_to_join(
         "test-group",
@@ -127,7 +125,7 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
 
     // Joiner-side handle with no MLS yet — the key-package surfaces all the
     // same; promotion to a voting proposal is the app's decision.
-    let (identity, _storage): (Arc<WalletIdentity>, Arc<MemoryDeMlsStorage>) =
+    let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     let mut group: Group<TestMls> = Group::prepare_to_join(
         group_name,
@@ -338,12 +336,11 @@ fn test_rejoin_after_eviction() {
         joiner.identity.identity_bytes().to_vec(),
         default_steward_config(),
     );
-    let key_package =
-        OpenMlsService::<Arc<MemoryDeMlsStorage>, Arc<WalletIdentity>>::generate_key_package(
-            &joiner.storage,
-            &joiner.identity,
-        )
-        .unwrap();
+    let key_package = OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(
+        &joiner.storage,
+        &joiner.credentials,
+    )
+    .unwrap();
     let kp_packet = build_key_package_message(group_name, key_package, b"test-app-id");
     let (welcome_packet, _) = steward_add_joiner(&mut steward_handle, &kp_packet);
 
@@ -361,7 +358,7 @@ fn test_rejoin_after_eviction() {
     let svc = OpenMlsService::new_from_welcome(
         &invitation.mls_message_out_bytes,
         Arc::clone(&joiner.storage),
-        Arc::clone(&joiner.identity),
+        Arc::clone(&joiner.credentials),
     )
     .unwrap()
     .expect("welcome should match this joiner's fresh KP");

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -62,8 +62,14 @@ const BOB_KEY: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6
 const CHARLIE_KEY: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const DAVE_KEY: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
-type TU =
-    User<DefaultProvider, de_mls::app::DefaultMlsService, de_mls::app::DefaultPeerScoring, H, SH>;
+type TU = User<
+    DefaultProvider,
+    de_mls::app::DefaultMlsService,
+    de_mls::app::DefaultPeerScoring,
+    de_mls::identity::WalletIdentity,
+    H,
+    SH,
+>;
 
 fn make(key: &str, cs: Arc<DefaultConsensusService>, cfg: GroupConfig) -> (TU, H) {
     let h = H::new();


### PR DESCRIPTION
Decouples user identity from MLS-internal state so a custom `Identity` impl plugs in without touching the MLS engine, mirroring libchat's `MlsContext` shape. Identity is now pure user-level (`identity_bytes` +
`identity_display`); MLS-specific signing keypair + credential live in their own `MlsCredentials` bundle, built once per user from the identity at User init and shared across every per-group `MlsService` via
`Arc<MlsCredentials>`.

- `Identity` trait moves to top-level `src/identity.rs`. Two methods only — no OpenMLS types in the surface. `WalletIdentity` (slim — wallet bytes + checksummed hex) is the default impl. The wallet utilities
(`parse_wallet_address`, `format_wallet_address`, `parse_wallet_to_bytes`, `ShortId`) move with it since they're identity-related, not MLS-coupled.
- `MlsCredentials` (new, `src/mls_crypto/credentials.rs`) bundles `CredentialWithKey` + `SignatureKeyPair`. Built via `MlsCredentials::from_identity::<I: Identity>(identity)` — works with any `Identity` impl, no
`WalletIdentity` dependency. User-level shared (matches libchat's `MlsContext::get_credential` per `plugin-tree-architecture.md`), not per-group.
- `OpenMlsService<S, I>` becomes `OpenMlsService<S>`; the identity generic disappears entirely. `MlsService` trait drops `type Identity` + `identity()` — the trait was previously the only place those leaked.
Three places that previously read `mls.identity()` now read `group.self_identity()`.
- `User<P, M, Sc, H, SCH>` becomes `User<P, M, Sc, I, H, SCH>` with `I: Identity` independent of the MLS generic. The convenience `with_private_key_and_config` binds `I = WalletIdentity`. Three new unit tests
cover the load-bearing `MlsCredentials::from_identity` invariants (serialized content matches identity bytes, fresh keypair per call, credential `signature_key` matches signer public).