### PR TITLE
refactor(mls): MlsService on GroupEntry, Group generic-free

### DIFF
--- a/src/app/consensus_bridge.rs
+++ b/src/app/consensus_bridge.rs
@@ -20,7 +20,6 @@ use crate::{
         CoreError, DeMlsProvider, Group, GroupEventHandler, ProviderConsensus,
         auto_approved_leave_proposal_id, build_create_proposal_request,
     },
-    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         AppMessage, GroupUpdateRequest, RemoveMember, VotePayload, group_update_request,
     },
@@ -164,8 +163,8 @@ pub async fn forward_incoming_proposal<P: DeMlsProvider>(
 ///   swallow the error so inbound dispatch keeps draining.
 ///
 /// Other consensus errors propagate.
-pub async fn forward_incoming_vote<P: DeMlsProvider, M: MlsService>(
-    group: &Group<M>,
+pub async fn forward_incoming_vote<P: DeMlsProvider>(
+    group: &Group,
     vote: Vote,
     consensus: &ProviderConsensus<P>,
 ) -> Result<(), CoreError> {

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     core::{
         DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProposalKind, StewardListPlugin,
-        group_members, target_identity_of,
+        target_identity_of,
     },
     identity::Identity,
     mls_crypto::MlsService,
@@ -88,8 +88,8 @@ impl<
             }
         }
 
-        entry.group.expect_mls()?;
-        let members = group_members(&entry.group)?;
+        entry.expect_mls()?;
+        let members = entry.group_members()?;
         Ok(members.len() as u32)
     }
 
@@ -257,10 +257,7 @@ impl<
                 .await
                 .ok_or(UserError::GroupNotFound)?;
             let entry = entry_arc.read().await;
-            entry
-                .group
-                .expect_mls()?
-                .build_message(&outbound, &self.app_id)?
+            entry.expect_mls()?.build_message(&outbound, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
 
@@ -374,9 +371,9 @@ impl<
         let (pending_join, members_for_rotation, current_epoch) = {
             let entry = entry_arc.read().await;
             let pending = entry.state_machine.current_state() == GroupState::PendingJoin;
-            match (pending, entry.group.mls()) {
+            match (pending, entry.mls()) {
                 (true, _) | (false, None) => (pending, Vec::new(), 0u64),
-                (false, Some(mls)) => (false, group_members(&entry.group)?, mls.current_epoch()?),
+                (false, Some(mls)) => (false, entry.group_members()?, mls.current_epoch()?),
             }
         };
         if pending_join {
@@ -468,10 +465,7 @@ impl<
         .await?;
         let packet = {
             let entry = entry_arc.read().await;
-            entry
-                .group
-                .expect_mls()?
-                .build_message(&app_message, &app_id)?
+            entry.expect_mls()?.build_message(&app_message, &app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())
@@ -584,7 +578,6 @@ impl<
         let packet = {
             let entry = entry_arc.read().await;
             entry
-                .group
                 .expect_mls()?
                 .build_message(&app_message, &self.app_id)?
         };

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -180,7 +180,7 @@ impl<
 
         let is_valid = {
             let entry = entry_arc.read().await;
-            entry.group.expect_mls()?;
+            entry.expect_mls()?;
             // Election proposals carry the candidate pool implicitly:
             // `proposed_stewards` is the full set the proposer sorted, so
             // `candidate_pool == proposed_stewards` for validation.

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -97,7 +97,7 @@ impl<
 
         let (finalize_result, downward_cross) = {
             let mut entry = entry_arc.write().await;
-            let allow_subset = entry.group.allow_subset_candidates();
+            let allow_subset = entry.steward.config().allow_subset_candidates;
             let result = if entry.mls().is_some() {
                 match entry.finalize_freeze_round(allow_subset, &self.app_id) {
                     Ok(result) => result,

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -3,11 +3,10 @@
 use tracing::{error, info};
 
 use crate::{
-    app::{FreezeTimeoutStatus, GroupState, StateChangeHandler, User, UserError, user::GroupEntry},
+    app::{FreezeTimeoutStatus, GroupState, StateChangeHandler, User, UserError},
     core::{
         DeMlsProvider, FreezeFinalizeResult, FreezeOutcome, GroupEventHandler, PeerScoringPlugin,
-        ScoreEvent, ScoreOp, StewardListPlugin, create_commit_candidate, finalize_freeze_round,
-        group_members,
+        ScoreEvent, ScoreOp, StewardListPlugin,
     },
     ds::WELCOME_SUBTOPIC,
     identity::Identity,
@@ -99,9 +98,8 @@ impl<
         let (finalize_result, downward_cross) = {
             let mut entry = entry_arc.write().await;
             let allow_subset = entry.group.allow_subset_candidates();
-            let result = if entry.group.mls().is_some() {
-                let GroupEntry { group, steward, .. } = &mut *entry;
-                match finalize_freeze_round(group, steward, allow_subset, &self.app_id) {
+            let result = if entry.mls().is_some() {
+                match entry.finalize_freeze_round(allow_subset, &self.app_id) {
                     Ok(result) => result,
                     Err(e) => {
                         error!(group = group_name, error = %e, "freeze finalize failed");
@@ -183,11 +181,11 @@ impl<
                         // the same event independently; threshold-crossing
                         // removal still goes through SCORE_BELOW_THRESHOLD
                         // consensus in steward.rs.
-                        let accuse_target = match entry.group.mls() {
+                        let accuse_target = match entry.mls() {
                             Some(mls) => {
                                 let violation_epoch = mls.current_epoch()?;
                                 let self_identity = self.identity().identity_bytes();
-                                let members = group_members(&entry.group)?;
+                                let members = entry.group_members()?;
                                 let eligible = entry.group.steward_eligibility(&members);
                                 entry
                                     .steward
@@ -274,7 +272,7 @@ impl<
             .state_machine
             .check_steward_inactivity(proposal_count, inactivity);
         if entered_freezing {
-            let epoch = entry.group.expect_mls()?.current_epoch()?;
+            let epoch = entry.expect_mls()?.current_epoch()?;
             entry.group.ensure_freeze_round(epoch);
 
             // Stewards build their own candidate under the same lock.
@@ -282,8 +280,7 @@ impl<
             // peers' candidates still get processed.
             let self_identity = self.identity().identity_bytes().to_vec();
             let outbound = if entry.steward.is_steward(&self_identity) {
-                let GroupEntry { group, steward, .. } = &mut *entry;
-                match create_commit_candidate(group, steward, &self_identity, &self.app_id) {
+                match entry.create_commit_candidate(&self_identity, &self.app_id) {
                     Ok(packets) => packets,
                     Err(e) => {
                         error!(

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -376,14 +376,13 @@ impl<
         };
         let mut entry = entry_arc.write().await;
         let sn = sync.steward_members.len();
-        entry.steward.set_config(protocol_config.clone());
+        entry.steward.set_config(protocol_config);
         let _events = entry.steward.install_list(
             sync.election_epoch,
             &sync.steward_members,
             sn,
             sync.retry_round,
         )?;
-        entry.group.set_protocol_config(protocol_config);
         entry.steward.set_max_retries(sync.max_reelection_attempts);
         entry.scoring.set_threshold(sync.threshold_peer_score);
         let snapshot = ScoreSnapshot {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -7,12 +7,11 @@ use tracing::{error, info};
 use crate::{
     app::{
         GroupState, StateChangeHandler, User, UserError, forward_incoming_proposal,
-        forward_incoming_vote, user::GroupEntry,
+        forward_incoming_vote,
     },
     core::{
         DeMlsProvider, GroupEventHandler, PeerScoringPlugin, ProcessResult, ProposalKind,
-        ScoreSnapshot, StewardList, StewardListConfig, StewardListPlugin, create_commit_candidate,
-        group_members, member_set, process_inbound,
+        ScoreSnapshot, StewardList, StewardListConfig, StewardListPlugin, member_set,
     },
     ds::{APP_MSG_SUBTOPIC, InboundPacket, WELCOME_SUBTOPIC},
     identity::{Identity, ShortId},
@@ -53,7 +52,7 @@ impl<
                     .await
                     .ok_or(UserError::GroupNotFound)?;
                 let entry = entry_arc.read().await;
-                forward_incoming_vote::<P, M>(&entry.group, vote, &*self.consensus_service).await?;
+                forward_incoming_vote::<P>(&entry.group, vote, &*self.consensus_service).await?;
                 Ok(())
             }
             ProcessResult::MembershipChangeReceived(request) => {
@@ -92,7 +91,7 @@ impl<
             && let Some(entry_arc) = self.lookup_entry(group_name).await
         {
             let mut entry = entry_arc.write().await;
-            let current_epoch = match entry.group.mls() {
+            let current_epoch = match entry.mls() {
                 Some(mls) => mls.current_epoch()?,
                 None => 0,
             };
@@ -163,9 +162,9 @@ impl<
         };
         let (packet, mls_members) = {
             let entry = entry_arc.read().await;
-            let mls = entry.group.expect_mls()?;
+            let mls = entry.expect_mls()?;
             let packet = mls.build_message(&msg, &self.app_id)?;
-            let members = group_members(&entry.group).unwrap_or_default();
+            let members = entry.group_members().unwrap_or_default();
             (packet, members)
         };
         self.handler.on_outbound(name, packet).await?;
@@ -189,8 +188,8 @@ impl<
         if let Some(entry_arc) = self.lookup_entry(group_name).await {
             let mls_members = {
                 let entry = entry_arc.read().await;
-                if entry.group.mls().is_some() {
-                    group_members(&entry.group).unwrap_or_default()
+                if entry.mls().is_some() {
+                    entry.group_members().unwrap_or_default()
                 } else {
                     Vec::new()
                 }
@@ -264,7 +263,7 @@ impl<
             // of the Group so its `delete()` runs before the entry drops.
             // Per-group scoring is dropped when the entry leaves the
             // registry below.
-            if let Some(mls) = entry.write().await.group.take_mls() {
+            if let Some(mls) = entry.write().await.take_mls() {
                 let _ = mls.delete();
             }
         }
@@ -287,13 +286,12 @@ impl<
             }
 
             entry.state_machine.start_freezing();
-            let epoch = entry.group.expect_mls()?.current_epoch()?;
+            let epoch = entry.expect_mls()?.current_epoch()?;
             entry.group.ensure_freeze_round(epoch);
 
             let self_identity = self.identity().identity_bytes().to_vec();
             let outbound = if entry.steward.is_steward(&self_identity) {
-                let GroupEntry { group, steward, .. } = &mut *entry;
-                match create_commit_candidate(group, steward, &self_identity, &self.app_id) {
+                match entry.create_commit_candidate(&self_identity, &self.app_id) {
                     Ok(packets) => packets,
                     Err(e) => {
                         error!(
@@ -335,8 +333,8 @@ impl<
             if entry.steward.current_list().is_some() {
                 return Ok(());
             }
-            let mls = entry.group.expect_mls()?;
-            (group_members(&entry.group)?, mls.current_epoch()?)
+            let mls = entry.expect_mls()?;
+            (entry.group_members()?, mls.current_epoch()?)
         };
         let local_default_peer_score = self.default_group_config.default_peer_score;
         if !validate_group_sync(
@@ -446,11 +444,11 @@ impl<
             APP_MSG_SUBTOPIC => {
                 let result = {
                     let mut entry = entry_arc.write().await;
-                    if entry.group.mls().is_none() {
+                    if entry.mls().is_none() {
                         // App messages on a group we haven't joined yet → ignore.
                         return Ok(());
                     }
-                    process_inbound(&mut entry.group, &packet.payload)?
+                    entry.process_inbound(&packet.payload)?
                 };
                 self.dispatch_inbound_result(&group_name, result).await
             }
@@ -483,11 +481,7 @@ impl<
                     .ok_or(UserError::GroupNotFound)?;
                 let already_member = {
                     let entry = entry_arc.read().await;
-                    entry
-                        .group
-                        .mls()
-                        .map(|m| m.is_member(&identity))
-                        .unwrap_or(false)
+                    entry.mls().map(|m| m.is_member(&identity)).unwrap_or(false)
                 };
                 if already_member {
                     info!(
@@ -520,7 +514,7 @@ impl<
                 let self_id = self.identity().identity_bytes().to_vec();
                 let already_in = {
                     let entry = entry_arc.read().await;
-                    entry.steward.is_steward(&self_id) || entry.group.mls().is_some()
+                    entry.steward.is_steward(&self_id) || entry.mls().is_some()
                 };
                 if already_in {
                     return Ok(());
@@ -534,7 +528,7 @@ impl<
                 let joined_name = svc.group_id().to_string();
                 {
                     let mut entry = entry_arc.write().await;
-                    entry.group.attach_mls(svc);
+                    entry.attach_mls(svc);
                 }
                 info!(group = group_name, "joined group via welcome");
                 self.dispatch_inbound_result(

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -58,19 +58,11 @@ impl<
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
         let (mut group, mls_opt, state_machine) = if is_creation {
             let mls = (self.mls_creator_factory)(group_name.to_string())?;
-            let group = Group::create_group(
-                group_name,
-                self_identity_bytes.clone(),
-                config.protocol.clone(),
-            );
+            let group = Group::create_group(group_name, self_identity_bytes.clone());
             let state_machine = GroupStateMachine::new_as_member_with_config(config.clone());
             (group, Some(mls), state_machine)
         } else {
-            let group = Group::prepare_to_join(
-                group_name,
-                self_identity_bytes.clone(),
-                config.protocol.clone(),
-            );
+            let group = Group::prepare_to_join(group_name, self_identity_bytes.clone());
             let state_machine = GroupStateMachine::new_as_pending_join_with_config(config.clone());
             (group, None, state_machine)
         };

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -56,24 +56,23 @@ impl<
         let liveness_criteria_yes = config.liveness_criteria_yes;
         let pending_update_max_epochs = config.pending_update_max_epochs;
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
-        let (mut group, state_machine) = if is_creation {
+        let (mut group, mls_opt, state_machine) = if is_creation {
             let mls = (self.mls_creator_factory)(group_name.to_string())?;
             let group = Group::create_group(
                 group_name,
                 self_identity_bytes.clone(),
                 config.protocol.clone(),
-                mls,
             );
             let state_machine = GroupStateMachine::new_as_member_with_config(config.clone());
-            (group, state_machine)
+            (group, Some(mls), state_machine)
         } else {
-            let group: Group<M> = Group::prepare_to_join(
+            let group = Group::prepare_to_join(
                 group_name,
                 self_identity_bytes.clone(),
                 config.protocol.clone(),
             );
             let state_machine = GroupStateMachine::new_as_pending_join_with_config(config.clone());
-            (group, state_machine)
+            (group, None, state_machine)
         };
         group.set_liveness_criteria_yes(liveness_criteria_yes);
         group.set_pending_update_max_epochs(pending_update_max_epochs);
@@ -108,6 +107,7 @@ impl<
             group_name.to_string(),
             Arc::new(RwLock::new(GroupEntry::new(
                 group,
+                mls_opt,
                 state_machine,
                 scoring,
                 steward,
@@ -211,10 +211,7 @@ impl<
                 .await
                 .ok_or(UserError::GroupNotFound)?;
             let entry = entry_arc.read().await;
-            entry
-                .group
-                .expect_mls()?
-                .build_message(&app_msg, &self.app_id)?
+            entry.expect_mls()?.build_message(&app_msg, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
 

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -70,10 +70,7 @@ impl<
             }
             .into();
 
-            entry
-                .group
-                .expect_mls()?
-                .build_message(&app_msg, &self.app_id)?
+            entry.expect_mls()?.build_message(&app_msg, &self.app_id)?
         };
         self.handler.on_outbound(group_name, packet).await?;
         Ok(())

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -18,7 +18,9 @@ use std::{
 
 use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::storage::ConsensusStorage;
+use prost::Message;
 use tokio::{sync::RwLock, task::JoinHandle};
+use tracing::info;
 
 use crate::{
     app::{
@@ -26,15 +28,21 @@ use crate::{
         StateChangeHandler, UserError,
     },
     core::{
-        DeMlsProvider, DefaultProvider, DeterministicStewardList, Group, GroupEventHandler,
-        PeerScoringEvent, PeerScoringPlugin, PeerScoringService, ProposalId, ProviderConsensus,
-        ScoringConfig, StewardListConfig, StewardListPlugin,
+        BufferedCommitCandidate, CoreError, DeMlsProvider, DefaultProvider,
+        DeterministicStewardList, FreezeFinalizeResult, Group, GroupEventHandler, PeerScoringEvent,
+        PeerScoringPlugin, PeerScoringService, ProcessResult, ProposalId, ProposalKind,
+        ProviderConsensus, ScoringConfig, StewardListConfig, StewardListPlugin,
+        compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
     },
+    ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     identity::{Identity, WalletIdentity},
     mls_crypto::{
-        KeyPackageBytes, MemoryDeMlsStorage, MlsCredentials, MlsError, MlsService, OpenMlsService,
+        CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MemoryDeMlsStorage, MlsCommitInput,
+        MlsCredentials, MlsError, MlsService, OpenMlsService,
     },
-    protos::de_mls::messages::v1::GroupUpdateRequest,
+    protos::de_mls::messages::v1::{
+        AppMessage, CommitCandidate, GroupUpdateRequest, group_update_request::Payload,
+    },
 };
 
 mod consensus;
@@ -51,11 +59,11 @@ mod steward;
 const MAX_EPOCH_HISTORY: usize = 10;
 
 pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> {
-    /// `Group<M>` owns the per-group MLS service inside its own
-    /// `Option<M>` slot — joiners in `PendingJoin` carry `None` until a
-    /// welcome arrives, at which point the User attaches the service via
-    /// [`Group::attach_mls`].
-    group: Group<M>,
+    group: Group,
+    /// Per-group MLS service. `None` for joiners in `PendingJoin` who
+    /// haven't accepted a welcome yet; once attached via
+    /// [`Self::attach_mls`] it stays `Some` for the entry's lifetime.
+    mls: Option<M>,
     state_machine: GroupStateMachine,
     /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
@@ -74,21 +82,241 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
 }
 
 impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, Sc, St> {
-    /// Build a fresh entry. Internal-only auxiliary state (epoch
-    /// history, future per-entry caches) starts empty.
+    /// Build a fresh entry. Creator path passes `Some(mls)`; joiner
+    /// path passes `None` and attaches later via [`Self::attach_mls`].
     pub(crate) fn new(
-        group: Group<M>,
+        group: Group,
+        mls: Option<M>,
         state_machine: GroupStateMachine,
         scoring: Sc,
         steward: St,
     ) -> Self {
         Self {
             group,
+            mls,
             state_machine,
             scoring,
             steward,
             epoch_history: VecDeque::new(),
         }
+    }
+
+    /// Borrow the MLS service, if attached. `None` for joiners
+    /// pre-welcome.
+    pub(crate) fn mls(&self) -> Option<&M> {
+        self.mls.as_ref()
+    }
+
+    /// Borrow the MLS service, erroring with
+    /// [`crate::core::CoreError::MlsGroupNotInitialized`] when not
+    /// attached. Use this in code paths where the service must be
+    /// present so the `?` chain stays linear.
+    pub(crate) fn expect_mls(&self) -> Result<&M, crate::core::CoreError> {
+        self.mls
+            .as_ref()
+            .ok_or(crate::core::CoreError::MlsGroupNotInitialized)
+    }
+
+    /// Attach an MLS service. Called by joiners after the welcome
+    /// arrives. Caller is responsible for not double-attaching.
+    pub(crate) fn attach_mls(&mut self, mls: M) {
+        self.mls = Some(mls);
+    }
+
+    /// Drop the attached MLS service and return it. Used on group leave
+    /// so the caller can run service-side cleanup (`mls.delete()`).
+    pub(crate) fn take_mls(&mut self) -> Option<M> {
+        self.mls.take()
+    }
+
+    // ── Protocol-function wrappers ─────────────────────────────────
+    //
+    // Pull `group`, `mls`, and `steward` from `self` so coordinator
+    // callsites don't destructure the entry. Protocol logic stays in
+    // `core::api`; these are pure delegation.
+
+    /// Current MLS members; empty when no service is attached
+    /// (joiner pre-welcome).
+    pub(crate) fn group_members(&self) -> Result<Vec<Vec<u8>>, CoreError> {
+        match &self.mls {
+            Some(mls) => Ok(mls.members()?),
+            None => Err(CoreError::MlsGroupNotInitialized),
+        }
+    }
+
+    /// Build a commit candidate. Errors with
+    /// [`CoreError::MlsGroupNotInitialized`] when no MLS service is
+    /// attached.
+    pub(crate) fn create_commit_candidate(
+        &mut self,
+        self_identity: &[u8],
+        app_id: &[u8],
+    ) -> Result<Option<OutboundPacket>, CoreError> {
+        let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
+        if !self.steward.is_steward(self_identity) && !self.group.is_in_recovery_mode() {
+            return Err(CoreError::NotASteward);
+        }
+
+        if self.group.approved_proposals().is_empty() {
+            return Err(CoreError::NoProposals);
+        }
+
+        // MLS forbids committing one's own removal. If the approved batch contains
+        // RemoveMember(self), skip local candidate creation — another steward will
+        // commit the batch (including this node's removal) once they enter freeze.
+        let self_removal_pending = self.group.approved_proposals().values().any(|req| {
+            matches!(
+                req.payload.as_ref(),
+                Some(Payload::RemoveMember(r))
+                    if r.identity == self_identity
+            )
+        });
+        if self_removal_pending {
+            info!(
+                group = self.group.group_name(),
+                "commit candidate skipped: approved batch contains self-remove"
+            );
+            return Ok(None);
+        }
+
+        // Governance proposals (emergency, election) are consensus-only and must
+        // not be in the approved queue at batch creation time.
+        let non_mls_ids: Vec<u32> = self
+            .group
+            .approved_proposals()
+            .iter()
+            .filter(|(_, req)| ProposalKind::of(req).is_governance())
+            .map(|(&id, _)| id)
+            .collect();
+
+        if !non_mls_ids.is_empty() {
+            return Err(CoreError::UnexpectedNonMlsProposals {
+                proposal_ids: non_mls_ids,
+            });
+        }
+
+        // Drop approved entries already reflected in group state (stale
+        // rebroadcast KPs, duplicate removes) — without this MLS would reject
+        // the whole batch with "Duplicate signature key in proposals and group".
+        let current_members = mls.members()?;
+        let current_members_set = member_set(&current_members);
+        let is_member = |id: &[u8]| current_members_set.contains(id);
+
+        // Urgent (ECP-driven) freeze: restrict the batch to just the target's
+        // RemoveMember. See `Group::urgent_commit_target`.
+        let urgent_target = self.group.urgent_commit_target().map(|t| t.to_vec());
+
+        // Iterate in insertion order (FIFO): library proposal IDs are
+        // content-derived hashes, so sort-by-id is not temporal.
+        let k_max = mls.commit_batch_max();
+        let mut updates = Vec::with_capacity(self.group.approved_order().len().min(k_max));
+        for pid in self.group.approved_order() {
+            if updates.len() >= k_max {
+                break;
+            }
+            let Some(proposal) = self.group.approved_proposals().get(pid) else {
+                continue;
+            };
+            match proposal.payload.as_ref() {
+                Some(Payload::InviteMember(im)) => {
+                    if urgent_target.is_some() {
+                        continue;
+                    }
+                    if is_member(&im.identity) {
+                        continue;
+                    }
+                    updates.push(MlsCommitInput::Add(KeyPackageBytes::new(
+                        im.key_package_bytes.clone(),
+                        im.identity.clone(),
+                    )));
+                }
+                Some(Payload::RemoveMember(rm)) => {
+                    if let Some(target) = urgent_target.as_deref()
+                        && rm.identity != target
+                    {
+                        continue;
+                    }
+                    if !is_member(&rm.identity) {
+                        continue;
+                    }
+                    updates.push(MlsCommitInput::Remove(rm.identity.clone()));
+                }
+                _ => return Err(CoreError::InvalidGroupUpdateRequest),
+            }
+        }
+
+        if updates.is_empty() {
+            return Ok(None);
+        }
+
+        let MlsCommitCandidate {
+            proposals: mls_proposals,
+            commit,
+            welcome,
+        } = mls.create_commit_candidate(&updates)?;
+
+        let candidate = CommitCandidate {
+            group_name: self.group.group_name_bytes().to_vec(),
+            mls_proposals,
+            commit_message: commit,
+            steward_identity: self_identity.to_vec(),
+        };
+
+        // Welcome bytes are deferred: sent from finalize_freeze_round after the
+        // commit merges, so joiners can't advance epoch ahead of the steward.
+        let commit_hash = compute_commit_hash(&candidate.commit_message);
+        let epoch = mls.current_epoch()?;
+        let _ = self.group.add_freeze_candidate(
+            BufferedCommitCandidate {
+                candidate_msg: candidate.clone(),
+                commit_hash,
+                is_local_candidate: true,
+                welcome_bytes: welcome,
+            },
+            epoch,
+        );
+
+        info!(
+            group = self.group.group_name(),
+            epoch,
+            proposals = updates.len(),
+            "commit candidate created"
+        );
+
+        let candidate_msg: AppMessage = candidate.into();
+        Ok(Some(OutboundPacket::new(
+            candidate_msg.encode_to_vec(),
+            APP_MSG_SUBTOPIC,
+            self.group.group_name(),
+            app_id,
+        )))
+        // create_commit_candidate(&mut self.group, mls, &self.steward, self_identity, app_id)
+    }
+
+    /// Finalize the active freeze round. Errors with
+    /// [`CoreError::MlsGroupNotInitialized`] when no MLS service is
+    /// attached.
+    pub(crate) fn finalize_freeze_round(
+        &mut self,
+        allow_subset_candidates: bool,
+        app_id: &[u8],
+    ) -> Result<FreezeFinalizeResult, CoreError> {
+        let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
+        finalize_freeze_round(
+            &mut self.group,
+            mls,
+            &self.steward,
+            allow_subset_candidates,
+            app_id,
+        )
+    }
+
+    /// Process an inbound app-subtopic payload. Errors with
+    /// [`CoreError::MlsGroupNotInitialized`] when no MLS service is
+    /// attached — caller should check `mls().is_some()` first.
+    pub(crate) fn process_inbound(&mut self, payload: &[u8]) -> Result<ProcessResult, CoreError> {
+        let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
+        process_inbound(&mut self.group, mls, payload)
     }
 
     /// Append a just-committed batch to the bounded UI history.

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     app::{GroupState, MemberRole, StateChangeHandler, User, UserError},
-    core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, StewardListPlugin, group_members},
+    core::{DeMlsProvider, GroupEventHandler, PeerScoringPlugin, StewardListPlugin},
     identity::{Identity, format_wallet_address},
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::GroupUpdateRequest,
@@ -32,7 +32,7 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        let epoch = match entry.group.mls() {
+        let epoch = match entry.mls() {
             Some(mls) => mls.current_epoch()?,
             None => 0,
         };
@@ -80,10 +80,10 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        if entry.group.mls().is_none() {
+        if entry.mls().is_none() {
             return Ok(Vec::new());
         }
-        let members = group_members(&entry.group)?;
+        let members = entry.group_members()?;
         Ok(members
             .into_iter()
             .map(|raw| format_wallet_address(raw.as_slice()).to_string())
@@ -114,8 +114,8 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        entry.group.expect_mls()?;
-        let members = group_members(&entry.group)?;
+        entry.expect_mls()?;
+        let members = entry.group_members()?;
         Ok(members
             .into_iter()
             .filter(|id| entry.group.is_pending_self_leave(id))
@@ -133,9 +133,9 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        let mls = entry.group.expect_mls()?;
+        let mls = entry.expect_mls()?;
         let epoch = mls.current_epoch()?;
-        let members = group_members(&entry.group)?;
+        let members = entry.group_members()?;
 
         let eligible = entry.group.steward_eligibility(&members);
         let (live_epoch, live_backup) = entry.steward.epoch_and_backup(epoch, &eligible);

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -7,7 +7,7 @@ use crate::{
     app::{StateChangeHandler, User, UserError},
     core::{
         DeMlsProvider, ElectionDecision, GroupEventHandler, PeerScoringPlugin, StewardListPlugin,
-        group_members, member_set, scoring_member_diff, target_identity_of,
+        member_set, scoring_member_diff, target_identity_of,
     },
     identity::{Identity, ShortId},
     mls_crypto::MlsService,
@@ -64,9 +64,9 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let mut entry = entry_arc.write().await;
-        let mls = entry.group.expect_mls()?;
+        let mls = entry.expect_mls()?;
         let epoch = mls.current_epoch()?;
-        let members = group_members(&entry.group)?;
+        let members = entry.group_members()?;
         let _events = entry.steward.maybe_auto_fill(epoch, &members)?;
         Ok(())
     }
@@ -90,9 +90,9 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let (proposed_stewards, election_epoch, retry_round) = {
             let entry = entry_arc.read().await;
-            let mls = entry.group.expect_mls()?;
+            let mls = entry.expect_mls()?;
             let epoch = mls.current_epoch()?;
-            let mls_members = group_members(&entry.group)?;
+            let mls_members = entry.group_members()?;
             let self_identity = self.identity().identity_bytes();
 
             // `has_election_in_flight` is a proposal-queue check, not a
@@ -182,8 +182,8 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let (is_authorized, self_id, epoch) = {
             let entry = entry_arc.read().await;
-            let mls = entry.group.expect_mls()?;
-            let mls_members = group_members(&entry.group)?;
+            let mls = entry.expect_mls()?;
+            let mls_members = entry.group_members()?;
             let self_id = self.identity().identity_bytes();
             // Deadlock proposer = election proposer with the stricter
             // predicate (MLS-present and not queued for removal).
@@ -242,9 +242,9 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let (current_epoch, members) = {
             let entry = entry_arc.read().await;
-            let mls = entry.group.expect_mls()?;
+            let mls = entry.expect_mls()?;
             let current_epoch = mls.current_epoch()?;
-            let members = group_members(&entry.group)?;
+            let members = entry.group_members()?;
             (current_epoch, members)
         };
 
@@ -268,12 +268,12 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let (current_epoch, members, max_age) = {
             let entry = entry_arc.read().await;
-            let Some(mls) = entry.group.mls() else {
+            let Some(mls) = entry.mls() else {
                 return Ok(());
             };
             (
                 mls.current_epoch()?,
-                group_members(&entry.group)?,
+                entry.group_members()?,
                 entry.group.pending_update_max_epochs(),
             )
         };
@@ -306,8 +306,8 @@ impl<
         let (current_epoch, to_propose): (u64, Vec<GroupUpdateRequest>) = {
             let entry = entry_arc.read().await;
 
-            let (current_epoch, members) = match entry.group.mls() {
-                Some(mls) => (mls.current_epoch()?, group_members(&entry.group)?),
+            let (current_epoch, members) = match entry.mls() {
+                Some(mls) => (mls.current_epoch()?, entry.group_members()?),
                 None => (0, Vec::new()),
             };
             let self_identity = self.identity().identity_bytes();
@@ -417,8 +417,8 @@ impl<
             // Filter ghosts and queued-removal targets so joiners don't
             // inherit stewards they would have to walk past on the very
             // first epoch.
-            let mls = entry.group.expect_mls()?;
-            let mls_members = group_members(&entry.group)?;
+            let mls = entry.expect_mls()?;
+            let mls_members = entry.group_members()?;
             let eligible = entry.group.steward_eligibility(&mls_members);
             let steward_members = entry.steward.steward_members(&eligible);
 
@@ -469,7 +469,7 @@ impl<
         // truth — events just trigger the look.
         let (is_steward, epoch, to_remove): (bool, u64, Vec<(Vec<u8>, i64)>) = {
             let mut entry = entry_arc.write().await;
-            let mls = entry.group.expect_mls()?;
+            let mls = entry.expect_mls()?;
             let is_steward = entry.steward.is_steward(self_id);
             let epoch = mls.current_epoch()?;
             if !is_steward {

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -431,7 +431,7 @@ impl<
                 election_epoch: list.election_epoch(),
                 sn_min: list.config().sn_min as u32,
                 sn_max: list.config().sn_max as u32,
-                allow_subset_candidates: entry.group.allow_subset_candidates(),
+                allow_subset_candidates: entry.steward.config().allow_subset_candidates,
                 peer_scores: scores,
                 timing: Some(timing),
                 retry_round: list.retry_round(),

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -58,7 +58,7 @@ pub enum FreezeOutcome {
 }
 
 /// Canonical commit hash used for dedup of buffered/committed candidates.
-pub(crate) fn compute_commit_hash(commit_message: &[u8]) -> Vec<u8> {
+pub fn compute_commit_hash(commit_message: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(commit_message);
     hasher.finalize().to_vec()
@@ -69,13 +69,11 @@ pub(crate) fn compute_commit_hash(commit_message: &[u8]) -> Vec<u8> {
 /// Enforces the invariants [`finalize_freeze_round`] assumes: non-empty
 /// proposals/commit, valid MLS wire kinds, non-empty `steward_identity`,
 /// not already committed. No MLS state is mutated here.
-pub(crate) fn process_commit_candidate<M>(
-    group: &mut Group<M>,
+pub fn process_commit_candidate<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
     candidate_msg: CommitCandidate,
-) -> Result<ProcessResult, CoreError>
-where
-    M: MlsService,
-{
+) -> Result<ProcessResult, CoreError> {
     let group_name = group.group_name().to_owned();
 
     // Auto-start a freeze round if we already have approved proposals —
@@ -85,7 +83,7 @@ where
             tracing::debug!(group = %group_name, "candidate ignored: no approved proposals");
             return Ok(ProcessResult::Noop);
         }
-        let epoch = group.expect_mls()?.current_epoch()?;
+        let epoch = mls.current_epoch()?;
         group.ensure_freeze_round(epoch);
     }
 
@@ -104,8 +102,6 @@ where
         tracing::debug!(group = %group_name, "candidate ignored: empty steward_identity");
         return Ok(ProcessResult::Noop);
     }
-
-    let mls = group.expect_mls()?;
 
     // Wire-level kind check — no MLS staging.
     let proposals_ok = candidate_msg
@@ -151,45 +147,37 @@ where
 /// 2. Filter candidates by action count and rank them by RFC priority.
 /// 3. Apply in priority order, falling back on the next candidate when
 ///    MLS staging rejects the current one.
-pub fn finalize_freeze_round<M>(
-    group: &mut Group<M>,
+pub fn finalize_freeze_round<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
     steward: &dyn StewardListPlugin,
     allow_subset_candidates: bool,
     app_id: &[u8],
-) -> Result<FreezeFinalizeResult, CoreError>
-where
-    M: MlsService,
-{
-    let current_epoch = group.expect_mls()?.current_epoch()?;
+) -> Result<FreezeFinalizeResult, CoreError> {
+    let current_epoch = mls.current_epoch()?;
     group.lock_freeze_round_selection(current_epoch);
 
     let Some(candidates) = group.take_round_candidates(current_epoch) else {
         // Drop any local pending commit so the next MLS encrypt
         // doesn't trip on "pending proposal exists".
-        if let Some(mls) = group.mls() {
-            let _ = mls.discard_own_commit();
-        }
+        let _ = mls.discard_own_commit();
         return Ok(FreezeFinalizeResult::default());
     };
 
     if candidates.is_empty() {
-        if let Some(mls) = group.mls() {
-            let _ = mls.discard_own_commit();
-        }
+        let _ = mls.discard_own_commit();
         return Ok(FreezeFinalizeResult::default());
     }
 
-    let ctx = RoundContext::snapshot(group, steward, current_epoch)?;
+    let ctx = RoundContext::snapshot(group, mls, steward, current_epoch)?;
     let sorted = rank_applicable_candidates(candidates, &ctx, allow_subset_candidates);
 
     if sorted.is_empty() {
-        if let Some(mls) = group.mls() {
-            let _ = mls.discard_own_commit();
-        }
+        let _ = mls.discard_own_commit();
         return Ok(FreezeFinalizeResult::default());
     }
 
-    apply_in_priority_order(group, steward, sorted, &ctx, app_id)
+    apply_in_priority_order(group, mls, steward, sorted, &ctx, app_id)
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -218,15 +206,12 @@ struct RoundContext {
 }
 
 impl RoundContext {
-    fn snapshot<M>(
-        group: &Group<M>,
+    fn snapshot<M: MlsService>(
+        group: &Group,
+        mls: &M,
         steward: &dyn StewardListPlugin,
         current_epoch: u64,
-    ) -> Result<Self, CoreError>
-    where
-        M: MlsService,
-    {
-        let mls = group.expect_mls()?;
+    ) -> Result<Self, CoreError> {
         let self_identity = group.self_identity().to_vec();
 
         let mut mls_actions: Vec<MlsProposalOutput> = Vec::new();
@@ -312,16 +297,14 @@ enum CandidateOutcome {
 /// `own_commit_discarded` enforces MLS's one-pending-commit rule: the
 /// first incoming attempt wipes our own pending commit, so a
 /// lower-priority local candidate afterwards has nothing to apply.
-fn apply_in_priority_order<M>(
-    group: &mut Group<M>,
+fn apply_in_priority_order<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
     steward: &dyn StewardListPlugin,
     sorted: Vec<BufferedCommitCandidate>,
     ctx: &RoundContext,
     app_id: &[u8],
-) -> Result<FreezeFinalizeResult, CoreError>
-where
-    M: MlsService,
-{
+) -> Result<FreezeFinalizeResult, CoreError> {
     let mut score_ops: Vec<ScoreOp> = Vec::new();
     let mut own_commit_discarded = false;
     let group_name = group.group_name().to_owned();
@@ -336,16 +319,23 @@ where
                 );
                 continue;
             }
-            apply_local_candidate(group, chosen, ctx.self_remove_pending, app_id)?
+            apply_local_candidate(group, mls, chosen, ctx.self_remove_pending, app_id)?
         } else {
             if !own_commit_discarded && steward.is_steward(&ctx.self_identity) {
                 // A failure here leaves an old pending commit in MLS and
                 // would sabotage every subsequent staging attempt — bubble
                 // the error out of the round instead of pressing on.
-                group.expect_mls()?.discard_own_commit()?;
+                mls.discard_own_commit()?;
                 own_commit_discarded = true;
             }
-            apply_incoming_candidate(group, steward, chosen, &ctx.mls_actions, ctx.current_epoch)?
+            apply_incoming_candidate(
+                group,
+                mls,
+                steward,
+                chosen,
+                &ctx.mls_actions,
+                ctx.current_epoch,
+            )?
         };
 
         match apply_result {
@@ -408,7 +398,7 @@ where
     // No candidate applied. Drop any local pending commit that wasn't
     // merged or discarded along an incoming-wins path — leaving it
     // behind would break the next MLS encrypt.
-    if !own_commit_discarded && let Some(mls) = group.mls() {
+    if !own_commit_discarded {
         let _ = mls.discard_own_commit();
     }
     group.clear_freeze_round();
@@ -473,20 +463,18 @@ fn compare_candidate_priority(
 /// Merge our own commit and send the deferred welcomes we held back.
 /// Validation happened at commit-creation time, so no re-staging is needed.
 /// Always returns `Terminal(Applied)` on a clean merge.
-fn apply_local_candidate<M>(
-    group: &mut Group<M>,
+fn apply_local_candidate<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
     chosen: BufferedCommitCandidate,
     self_removed: bool,
     app_id: &[u8],
-) -> Result<CandidateOutcome, CoreError>
-where
-    M: MlsService,
-{
+) -> Result<CandidateOutcome, CoreError> {
     // Local candidate: we wrote the message, so the wire-claimed identity
     // is our own and is trusted by definition.
     let committer = chosen.candidate_msg.steward_identity.clone();
 
-    group.expect_mls()?.merge_own_commit()?;
+    mls.merge_own_commit()?;
 
     // Welcomes go out only after our merge — joiners must not race ahead of the steward's epoch.
     let outbound = chosen
@@ -517,18 +505,15 @@ where
 ///
 /// Caller must have discarded any own pending commit first — MLS allows
 /// only one per group at a time.
-fn apply_incoming_candidate<M>(
-    group: &mut Group<M>,
+fn apply_incoming_candidate<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
     steward: &dyn StewardListPlugin,
     chosen: BufferedCommitCandidate,
     expected_actions: &[MlsProposalOutput],
     current_epoch: u64,
-) -> Result<CandidateOutcome, CoreError>
-where
-    M: MlsService,
-{
+) -> Result<CandidateOutcome, CoreError> {
     let group_name = group.group_name().to_owned();
-    let mls = group.expect_mls()?;
 
     let (commit_sender, self_removed, commit_actions) =
         match stage_candidate(mls, &group_name, &chosen.candidate_msg, current_epoch)? {
@@ -687,8 +672,8 @@ where
 
 /// Check that a commit's MLS actions match the voted-approved set.
 /// `Some(evidence)` on mismatch.
-fn validate_commit_candidate<M: MlsService>(
-    group: &Group<M>,
+fn validate_commit_candidate(
+    group: &Group,
     expected_actions: &[MlsProposalOutput],
     sender_id: &[u8],
     mls_actions: &[MlsProposalOutput],
@@ -736,8 +721,8 @@ fn expected_action_for_request(req: &GroupUpdateRequest) -> Option<MlsProposalOu
 /// (re-election in progress), and "Layer-3 recovery_mode active" (RFC
 /// §Anti-Deadlock: any member MAY commit to restore liveness; mirrors
 /// the relaxed gate in `create_commit_candidate`).
-fn check_commit_sender_authorized<M: MlsService>(
-    group: &Group<M>,
+fn check_commit_sender_authorized(
+    group: &Group,
     steward: &dyn StewardListPlugin,
     commit_sender: &[u8],
     epoch: u64,
@@ -769,8 +754,8 @@ fn check_commit_sender_authorized<M: MlsService>(
 /// the commit was urgent-target-only and only the targeted entry was
 /// dropped). Caller surfaces the batch through `FreezeFinalizeResult` so
 /// the app layer can archive it for UI history.
-fn record_applied_commit<M: MlsService>(
-    group: &mut Group<M>,
+fn record_applied_commit(
+    group: &mut Group,
     commit_hash: Vec<u8>,
 ) -> HashMap<ProposalId, GroupUpdateRequest> {
     group.record_committed_batch(commit_hash);

--- a/src/core/api/inbound.rs
+++ b/src/core/api/inbound.rs
@@ -45,18 +45,18 @@ fn authorize_fast_path_proposal(proposal: &Proposal, mls_sender: &[u8]) -> bool 
 
 /// Process an inbound packet on the app subtopic and decide what action is
 /// needed. Welcome-subtopic packets are handled at the app layer.
-pub fn process_inbound<M>(group: &mut Group<M>, payload: &[u8]) -> Result<ProcessResult, CoreError>
-where
-    M: MlsService,
-{
+pub fn process_inbound<M: MlsService>(
+    group: &mut Group,
+    mls: &M,
+    payload: &[u8],
+) -> Result<ProcessResult, CoreError> {
     // 1. Try plaintext CommitCandidate (sent as plaintext AppMessage)
     if let Ok(app_message) = AppMessage::decode(payload) {
         if let Some(app_message::Payload::CommitCandidate(candidate)) = app_message.payload {
-            return process_commit_candidate(group, candidate);
+            return process_commit_candidate(group, mls, candidate);
         }
     }
 
-    let mls = group.expect_mls()?;
     // 2. MLS-encrypted app messages only — use decrypt_application_only.
     //    This NEVER stores proposals or processes commits, preventing
     //    rogue MLS proposals on the app subtopic from polluting state.

--- a/src/core/api/mod.rs
+++ b/src/core/api/mod.rs
@@ -11,7 +11,6 @@ mod lifecycle;
 mod steward;
 
 pub use freeze::{FreezeFinalizeResult, FreezeOutcome, finalize_freeze_round};
-pub(crate) use freeze::{compute_commit_hash, process_commit_candidate};
+pub use freeze::{compute_commit_hash, process_commit_candidate};
 pub use inbound::process_inbound;
 pub use lifecycle::{build_create_proposal_request, build_key_package_message};
-pub use steward::{create_commit_candidate, group_members};

--- a/src/core/api/steward.rs
+++ b/src/core/api/steward.rs
@@ -1,194 +1,37 @@
-//! Steward commit candidate creation and group member queries.
+// //! Steward commit candidate creation and group member queries.
 
-use prost::Message;
-use tracing::info;
+// use prost::Message;
+// use tracing::info;
 
-use crate::{
-    core::{
-        api::compute_commit_hash,
-        error::CoreError,
-        group::{BufferedCommitCandidate, Group, member_set},
-        proposal_kind::ProposalKind,
-        steward_list_plugin::StewardListPlugin,
-    },
-    ds::{APP_MSG_SUBTOPIC, OutboundPacket},
-    mls_crypto::{
-        CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MlsCommitInput, MlsService,
-    },
-    protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request},
-};
+// use crate::{
+//     core::{
+//         api::compute_commit_hash,
+//         error::CoreError,
+//         group::{BufferedCommitCandidate, Group, member_set},
+//         proposal_kind::ProposalKind,
+//         steward_list_plugin::StewardListPlugin,
+//     },
+//     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
+//     mls_crypto::{
+//         CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MlsCommitInput, MlsService,
+//     },
+//     protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request},
+// };
 
-// ─────────────────────────── Steward Operations ───────────────────────────
+// // ─────────────────────────── Steward Operations ───────────────────────────
 
-/// Build a commit candidate and buffer it for [`crate::core::finalize_freeze_round`].
-///
-/// The gate is plain steward-list membership — intentionally **not**
-/// epoch-steward or list-exhaustion, so members of the *previous* list
-/// can commit recovery actions when an election fails.
-/// `Group::is_in_recovery_mode()` (Layer 3) bypasses the gate entirely.
-pub fn create_commit_candidate<M>(
-    group: &mut Group<M>,
-    steward: &dyn StewardListPlugin,
-    self_identity: &[u8],
-    app_id: &[u8],
-) -> Result<Option<OutboundPacket>, CoreError>
-where
-    M: MlsService,
-{
-    if !steward.is_steward(self_identity) && !group.is_in_recovery_mode() {
-        return Err(CoreError::NotASteward);
-    }
+// /// Build a commit candidate and buffer it for [`crate::core::finalize_freeze_round`].
+// ///
+// /// The gate is plain steward-list membership — intentionally **not**
+// /// epoch-steward or list-exhaustion, so members of the *previous* list
+// /// can commit recovery actions when an election fails.
+// /// `Group::is_in_recovery_mode()` (Layer 3) bypasses the gate entirely.
+// pub fn create_commit_candidate<M: MlsService>(
+//     group: &mut Group,
+//     mls: &M,
+//     steward: &dyn StewardListPlugin,
+//     self_identity: &[u8],
+//     app_id: &[u8],
+// ) -> Result<Option<OutboundPacket>, CoreError> {
 
-    if group.approved_proposals().is_empty() {
-        return Err(CoreError::NoProposals);
-    }
-    let res = group.mls();
-    if res.is_none() {
-        return Err(CoreError::MlsGroupNotInitialized);
-    }
-    let mls = res.unwrap();
-
-    // MLS forbids committing one's own removal. If the approved batch contains
-    // RemoveMember(self), skip local candidate creation — another steward will
-    // commit the batch (including this node's removal) once they enter freeze.
-    let self_removal_pending = group.approved_proposals().values().any(|req| {
-        matches!(
-            req.payload.as_ref(),
-            Some(group_update_request::Payload::RemoveMember(r))
-                if r.identity == self_identity
-        )
-    });
-    if self_removal_pending {
-        info!(
-            group = group.group_name(),
-            "commit candidate skipped: approved batch contains self-remove"
-        );
-        return Ok(None);
-    }
-
-    // Governance proposals (emergency, election) are consensus-only and must
-    // not be in the approved queue at batch creation time.
-    let non_mls_ids: Vec<u32> = group
-        .approved_proposals()
-        .iter()
-        .filter(|(_, req)| ProposalKind::of(req).is_governance())
-        .map(|(&id, _)| id)
-        .collect();
-
-    if !non_mls_ids.is_empty() {
-        return Err(CoreError::UnexpectedNonMlsProposals {
-            proposal_ids: non_mls_ids,
-        });
-    }
-
-    // Drop approved entries already reflected in group state (stale
-    // rebroadcast KPs, duplicate removes) — without this MLS would reject
-    // the whole batch with "Duplicate signature key in proposals and group".
-    let current_members = mls.members()?;
-    let current_members_set = member_set(&current_members);
-    let is_member = |id: &[u8]| current_members_set.contains(id);
-
-    // Urgent (ECP-driven) freeze: restrict the batch to just the target's
-    // RemoveMember. See `Group::urgent_commit_target`.
-    let urgent_target = group.urgent_commit_target().map(|t| t.to_vec());
-
-    // Iterate in insertion order (FIFO): library proposal IDs are
-    // content-derived hashes, so sort-by-id is not temporal.
-    let k_max = mls.commit_batch_max();
-    let mut updates = Vec::with_capacity(group.approved_order().len().min(k_max));
-    for pid in group.approved_order() {
-        if updates.len() >= k_max {
-            break;
-        }
-        let Some(proposal) = group.approved_proposals().get(pid) else {
-            continue;
-        };
-        match proposal.payload.as_ref() {
-            Some(group_update_request::Payload::InviteMember(im)) => {
-                if urgent_target.is_some() {
-                    continue;
-                }
-                if is_member(&im.identity) {
-                    continue;
-                }
-                updates.push(MlsCommitInput::Add(KeyPackageBytes::new(
-                    im.key_package_bytes.clone(),
-                    im.identity.clone(),
-                )));
-            }
-            Some(group_update_request::Payload::RemoveMember(rm)) => {
-                if let Some(target) = urgent_target.as_deref()
-                    && rm.identity != target
-                {
-                    continue;
-                }
-                if !is_member(&rm.identity) {
-                    continue;
-                }
-                updates.push(MlsCommitInput::Remove(rm.identity.clone()));
-            }
-            _ => return Err(CoreError::InvalidGroupUpdateRequest),
-        }
-    }
-
-    if updates.is_empty() {
-        return Ok(None);
-    }
-
-    let MlsCommitCandidate {
-        proposals: mls_proposals,
-        commit,
-        welcome,
-    } = mls.create_commit_candidate(&updates)?;
-
-    let candidate = CommitCandidate {
-        group_name: group.group_name_bytes().to_vec(),
-        mls_proposals,
-        commit_message: commit,
-        steward_identity: self_identity.to_vec(),
-    };
-
-    // Welcome bytes are deferred: sent from finalize_freeze_round after the
-    // commit merges, so joiners can't advance epoch ahead of the steward.
-    let commit_hash = compute_commit_hash(&candidate.commit_message);
-    let epoch = mls.current_epoch()?;
-    let _ = group.add_freeze_candidate(
-        BufferedCommitCandidate {
-            candidate_msg: candidate.clone(),
-            commit_hash,
-            is_local_candidate: true,
-            welcome_bytes: welcome,
-        },
-        epoch,
-    );
-
-    info!(
-        group = group.group_name(),
-        epoch,
-        proposals = updates.len(),
-        "commit candidate created"
-    );
-
-    let candidate_msg: AppMessage = candidate.into();
-    Ok(Some(OutboundPacket::new(
-        candidate_msg.encode_to_vec(),
-        APP_MSG_SUBTOPIC,
-        group.group_name(),
-        app_id,
-    )))
-}
-
-// ─────────────────────────── Member Queries ───────────────────────────
-
-/// Current members of a group, read from its MLS service. Returns an
-/// empty list when the group hasn't accepted a welcome yet (e.g. a
-/// pending joiner querying its own state).
-pub fn group_members<M>(group: &Group<M>) -> Result<Vec<Vec<u8>>, CoreError>
-where
-    M: MlsService,
-{
-    match group.mls() {
-        Some(mls) => Ok(mls.members()?),
-        None => Ok(Vec::new()),
-    }
-}
+// }

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -14,7 +14,6 @@ use tracing::info;
 use crate::{
     core::{CoreError, Group},
     identity::ShortId,
-    mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
         GroupUpdateRequest, RemoveMember, StewardElectionProposal, ViolationEvidence,
         ViolationType, group_update_request,
@@ -97,8 +96,8 @@ fn pending_removal_target(
 /// Election outcome — no MLS operation. YES hands the proposed list
 /// back to the app for validation and install; NO drops the owner's
 /// voting-queue entry.
-fn apply_election_outcome<M: MlsService>(
-    group: &mut Group<M>,
+fn apply_election_outcome(
+    group: &mut Group,
     proposal_id: u32,
     approved: bool,
     election: StewardElectionProposal,
@@ -144,8 +143,8 @@ fn apply_election_outcome<M: MlsService>(
 ///   `RemoveMember` for an already-queued target is deduped at insertion.
 /// - **Rejected (any kind)** — dropped from the voting queue if we
 ///   owned it.
-pub fn apply_consensus_result<M: MlsService>(
-    group: &mut Group<M>,
+pub fn apply_consensus_result(
+    group: &mut Group,
     proposal_id: u32,
     approved: bool,
     payload: &[u8],
@@ -265,7 +264,6 @@ pub fn apply_consensus_result<M: MlsService>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::group::test_stubs::NoopMls;
     use crate::core::steward_list_plugin::{StewardList, StewardListConfig};
     use crate::protos::de_mls::messages::v1::{
         GroupUpdateRequest, StewardElectionProposal, group_update_request,
@@ -280,8 +278,8 @@ mod tests {
         ids.iter().map(|&id| member(id)).collect()
     }
 
-    fn make_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group<NoopMls> {
-        Group::create_group(name, identity, config, NoopMls::new(name))
+    fn make_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group {
+        Group::create_group(name, identity, config)
     }
 
     fn election_request(stewards: Vec<Vec<u8>>, epoch: u64) -> GroupUpdateRequest {

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -278,8 +278,8 @@ mod tests {
         ids.iter().map(|&id| member(id)).collect()
     }
 
-    fn make_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group {
-        Group::create_group(name, identity, config)
+    fn make_group(name: &str, identity: Vec<u8>) -> Group {
+        Group::create_group(name, identity)
     }
 
     fn election_request(stewards: Vec<Vec<u8>>, epoch: u64) -> GroupUpdateRequest {
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn election_yes_owner_returns_outcome_and_clears_queue() {
         let config = StewardListConfig::new(2, 5).unwrap();
-        let mut group = make_group("test-group", member(1), config.clone());
+        let mut group = make_group("test-group", member(1));
         let mems = members(&[1, 2, 3, 4, 5]);
         let sn = mems.len().min(config.sn_max);
         let list = StewardList::generate(10, b"test-group", &mems, sn, config, 0).unwrap();
@@ -321,8 +321,7 @@ mod tests {
     /// NO on an election returns no outcome and leaves the approved queue empty.
     #[test]
     fn election_no_returns_empty() {
-        let config = StewardListConfig::new(2, 5).unwrap();
-        let mut group = make_group("test-group", member(1), config);
+        let mut group = make_group("test-group", member(1));
         let request = election_request(vec![member(1), member(2)], 10);
 
         let proposal_id = 43;
@@ -340,8 +339,7 @@ mod tests {
     /// (non-owner path), and doesn't touch any proposal queues.
     #[test]
     fn election_yes_nonowner_returns_outcome_without_queue_side_effects() {
-        let config = StewardListConfig::new(2, 5).unwrap();
-        let mut group = make_group("test-group", member(1), config);
+        let mut group = make_group("test-group", member(1));
         let request = election_request(vec![member(1), member(2), member(3)], 5);
 
         let proposal_id = 44;
@@ -367,8 +365,7 @@ mod tests {
     /// when an entry for the same target is already in `approved_proposals`.
     #[test]
     fn removal_deduped_when_target_already_pending() {
-        let config = StewardListConfig::new(2, 5).unwrap();
-        let mut group = make_group("test-group", member(1), config);
+        let mut group = make_group("test-group", member(1));
         let target = member(7);
 
         // First removal — non-owner path inserts straight into approved.
@@ -397,8 +394,7 @@ mod tests {
     /// queue does not retain an outcome we deliberately discarded.
     #[test]
     fn removal_dedup_clears_owner_voting_entry() {
-        let config = StewardListConfig::new(2, 5).unwrap();
-        let mut group = make_group("test-group", member(1), config);
+        let mut group = make_group("test-group", member(1));
         let target = member(7);
 
         // Pre-existing approved removal from an unrelated path.
@@ -433,8 +429,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_yes_marks_urgent_and_force_freezes() {
-        let config = StewardListConfig::new(1, 5).unwrap();
-        let mut group = make_group("urgent-yes", member(1), config);
+        let mut group = make_group("urgent-yes", member(1));
         let target = member(7);
 
         let request = score_below_threshold_request(target.clone(), member(1));
@@ -454,8 +449,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_no_does_not_mark_urgent() {
-        let config = StewardListConfig::new(1, 5).unwrap();
-        let mut group = make_group("urgent-no", member(1), config);
+        let mut group = make_group("urgent-no", member(1));
         let request = score_below_threshold_request(member(7), member(1));
         let payload = request.encode_to_vec();
 
@@ -475,8 +469,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_yes_opens_recovery_mode_and_force_freezes() {
-        let config = StewardListConfig::new(1, 5).unwrap();
-        let mut group = make_group("deadlock-yes", member(1), config);
+        let mut group = make_group("deadlock-yes", member(1));
         assert!(!group.is_in_recovery_mode());
 
         let request = deadlock_request(member(1));
@@ -498,8 +491,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_no_does_not_open_recovery_mode() {
-        let config = StewardListConfig::new(1, 5).unwrap();
-        let mut group = make_group("deadlock-no", member(1), config);
+        let mut group = make_group("deadlock-no", member(1));
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    core::{proposal_kind::ProposalKind, steward_list_plugin::StewardListConfig},
+    core::proposal_kind::ProposalKind,
     protos::de_mls::messages::v1::{CommitCandidate, GroupUpdateRequest, group_update_request},
 };
 
@@ -109,10 +109,6 @@ pub struct Group {
     approved_order: Vec<ProposalId>,
     /// Proposals waiting on consensus voting (created by this user).
     voting_proposals: HashMap<ProposalId, GroupUpdateRequest>,
-    /// Protocol configuration. Currently bundles steward list bounds
-    /// (also held on the steward plug-in) with `k_max` (commit batch
-    /// ceiling). Pending split into per-concern config types.
-    protocol_config: StewardListConfig,
     /// Active emergency criteria proposals not yet finalized by consensus.
     /// While non-empty, lower-priority proposals MUST be blocked (RFC §Partial Freeze).
     active_emergency_ids: HashSet<ProposalId>,
@@ -152,18 +148,13 @@ pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
 pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
 
 impl Group {
-    fn new_base(
-        group_name: &str,
-        self_identity: Vec<u8>,
-        protocol_config: StewardListConfig,
-    ) -> Self {
+    fn new_base(group_name: &str, self_identity: Vec<u8>) -> Self {
         Self {
             group_name: group_name.to_string(),
             self_identity,
             approved_proposals: HashMap::new(),
             approved_order: Vec::new(),
             voting_proposals: HashMap::new(),
-            protocol_config,
             active_emergency_ids: HashSet::new(),
             pending_removal_targets: HashSet::new(),
             committed_batch_hashes: VecDeque::new(),
@@ -195,23 +186,15 @@ impl Group {
     /// Build a joiner-side handle for an existing group. The MLS service
     /// is held on `GroupEntry`; the lifecycle layer attaches it via
     /// `entry.attach_mls(...)` once the welcome arrives.
-    pub fn prepare_to_join(
-        group_name: &str,
-        self_identity: Vec<u8>,
-        protocol_config: StewardListConfig,
-    ) -> Self {
-        Self::new_base(group_name, self_identity, protocol_config)
+    pub fn prepare_to_join(group_name: &str, self_identity: Vec<u8>) -> Self {
+        Self::new_base(group_name, self_identity)
     }
 
     /// Build a creator-side handle. The steward list and MLS service
     /// are owned by `GroupEntry`; this constructor only initializes the
     /// proposal-queue and freeze-round state.
-    pub fn create_group(
-        group_name: &str,
-        creator_identity: Vec<u8>,
-        protocol_config: StewardListConfig,
-    ) -> Self {
-        Self::new_base(group_name, creator_identity, protocol_config)
+    pub fn create_group(group_name: &str, creator_identity: Vec<u8>) -> Self {
+        Self::new_base(group_name, creator_identity)
     }
 
     pub fn group_name(&self) -> &str {
@@ -220,10 +203,6 @@ impl Group {
 
     pub fn group_name_bytes(&self) -> &[u8] {
         self.group_name.as_bytes()
-    }
-
-    pub fn allow_subset_candidates(&self) -> bool {
-        self.protocol_config.allow_subset_candidates
     }
 
     /// Build the eligibility predicate that the steward plug-in's "live"
@@ -433,16 +412,6 @@ impl Group {
 
     pub fn exit_recovery_mode(&mut self) {
         self.recovery_mode = false;
-    }
-
-    // ─────────────────────────── Protocol Config ───────────────────────────
-
-    pub fn protocol_config(&self) -> &StewardListConfig {
-        &self.protocol_config
-    }
-
-    pub fn set_protocol_config(&mut self, config: StewardListConfig) {
-        self.protocol_config = config;
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election
@@ -766,16 +735,12 @@ mod tests {
         ids.iter().map(|&id| member(id)).collect()
     }
 
-    fn default_config() -> StewardListConfig {
-        StewardListConfig::new(1, 5).unwrap()
-    }
-
     /// Test convenience: build a creator-side `Group`. Steward
     /// list is owned by the per-group plug-in (covered separately in
     /// `core::steward_list_plugin::tests`); these tests focus on
     /// proposal-queue + dedup + freeze-round logic on `Group`.
-    fn creator_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group {
-        Group::create_group(name, identity, config)
+    fn creator_group(name: &str, identity: Vec<u8>) -> Group {
+        Group::create_group(name, identity)
     }
 
     fn insert_self_leave(group: &mut Group, identity: &[u8]) {
@@ -789,8 +754,7 @@ mod tests {
 
     #[test]
     fn test_reject_all_approved_preserves_self_leave_entry() {
-        let config = StewardListConfig::new(1, 3).unwrap();
-        let mut group = creator_group("test-group", member(1), config);
+        let mut group = creator_group("test-group", member(1));
 
         let leaver = member(2);
         insert_self_leave(&mut group, &leaver);
@@ -816,8 +780,7 @@ mod tests {
 
     #[test]
     fn test_prune_clears_self_leave_entry_when_member_gone() {
-        let config = StewardListConfig::new(1, 3).unwrap();
-        let mut group = creator_group("test-group", member(1), config);
+        let mut group = creator_group("test-group", member(1));
 
         let leaver = member(2);
         insert_self_leave(&mut group, &leaver);
@@ -870,7 +833,7 @@ mod tests {
 
     #[test]
     fn mark_consensus_outcome_persists_in_resolved_cache() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
         assert!(!group.is_consensus_outcome_applied(42));
         group.mark_consensus_outcome_applied(42);
         assert!(group.is_consensus_outcome_applied(42));
@@ -889,8 +852,7 @@ mod tests {
     /// source; Add proposals are dropped.
     #[test]
     fn test_reject_all_approved_preserves_all_remove_member() {
-        let config = StewardListConfig::new(1, 3).unwrap();
-        let mut group = creator_group("test-group", member(1), config);
+        let mut group = creator_group("test-group", member(1));
 
         let ban_id: ProposalId = 0x1111_2222;
         let ecp_id: ProposalId = 0x3333_4444;
@@ -917,7 +879,7 @@ mod tests {
     /// `approved_order` is FIFO regardless of proposal-id ordering.
     #[test]
     fn test_approved_order_preserves_fifo_across_mutations() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
 
         insert_remove_member(&mut group, &member(2), 500);
         insert_remove_member(&mut group, &member(3), 100);
@@ -937,7 +899,7 @@ mod tests {
 
     #[test]
     fn test_urgent_commit_target_set_take_clears() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
         assert!(group.urgent_commit_target().is_none());
 
         let target = member(7);
@@ -951,7 +913,7 @@ mod tests {
 
     #[test]
     fn test_drop_approved_removals_for_target() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
         let victim = member(7);
         let bystander = member(9);
 
@@ -983,7 +945,7 @@ mod tests {
     /// `first_seen_epoch < cutoff` are dropped.
     #[test]
     fn test_expire_pending_updates_drops_entries_older_than_max_age() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
         let stale = member(7);
         let fresh = member(9);
 
@@ -1003,7 +965,7 @@ mod tests {
     /// boundary case a tightened sync hits when shrinking the window.
     #[test]
     fn test_expire_pending_updates_max_age_zero_keeps_only_current_epoch() {
-        let mut group = creator_group("g", member(1), default_config());
+        let mut group = creator_group("g", member(1));
         let prior = member(7);
         let current = member(9);
 

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -1,14 +1,14 @@
-//! Per-group app-level state: proposal queues, steward list, freeze-round
-//! candidate buffer, pending-update buffer, ECP dedup. MLS crypto state
-//! lives in `OpenMlsService` alongside this.
+//! Per-group protocol-queue state: approved/voting proposal queues,
+//! freeze-round candidate buffer, pending-update buffer, urgent-commit
+//! target, recovery-mode flag, ECP dedup. MLS crypto state and the
+//! steward-list plug-in live alongside on `GroupEntry`.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use sha2::{Digest, Sha256};
 
 use crate::{
-    core::{CoreError, proposal_kind::ProposalKind, steward_list_plugin::StewardListConfig},
-    mls_crypto::MlsService,
+    core::{proposal_kind::ProposalKind, steward_list_plugin::StewardListConfig},
     protos::de_mls::messages::v1::{CommitCandidate, GroupUpdateRequest, group_update_request},
 };
 
@@ -39,7 +39,7 @@ pub fn is_auto_approved_entry(proposal_id: u32, request: &GroupUpdateRequest) ->
 
 /// Borrow-only `HashSet` view over a slice of identity blobs, for O(1)
 /// membership lookups against `Vec<Vec<u8>>`.
-pub(crate) fn member_set(members: &[Vec<u8>]) -> HashSet<&[u8]> {
+pub fn member_set(members: &[Vec<u8>]) -> HashSet<&[u8]> {
     members.iter().map(|m| m.as_slice()).collect()
 }
 
@@ -74,7 +74,7 @@ const MAX_COMMITTED_HASHES: usize = 10;
 
 /// A commit candidate buffered during freeze for later selection.
 #[derive(Clone, Debug)]
-pub(crate) struct BufferedCommitCandidate {
+pub struct BufferedCommitCandidate {
     pub candidate_msg: CommitCandidate,
     pub commit_hash: Vec<u8>,
     pub is_local_candidate: bool,
@@ -92,16 +92,11 @@ pub(crate) struct FreezeRound {
 /// Per-group protocol state. Stewards batch commits; members vote.
 /// Construct with [`Self::create_group`] or [`Self::prepare_to_join`].
 ///
-/// Owns the per-group MLS service (`Option<M>` because joiners in
-/// `PendingJoin` don't have a service until the welcome arrives — at that
-/// point the User attaches one via [`Self::attach_mls`]).
-///
-/// Steward-list state (active list, retry round, retry policy) lives in
-/// the per-group `StewardListPlugin` instance on `GroupEntry`, not here.
-pub struct Group<M: MlsService> {
-    /// Per-group MLS service. `None` for joiners that haven't accepted
-    /// a welcome yet; otherwise `Some`.
-    mls: Option<M>,
+/// Pure proposal-queue and freeze-round bookkeeping — MLS state lives
+/// on the per-group [`crate::mls_crypto::MlsService`] instance held on
+/// `GroupEntry`, alongside the steward-list plug-in. `Group` itself has
+/// no `M` generic.
+pub struct Group {
     /// The name of the group.
     group_name: String,
     /// This user's identity bytes (set at construction; matches the
@@ -156,15 +151,13 @@ pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
 
 pub const DEFAULT_PENDING_UPDATE_MAX_EPOCHS: u32 = 3;
 
-impl<M: MlsService> Group<M> {
+impl Group {
     fn new_base(
         group_name: &str,
         self_identity: Vec<u8>,
         protocol_config: StewardListConfig,
-        mls: Option<M>,
     ) -> Self {
         Self {
-            mls,
             group_name: group_name.to_string(),
             self_identity,
             approved_proposals: HashMap::new(),
@@ -191,32 +184,6 @@ impl<M: MlsService> Group<M> {
         &self.self_identity
     }
 
-    /// Borrow the MLS service for this group, if attached. Returns `None`
-    /// for joiners in `PendingJoin` who haven't accepted a welcome yet.
-    pub fn mls(&self) -> Option<&M> {
-        self.mls.as_ref()
-    }
-
-    /// Borrow the MLS service, erroring with [`CoreError::MlsGroupNotInitialized`]
-    /// when not attached. Use this in code paths where the service must be
-    /// present (Working state) so the `?` chain stays linear.
-    pub fn expect_mls(&self) -> Result<&M, CoreError> {
-        self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)
-    }
-
-    /// Attach an MLS service to this group. Used by joiners after a
-    /// welcome arrives; idempotent in spirit (overwrites whatever was
-    /// there — caller is responsible for not double-attaching).
-    pub fn attach_mls(&mut self, mls: M) {
-        self.mls = Some(mls);
-    }
-
-    /// Drop the attached MLS service and return it. Used on group leave
-    /// so the caller can run service-side cleanup (`mls.delete()`).
-    pub fn take_mls(&mut self) -> Option<M> {
-        self.mls.take()
-    }
-
     pub(crate) fn is_consensus_outcome_applied(&self, proposal_id: ProposalId) -> bool {
         self.resolved_proposals.contains(proposal_id)
     }
@@ -226,26 +193,25 @@ impl<M: MlsService> Group<M> {
     }
 
     /// Build a joiner-side handle for an existing group. The MLS service
-    /// starts unattached; the User attaches it via [`Self::attach_mls`]
-    /// once the welcome arrives.
+    /// is held on `GroupEntry`; the lifecycle layer attaches it via
+    /// `entry.attach_mls(...)` once the welcome arrives.
     pub fn prepare_to_join(
         group_name: &str,
         self_identity: Vec<u8>,
         protocol_config: StewardListConfig,
     ) -> Self {
-        Self::new_base(group_name, self_identity, protocol_config, None)
+        Self::new_base(group_name, self_identity, protocol_config)
     }
 
-    /// Build a creator-side handle. The steward list is owned by the
-    /// per-group `StewardListPlugin` on `GroupEntry`; the lifecycle
-    /// layer bootstraps the list separately after this constructor.
+    /// Build a creator-side handle. The steward list and MLS service
+    /// are owned by `GroupEntry`; this constructor only initializes the
+    /// proposal-queue and freeze-round state.
     pub fn create_group(
         group_name: &str,
         creator_identity: Vec<u8>,
         protocol_config: StewardListConfig,
-        mls: M,
     ) -> Self {
-        Self::new_base(group_name, creator_identity, protocol_config, Some(mls))
+        Self::new_base(group_name, creator_identity, protocol_config)
     }
 
     pub fn group_name(&self) -> &str {
@@ -520,11 +486,7 @@ impl<M: MlsService> Group<M> {
     ///
     /// Returns `true` if buffered, `false` if ignored (locked round or duplicate).
     /// The `epoch` parameter should be the current MLS epoch from `OpenMlsService::current_epoch()`.
-    pub(crate) fn add_freeze_candidate(
-        &mut self,
-        candidate: BufferedCommitCandidate,
-        epoch: u64,
-    ) -> bool {
+    pub fn add_freeze_candidate(&mut self, candidate: BufferedCommitCandidate, epoch: u64) -> bool {
         self.ensure_freeze_round(epoch);
         let Some(round) = self.freeze_round.as_mut() else {
             return false;
@@ -792,97 +754,8 @@ impl ResolvedProposalCache {
 
 /// Test-only stubs shared across `core/`'s unit-test modules.
 #[cfg(test)]
-pub(crate) mod test_stubs {
-    use crate::ds::OutboundPacket;
-    use crate::mls_crypto::{
-        CommitCandidate as MlsCommitCandidate, DecryptResult, MlsCommitInput, MlsError,
-        MlsMessageKind, MlsService, StagedCandidateResult,
-    };
-    use crate::protos::de_mls::messages::v1::AppMessage;
-
-    /// Test-only no-op MLS service. `Group`'s pure-state tests never call
-    /// MLS operations, so every protocol method is a stub. If a test
-    /// reaches one of these, it's the wrong test and the panic message
-    /// will say so.
-    pub(crate) struct NoopMls {
-        group_id: String,
-    }
-
-    impl NoopMls {
-        pub(crate) fn new(group_id: &str) -> Self {
-            Self {
-                group_id: group_id.to_string(),
-            }
-        }
-    }
-
-    impl MlsService for NoopMls {
-        fn group_id(&self) -> &str {
-            &self.group_id
-        }
-        fn delete(&self) -> Result<(), MlsError> {
-            Ok(())
-        }
-        fn members(&self) -> Result<Vec<Vec<u8>>, MlsError> {
-            Ok(Vec::new())
-        }
-        fn is_member(&self, _identity: &[u8]) -> bool {
-            false
-        }
-        fn current_epoch(&self) -> Result<u64, MlsError> {
-            Ok(0)
-        }
-        fn create_commit_candidate(
-            &self,
-            _updates: &[MlsCommitInput],
-        ) -> Result<MlsCommitCandidate, MlsError> {
-            unreachable!("NoopMls::create_commit_candidate not used in pure-state tests")
-        }
-        fn merge_own_commit(&self) -> Result<(), MlsError> {
-            unreachable!()
-        }
-        fn discard_own_commit(&self) -> Result<(), MlsError> {
-            unreachable!()
-        }
-        fn stage_remote_commit(
-            &self,
-            _proposals: &[Vec<u8>],
-            _commit_bytes: &[u8],
-        ) -> Result<StagedCandidateResult, MlsError> {
-            unreachable!()
-        }
-        fn merge_staged_commit(&self) -> Result<(), MlsError> {
-            unreachable!()
-        }
-        fn discard_staged_commit(&self) -> Result<(), MlsError> {
-            unreachable!()
-        }
-        fn encrypt(&self, _plaintext: &[u8]) -> Result<Vec<u8>, MlsError> {
-            unreachable!()
-        }
-        fn build_message(
-            &self,
-            _app_msg: &AppMessage,
-            _app_id: &[u8],
-        ) -> Result<OutboundPacket, MlsError> {
-            unreachable!()
-        }
-        fn decrypt_application_only(&self, _ciphertext: &[u8]) -> Result<DecryptResult, MlsError> {
-            unreachable!()
-        }
-        fn decrypt(&self, _ciphertext: &[u8]) -> Result<DecryptResult, MlsError> {
-            unreachable!()
-        }
-        fn inspect_message_kind(&self, _message_bytes: &[u8]) -> Result<MlsMessageKind, MlsError> {
-            unreachable!()
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::group::test_stubs::NoopMls;
     use crate::protos::de_mls::messages::v1::{InviteMember, RemoveMember};
 
     fn member(id: u8) -> Vec<u8> {
@@ -897,15 +770,15 @@ mod tests {
         StewardListConfig::new(1, 5).unwrap()
     }
 
-    /// Test convenience: build a creator-side `Group<NoopMls>`. Steward
+    /// Test convenience: build a creator-side `Group`. Steward
     /// list is owned by the per-group plug-in (covered separately in
     /// `core::steward_list_plugin::tests`); these tests focus on
     /// proposal-queue + dedup + freeze-round logic on `Group`.
-    fn creator_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group<NoopMls> {
-        Group::create_group(name, identity, config, NoopMls::new(name))
+    fn creator_group(name: &str, identity: Vec<u8>, config: StewardListConfig) -> Group {
+        Group::create_group(name, identity, config)
     }
 
-    fn insert_self_leave(group: &mut Group<NoopMls>, identity: &[u8]) {
+    fn insert_self_leave(group: &mut Group, identity: &[u8]) {
         let remove = GroupUpdateRequest {
             payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
                 identity: identity.to_vec(),
@@ -1003,7 +876,7 @@ mod tests {
         assert!(group.is_consensus_outcome_applied(42));
     }
 
-    fn insert_remove_member(group: &mut Group<NoopMls>, target: &[u8], proposal_id: ProposalId) {
+    fn insert_remove_member(group: &mut Group, target: &[u8], proposal_id: ProposalId) {
         let remove = GroupUpdateRequest {
             payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
                 identity: target.to_vec(),
@@ -1095,7 +968,7 @@ mod tests {
         assert!(!group.approved_proposals().contains_key(&101));
     }
 
-    fn buffer_remove_at(group: &mut Group<NoopMls>, target: &[u8], epoch: u64) {
+    fn buffer_remove_at(group: &mut Group, target: &[u8], epoch: u64) {
         let request = GroupUpdateRequest {
             payload: Some(group_update_request::Payload::RemoveMember(RemoveMember {
                 identity: target.to_vec(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,7 +27,7 @@ mod steward_list_plugin;
 // ── Core group operations ──
 pub use api::{
     FreezeFinalizeResult, FreezeOutcome, build_create_proposal_request, build_key_package_message,
-    create_commit_candidate, finalize_freeze_round, group_members, process_inbound,
+    compute_commit_hash, finalize_freeze_round, process_inbound,
 };
 
 // ── Consensus result application (pure, synchronous) ──
@@ -45,10 +45,10 @@ pub use error::CoreError;
 pub use events::{CallbackError, GroupEventHandler};
 
 // ── Group state ──
-pub(crate) use group::member_set;
 pub use group::{
-    DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_PENDING_UPDATE_MAX_EPOCHS, Group, PendingUpdate,
-    ProposalId, auto_approved_leave_proposal_id, target_identity_of,
+    BufferedCommitCandidate, DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
+    Group, PendingUpdate, ProposalId, auto_approved_leave_proposal_id, member_set,
+    target_identity_of,
 };
 
 // ── Proposal classification ──

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,18 +16,20 @@ use async_trait::async_trait;
 use de_mls::app::{FixedScoringProvider, InMemoryPeerScoreStorage};
 use de_mls::core::PeerScoringService;
 use de_mls::core::{
-    CallbackError, DeterministicStewardList, FreezeOutcome, Group, GroupEventHandler,
-    ProcessResult, ScoringConfig, StewardListConfig, StewardListPlugin, build_key_package_message,
-    create_commit_candidate, finalize_freeze_round, process_inbound,
+    BufferedCommitCandidate, CallbackError, CoreError, DeterministicStewardList, FreezeOutcome,
+    Group, GroupEventHandler, ProcessResult, ProposalKind, ScoringConfig, StewardListConfig,
+    StewardListPlugin, build_key_package_message, compute_commit_hash, finalize_freeze_round,
+    member_set, process_inbound,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, OutboundPacket, WELCOME_SUBTOPIC};
 use de_mls::identity::{Identity, WalletIdentity, parse_wallet_address};
 use de_mls::mls_crypto::{
-    MemoryDeMlsStorage, MlsCredentials, MlsService, OpenMlsService, key_package_bytes_from_json,
+    CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MemoryDeMlsStorage, MlsCommitInput,
+    MlsCredentials, MlsService, OpenMlsService, key_package_bytes_from_json,
 };
 use de_mls::protos::de_mls::messages::v1::{
-    AppMessage, GroupUpdateRequest, InviteMember, WelcomeMessage, group_update_request,
-    welcome_message,
+    AppMessage, CommitCandidate, GroupUpdateRequest, InviteMember, WelcomeMessage,
+    group_update_request, welcome_message,
 };
 use prost::Message as _;
 
@@ -128,6 +130,133 @@ impl GroupEventHandler for MockHandler {
     }
 }
 
+// ─────────────────────────── Test-only protocol helper ───────────────────────────
+
+/// Test-side mirror of `GroupEntry::create_commit_candidate`.
+///
+/// Production callers go through `GroupEntry::create_commit_candidate`,
+/// which pulls `group`, `mls`, and `steward` from `&mut self`. Tests
+/// keep these as separate fields on `StewardHandle` / `JoinerHandle`
+/// (no `state_machine` / `scoring`), so we can't use the entry method
+/// directly. This helper takes the same fields as parameters and runs
+/// identical logic. **Keep in sync with `GroupEntry::create_commit_candidate`.**
+pub fn build_commit_candidate(
+    group: &mut Group,
+    mls: &TestMls,
+    steward: &DeterministicStewardList,
+    self_identity: &[u8],
+    app_id: &[u8],
+) -> Result<Option<OutboundPacket>, CoreError> {
+    if !steward.is_steward(self_identity) && !group.is_in_recovery_mode() {
+        return Err(CoreError::NotASteward);
+    }
+    if group.approved_proposals().is_empty() {
+        return Err(CoreError::NoProposals);
+    }
+
+    let self_removal_pending = group.approved_proposals().values().any(|req| {
+        matches!(
+            req.payload.as_ref(),
+            Some(group_update_request::Payload::RemoveMember(r))
+                if r.identity == self_identity
+        )
+    });
+    if self_removal_pending {
+        return Ok(None);
+    }
+
+    let non_mls_ids: Vec<u32> = group
+        .approved_proposals()
+        .iter()
+        .filter(|(_, req)| ProposalKind::of(req).is_governance())
+        .map(|(&id, _)| id)
+        .collect();
+    if !non_mls_ids.is_empty() {
+        return Err(CoreError::UnexpectedNonMlsProposals {
+            proposal_ids: non_mls_ids,
+        });
+    }
+
+    let current_members = mls.members()?;
+    let current_members_set = member_set(&current_members);
+    let is_member = |id: &[u8]| current_members_set.contains(id);
+    let urgent_target = group.urgent_commit_target().map(|t| t.to_vec());
+
+    let k_max = mls.commit_batch_max();
+    let mut updates = Vec::with_capacity(group.approved_order().len().min(k_max));
+    for pid in group.approved_order() {
+        if updates.len() >= k_max {
+            break;
+        }
+        let Some(proposal) = group.approved_proposals().get(pid) else {
+            continue;
+        };
+        match proposal.payload.as_ref() {
+            Some(group_update_request::Payload::InviteMember(im)) => {
+                if urgent_target.is_some() {
+                    continue;
+                }
+                if is_member(&im.identity) {
+                    continue;
+                }
+                updates.push(MlsCommitInput::Add(KeyPackageBytes::new(
+                    im.key_package_bytes.clone(),
+                    im.identity.clone(),
+                )));
+            }
+            Some(group_update_request::Payload::RemoveMember(rm)) => {
+                if let Some(target) = urgent_target.as_deref()
+                    && rm.identity != target
+                {
+                    continue;
+                }
+                if !is_member(&rm.identity) {
+                    continue;
+                }
+                updates.push(MlsCommitInput::Remove(rm.identity.clone()));
+            }
+            _ => return Err(CoreError::InvalidGroupUpdateRequest),
+        }
+    }
+
+    if updates.is_empty() {
+        return Ok(None);
+    }
+
+    let MlsCommitCandidate {
+        proposals: mls_proposals,
+        commit,
+        welcome,
+    } = mls.create_commit_candidate(&updates)?;
+
+    let candidate = CommitCandidate {
+        group_name: group.group_name_bytes().to_vec(),
+        mls_proposals,
+        commit_message: commit,
+        steward_identity: self_identity.to_vec(),
+    };
+
+    let commit_hash = compute_commit_hash(&candidate.commit_message);
+    let epoch = mls.current_epoch()?;
+    let _ = group.add_freeze_candidate(
+        BufferedCommitCandidate {
+            candidate_msg: candidate.clone(),
+            commit_hash,
+            is_local_candidate: true,
+            welcome_bytes: welcome,
+        },
+        epoch,
+    );
+
+    let candidate_msg: AppMessage = candidate.into();
+    Ok(Some(OutboundPacket::new(
+        candidate_msg.encode_to_vec(),
+        APP_MSG_SUBTOPIC,
+        group.group_name(),
+        app_id,
+    )))
+}
+
 // ─────────────────────────── MLS + group setup ───────────────────────────
 
 pub fn default_steward_config() -> StewardListConfig {
@@ -175,7 +304,8 @@ pub fn setup_mls_for_group(group_name: &str, wallet_hex: &str) -> TestMls {
 /// accepted via [`JoinerHandle::accept_welcome_packet`], which constructs
 /// a fresh MLS service and attaches it to the joiner's group.
 pub fn process_inbound_compat(
-    group: &mut Group<TestMls>,
+    group: &mut Group,
+    mls: Option<&TestMls>,
     payload: &[u8],
     subtopic: &str,
 ) -> Result<ProcessResult, de_mls::core::CoreError> {
@@ -185,7 +315,7 @@ pub fn process_inbound_compat(
             Some(welcome_message::Payload::UserKeyPackage(user_kp)) => {
                 let (key_package_bytes, identity) =
                     key_package_bytes_from_json(user_kp.key_package_bytes)?;
-                if let Some(mls) = group.mls()
+                if let Some(mls) = mls
                     && mls.is_member(&identity)
                 {
                     return Ok(ProcessResult::Noop);
@@ -208,12 +338,12 @@ pub fn process_inbound_compat(
             None => Ok(ProcessResult::Noop),
         }
     } else if subtopic == APP_MSG_SUBTOPIC {
-        if group.mls().is_none() {
+        let Some(mls) = mls else {
             // Pre-refactor behaviour: app messages on a group with no MLS
             // state are silently ignored. Mirrors the User-layer dispatch.
             return Ok(ProcessResult::Noop);
-        }
-        process_inbound(group, payload)
+        };
+        process_inbound(group, mls, payload)
     } else {
         Err(de_mls::core::CoreError::InvalidSubtopic(
             subtopic.to_string(),
@@ -221,12 +351,13 @@ pub fn process_inbound_compat(
     }
 }
 
-/// Test handle: bundles `Group<TestMls>` with the per-group steward
-/// plug-in. Replaces the bare `Group<TestMls>` returned by setup helpers
-/// before the plug-in extraction. Tests access `handle.group` and
-/// `handle.steward` explicitly.
+/// Test handle: bundles `Group`, the per-group MLS service, the
+/// steward-list plug-in, and the self identity. Tests access them as
+/// individual fields; `Deref<Target = Group>` keeps proposal-queue calls
+/// working unchanged (e.g. `handle.insert_approved_proposal(...)`).
 pub struct StewardHandle {
-    pub group: Group<TestMls>,
+    pub group: Group,
+    pub mls: TestMls,
     pub steward: DeterministicStewardList,
     pub identity: Vec<u8>,
 }
@@ -238,18 +369,15 @@ impl StewardHandle {
     }
 }
 
-/// Test ergonomics: deref to the embedded `Group<TestMls>` so existing
-/// proposal-queue calls (`insert_approved_proposal`, `mls`, etc.) keep
-/// working unchanged. Steward-list calls go through `handle.steward`.
 impl std::ops::Deref for StewardHandle {
-    type Target = Group<TestMls>;
-    fn deref(&self) -> &Group<TestMls> {
+    type Target = Group;
+    fn deref(&self) -> &Group {
         &self.group
     }
 }
 
 impl std::ops::DerefMut for StewardHandle {
-    fn deref_mut(&mut self) -> &mut Group<TestMls> {
+    fn deref_mut(&mut self) -> &mut Group {
         &mut self.group
     }
 }
@@ -268,13 +396,14 @@ pub fn setup_steward_with_config(
         OpenMlsService::new_as_creator(group_name.to_string(), storage, Arc::clone(&credentials))
             .unwrap();
     let identity_bytes = identity.identity_bytes().to_vec();
-    let group = Group::create_group(group_name, identity_bytes.clone(), config.clone(), mls);
+    let group = Group::create_group(group_name, identity_bytes.clone(), config.clone());
     let mut steward = DeterministicStewardList::empty(group_name.as_bytes().to_vec(), config);
     let _events = steward
         .install_list(0, std::slice::from_ref(&identity_bytes), 1, 0)
         .expect("bootstrap list install");
     StewardHandle {
         group,
+        mls,
         steward,
         identity: identity_bytes,
     }
@@ -288,7 +417,8 @@ pub struct JoinerHandle {
     pub identity: Arc<WalletIdentity>,
     pub credentials: Arc<MlsCredentials>,
     pub storage: Arc<MemoryDeMlsStorage>,
-    pub group: Group<TestMls>,
+    pub group: Group,
+    pub mls: Option<TestMls>,
     pub steward: DeterministicStewardList,
     pub kp_packet: OutboundPacket,
 }
@@ -309,7 +439,7 @@ impl JoinerHandle {
     }
 
     /// Accept a welcome `OutboundPacket` (the kind `steward_add_joiner`
-    /// returns) and attach the resulting MLS service to `self.group`.
+    /// returns) and store the resulting MLS service on the handle.
     /// Panics if the packet isn't an `InvitationToJoin` or doesn't match
     /// this joiner's key package — both indicate a test setup bug.
     pub fn accept_welcome_packet(&mut self, welcome_packet: &OutboundPacket) {
@@ -322,7 +452,7 @@ impl JoinerHandle {
             .try_accept_welcome(&invitation.mls_message_out_bytes)
             .unwrap()
             .expect("welcome did not match this joiner's KP");
-        self.group.attach_mls(svc);
+        self.mls = Some(svc);
     }
 }
 
@@ -336,7 +466,7 @@ pub fn setup_joiner_with_config(
     config: StewardListConfig,
 ) -> JoinerHandle {
     let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
-    let group: Group<TestMls> = Group::prepare_to_join(
+    let group = Group::prepare_to_join(
         group_name,
         identity.identity_bytes().to_vec(),
         config.clone(),
@@ -351,6 +481,7 @@ pub fn setup_joiner_with_config(
         credentials,
         storage,
         group,
+        mls: None,
         steward,
         kp_packet,
     }
@@ -380,10 +511,7 @@ pub fn steward_add_joiner(
     };
     let (key_package_bytes, identity) =
         key_package_bytes_from_json(user_kp.key_package_bytes).unwrap();
-    let already_member = steward_handle
-        .group
-        .mls()
-        .is_some_and(|m| m.is_member(&identity));
+    let already_member = steward_handle.mls.is_member(&identity);
     if already_member {
         panic!("Expected key package skipped for already-member");
     }
@@ -399,8 +527,9 @@ pub fn steward_add_joiner(
         .group
         .insert_approved_proposal(proposal_id, gur);
     let self_id = steward_handle.identity.clone();
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &self_id,
         b"test-app-id",
@@ -409,6 +538,7 @@ pub fn steward_add_joiner(
 
     let finalize = finalize_freeze_round(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         false,
         b"test-app-id",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -396,7 +396,7 @@ pub fn setup_steward_with_config(
         OpenMlsService::new_as_creator(group_name.to_string(), storage, Arc::clone(&credentials))
             .unwrap();
     let identity_bytes = identity.identity_bytes().to_vec();
-    let group = Group::create_group(group_name, identity_bytes.clone(), config.clone());
+    let group = Group::create_group(group_name, identity_bytes.clone());
     let mut steward = DeterministicStewardList::empty(group_name.as_bytes().to_vec(), config);
     let _events = steward
         .install_list(0, std::slice::from_ref(&identity_bytes), 1, 0)
@@ -466,11 +466,7 @@ pub fn setup_joiner_with_config(
     config: StewardListConfig,
 ) -> JoinerHandle {
     let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
-    let group = Group::prepare_to_join(
-        group_name,
-        identity.identity_bytes().to_vec(),
-        config.clone(),
-    );
+    let group = Group::prepare_to_join(group_name, identity.identity_bytes().to_vec());
     let steward = DeterministicStewardList::empty(group_name.as_bytes().to_vec(), config);
     let key_package =
         OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(&storage, &credentials)

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -46,11 +46,7 @@ fn test_process_inbound_app_msg_before_mls_init() {
     // Joiner-side handle with no MLS service attached yet.
     let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Group = Group::prepare_to_join(
-        "test-group",
-        identity.identity_bytes().to_vec(),
-        default_steward_config(),
-    );
+    let mut group: Group = Group::prepare_to_join("test-group", identity.identity_bytes().to_vec());
 
     let result =
         process_inbound_compat(&mut group, None, b"some payload", APP_MSG_SUBTOPIC).unwrap();
@@ -134,11 +130,7 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
     // same; promotion to a voting proposal is the app's decision.
     let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Group = Group::prepare_to_join(
-        group_name,
-        identity.identity_bytes().to_vec(),
-        default_steward_config(),
-    );
+    let mut group: Group = Group::prepare_to_join(group_name, identity.identity_bytes().to_vec());
 
     let other = setup_joiner(group_name, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
 
@@ -545,7 +537,7 @@ fn test_auto_fill_never_triggers_with_default_config() {
     let members = steward_handle.mls.members().unwrap();
     assert_eq!(members.len(), 1);
     assert!(
-        members.len() >= steward_handle.protocol_config().sn_min,
+        members.len() >= steward_handle.steward.config().sn_min,
         "default config (sn_min=1) should never trigger auto-fill"
     );
 }
@@ -694,8 +686,8 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         joiner.group.pending_update_max_epochs(),
         STEWARD_PENDING_MAX_EPOCHS
     );
-    assert_ne!(joiner.group.protocol_config().sn_min, STEWARD_SN_MIN);
-    assert_ne!(joiner.group.protocol_config().sn_max, STEWARD_SN_MAX);
+    assert_ne!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
+    assert_ne!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
 
     let (welcome_packet, _) = steward_add_joiner(&mut steward_handle, &joiner.kp_packet);
     joiner.accept_welcome_packet(&welcome_packet);
@@ -708,7 +700,7 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         election_epoch: steward_list.election_epoch(),
         sn_min: steward_list.config().sn_min as u32,
         sn_max: steward_list.config().sn_max as u32,
-        allow_subset_candidates: steward_handle.allow_subset_candidates(),
+        allow_subset_candidates: steward_handle.steward.config().allow_subset_candidates,
         peer_scores: vec![
             PeerScore {
                 member_id: alice.clone(),
@@ -756,7 +748,7 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut applied_protocol =
         StewardListConfig::new(received.sn_min as usize, received.sn_max as usize).unwrap();
     applied_protocol.allow_subset_candidates = received.allow_subset_candidates;
-    joiner.group.set_protocol_config(applied_protocol);
+    joiner.steward.set_config(applied_protocol);
     joiner
         .group
         .set_liveness_criteria_yes(received.liveness_criteria_yes);
@@ -769,8 +761,8 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         joiner.group.pending_update_max_epochs(),
         STEWARD_PENDING_MAX_EPOCHS
     );
-    assert_eq!(joiner.group.protocol_config().sn_min, STEWARD_SN_MIN);
-    assert_eq!(joiner.group.protocol_config().sn_max, STEWARD_SN_MAX);
+    assert_eq!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
+    assert_eq!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
 
     let mut scoring = PeerScoringService::new(
         InMemoryPeerScoreStorage::new(),

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -11,8 +11,7 @@ use prost::Message;
 
 use de_mls::core::{
     CoreError, FreezeOutcome, Group, ProcessResult, StewardList, StewardListConfig,
-    StewardListPlugin, build_key_package_message, create_commit_candidate, finalize_freeze_round,
-    group_members,
+    StewardListPlugin, build_key_package_message, finalize_freeze_round,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC};
 use de_mls::identity::{Identity, parse_wallet_address};
@@ -23,8 +22,9 @@ use de_mls::protos::de_mls::messages::v1::{
 
 mod common;
 use common::{
-    TestMls, default_steward_config, process_inbound_compat, setup_identity_storage, setup_joiner,
-    setup_joiner_with_config, setup_steward, setup_steward_with_config, steward_add_joiner,
+    build_commit_candidate, default_steward_config, process_inbound_compat, setup_identity_storage,
+    setup_joiner, setup_joiner_with_config, setup_steward, setup_steward_with_config,
+    steward_add_joiner,
 };
 
 // ─────────────────────────── process_inbound tests ───────────────────────────
@@ -33,7 +33,7 @@ use common::{
 fn test_process_inbound_invalid_subtopic() {
     let mut group = setup_steward("test-group", "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-    let result = process_inbound_compat(&mut group, b"some payload", "invalid");
+    let result = process_inbound_compat(&mut group, None, b"some payload", "invalid");
     assert!(result.is_err());
     match result.unwrap_err() {
         CoreError::InvalidSubtopic(s) => assert_eq!(s, "invalid"),
@@ -46,13 +46,14 @@ fn test_process_inbound_app_msg_before_mls_init() {
     // Joiner-side handle with no MLS service attached yet.
     let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Group<TestMls> = Group::prepare_to_join(
+    let mut group: Group = Group::prepare_to_join(
         "test-group",
         identity.identity_bytes().to_vec(),
         default_steward_config(),
     );
 
-    let result = process_inbound_compat(&mut group, b"some payload", APP_MSG_SUBTOPIC).unwrap();
+    let result =
+        process_inbound_compat(&mut group, None, b"some payload", APP_MSG_SUBTOPIC).unwrap();
     assert!(matches!(result, ProcessResult::Noop));
 }
 
@@ -74,13 +75,17 @@ fn test_process_inbound_conversation_message_roundtrip() {
     };
     let app_msg: AppMessage = conv.into();
     let outbound = steward_handle
-        .mls()
-        .unwrap()
+        .mls
         .build_message(&app_msg, b"test-app-id")
         .unwrap();
 
-    let result =
-        process_inbound_compat(&mut joiner.group, &outbound.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &outbound.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
 
     match result {
         ProcessResult::AppMessage(msg) => {
@@ -106,7 +111,8 @@ fn test_process_inbound_welcome_steward_receives_key_package() {
     let joiner = setup_joiner(group_name, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
 
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &joiner.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -128,7 +134,7 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
     // same; promotion to a voting proposal is the app's decision.
     let (identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Group<TestMls> = Group::prepare_to_join(
+    let mut group: Group = Group::prepare_to_join(
         group_name,
         identity.identity_bytes().to_vec(),
         default_steward_config(),
@@ -137,7 +143,8 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
     let other = setup_joiner(group_name, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
 
     let result =
-        process_inbound_compat(&mut group, &other.kp_packet.payload, WELCOME_SUBTOPIC).unwrap();
+        process_inbound_compat(&mut group, None, &other.kp_packet.payload, WELCOME_SUBTOPIC)
+            .unwrap();
 
     assert!(
         matches!(result, ProcessResult::MembershipChangeReceived(_)),
@@ -158,7 +165,7 @@ fn test_process_inbound_welcome_invitation_joins_group() {
     joiner.accept_welcome_packet(&welcome_packet);
 
     // Joiner now has a live MLS service for the right group.
-    let mls = joiner.group.mls().expect("welcome attaches MLS service");
+    let mls = joiner.mls.as_ref().expect("welcome attaches MLS service");
     assert_eq!(mls.group_id(), group_name);
 }
 
@@ -200,7 +207,7 @@ fn test_process_inbound_welcome_already_joined_ignores() {
 
     // Joiner2 actually accepts theirs as a sanity check.
     joiner2.accept_welcome_packet(&welcome_packet2);
-    assert!(joiner2.group.mls().is_some());
+    assert!(joiner2.mls.is_some());
 }
 
 #[test]
@@ -226,8 +233,9 @@ fn test_process_inbound_leave_group() {
     };
     steward_handle.insert_approved_proposal(2, remove_req.clone());
     joiner.group.insert_approved_proposal(2, remove_req);
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -240,11 +248,16 @@ fn test_process_inbound_leave_group() {
         .expect("Expected batch proposals packet");
 
     // Start freeze round before receiving candidate
-    let epoch = joiner.group.mls().unwrap().current_epoch().unwrap();
+    let epoch = joiner.mls.as_ref().unwrap().current_epoch().unwrap();
     joiner.group.start_freeze_round(epoch);
 
-    let remove_result =
-        process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let remove_result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
 
     assert!(
         matches!(remove_result, ProcessResult::CommitCandidateReceived),
@@ -252,8 +265,14 @@ fn test_process_inbound_leave_group() {
         remove_result
     );
 
-    let finalize =
-        finalize_freeze_round(&mut joiner.group, &joiner.steward, false, b"test-app-id").unwrap();
+    let finalize = finalize_freeze_round(
+        &mut joiner.group,
+        joiner.mls.as_ref().unwrap(),
+        &joiner.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
     let matched = matches!(
         &finalize.outcome,
         FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::LeaveGroup)
@@ -284,7 +303,7 @@ fn test_rejoin_after_eviction() {
     let mut joiner = setup_joiner(group_name, joiner_hex);
     let (welcome_packet, _) = steward_add_joiner(&mut steward_handle, &joiner.kp_packet);
     joiner.accept_welcome_packet(&welcome_packet);
-    assert!(joiner.group.mls().is_some());
+    assert!(joiner.mls.as_ref().is_some());
 
     // Phase 2: steward commits a removal of the joiner. Both sides apply
     // the commit; the joiner's finalize emits `LeaveGroup`.
@@ -299,8 +318,9 @@ fn test_rejoin_after_eviction() {
     };
     steward_handle.insert_approved_proposal(2, remove_req.clone());
     joiner.group.insert_approved_proposal(2, remove_req);
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -311,12 +331,24 @@ fn test_rejoin_after_eviction() {
         .find(|p| p.subtopic == APP_MSG_SUBTOPIC)
         .expect("Expected batch proposals packet");
 
-    let epoch_before_remove = joiner.group.mls().unwrap().current_epoch().unwrap();
+    let epoch_before_remove = joiner.mls.as_ref().unwrap().current_epoch().unwrap();
     joiner.group.start_freeze_round(epoch_before_remove);
 
-    process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
-    let finalize_joiner =
-        finalize_freeze_round(&mut joiner.group, &joiner.steward, false, b"test-app-id").unwrap();
+    process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
+    let finalize_joiner = finalize_freeze_round(
+        &mut joiner.group,
+        joiner.mls.as_ref().unwrap(),
+        &joiner.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
     assert!(
         matches!(
             &finalize_joiner.outcome,
@@ -326,6 +358,7 @@ fn test_rejoin_after_eviction() {
     );
     let finalize_steward = finalize_freeze_round(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         false,
         b"test-app-id",
@@ -335,27 +368,22 @@ fn test_rejoin_after_eviction() {
         &finalize_steward.outcome,
         FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::GroupUpdated)
     ));
-    assert!(!steward_handle.mls().unwrap().is_member(&joiner_id),);
+    assert!(!steward_handle.mls.is_member(&joiner_id),);
 
     // Phase 3: app-layer cleanup that follows `ProcessResult::LeaveGroup`.
-    // Take the MLS service out of the joiner's group and tear down its
-    // storage; the second take is a no-op (idempotent at the Group level).
-    let removed = joiner.group.take_mls().expect("mls present pre-leave");
+    // Take the MLS service out of the joiner handle and tear down its
+    // storage; the second take is a no-op (idempotent).
+    let removed = joiner.mls.take().expect("mls present pre-leave");
     removed.delete().unwrap();
     drop(removed);
-    assert!(joiner.group.mls().is_none());
-    assert!(
-        joiner.group.take_mls().is_none(),
-        "second take is idempotent"
-    );
+    assert!(joiner.mls.is_none());
+    assert!(joiner.mls.take().is_none(), "second take is idempotent");
 
-    // Phase 4: joiner rebuilds the app-layer handle, generates a fresh KP
-    // (re-using the same identity + storage), and the steward re-adds.
-    let mut joiner_group: Group<TestMls> = Group::prepare_to_join(
-        group_name,
-        joiner.identity.identity_bytes().to_vec(),
-        default_steward_config(),
-    );
+    // Phase 4: joiner generates a fresh KP (re-using the same identity +
+    // storage); the steward re-adds them. With MLS now on the entry/handle
+    // rather than `Group`, no separate joiner-side `Group` allocation is
+    // needed for the rejoin — the test only needs the resulting MLS service.
+    let _ = default_steward_config();
     let key_package = OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(
         &joiner.storage,
         &joiner.credentials,
@@ -375,29 +403,23 @@ fn test_rejoin_after_eviction() {
         )) => inv,
         other => panic!("Expected InvitationToJoin, got {:?}", other),
     };
-    let svc = OpenMlsService::new_from_welcome(
+    let joiner_mls = OpenMlsService::new_from_welcome(
         &invitation.mls_message_out_bytes,
         Arc::clone(&joiner.storage),
         Arc::clone(&joiner.credentials),
     )
     .unwrap()
     .expect("welcome should match this joiner's fresh KP");
-    joiner_group.attach_mls(svc);
 
     // Phase 5: both sides see the rejoined member at a strictly-later epoch.
-    let epoch_after_rejoin = joiner_group.mls().unwrap().current_epoch().unwrap();
+    let epoch_after_rejoin = joiner_mls.current_epoch().unwrap();
     assert!(
         epoch_after_rejoin > epoch_before_remove,
         "Rejoin should land at a later epoch ({epoch_after_rejoin} > {epoch_before_remove})"
     );
-    assert!(steward_handle.mls().unwrap().is_member(&joiner_id));
-    assert!(joiner_group.mls().unwrap().is_member(&joiner_id));
-    assert!(
-        joiner_group
-            .mls()
-            .unwrap()
-            .is_member(steward_handle.self_identity()),
-    );
+    assert!(steward_handle.mls.is_member(&joiner_id));
+    assert!(joiner_mls.is_member(&joiner_id));
+    assert!(joiner_mls.is_member(steward_handle.self_identity()),);
 }
 
 #[test]
@@ -422,8 +444,9 @@ fn test_process_inbound_raw_commit_payload_is_ignored() {
         ),
     };
     steward_handle.insert_approved_proposal(7, remove_req);
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -441,7 +464,13 @@ fn test_process_inbound_raw_commit_payload_is_ignored() {
         _ => panic!("Expected CommitCandidate payload"),
     };
 
-    let result = process_inbound_compat(&mut joiner.group, &raw_commit, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &raw_commit,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(matches!(result, ProcessResult::Noop));
 }
 
@@ -460,7 +489,7 @@ fn test_auto_fill_steward_list_triggers_below_sn_min() {
     let mut steward_handle = setup_steward_with_config(group, steward_hex, config.clone());
 
     // Bootstrap: 1 member < sn_min=3
-    let members_before = group_members(&steward_handle).unwrap();
+    let members_before = steward_handle.mls.members().unwrap();
     assert_eq!(members_before.len(), 1);
     assert!(members_before.len() < config.sn_min);
 
@@ -469,10 +498,10 @@ fn test_auto_fill_steward_list_triggers_below_sn_min() {
     steward_add_joiner(&mut steward_handle, &joiner1.kp_packet);
 
     // 2 members: still below sn_min=3
-    let members_2 = group_members(&steward_handle).unwrap();
+    let members_2 = steward_handle.mls.members().unwrap();
     assert_eq!(members_2.len(), 2);
     assert!(members_2.len() < config.sn_min);
-    let epoch = steward_handle.mls().unwrap().current_epoch().unwrap();
+    let epoch = steward_handle.mls.current_epoch().unwrap();
     let sn = members_2.len().min(config.sn_max);
     assert!(
         steward_handle
@@ -498,7 +527,7 @@ fn test_auto_fill_steward_list_triggers_below_sn_min() {
     steward_add_joiner(&mut steward_handle, &joiner2.kp_packet);
 
     // 3 members: at sn_min=3
-    let members_3 = group_members(&steward_handle).unwrap();
+    let members_3 = steward_handle.mls.members().unwrap();
     assert_eq!(members_3.len(), 3);
     assert!(
         members_3.len() >= config.sn_min,
@@ -513,7 +542,7 @@ fn test_auto_fill_never_triggers_with_default_config() {
 
     let steward_handle = setup_steward(group, steward_hex);
 
-    let members = group_members(&steward_handle).unwrap();
+    let members = steward_handle.mls.members().unwrap();
     assert_eq!(members.len(), 1);
     assert!(
         members.len() >= steward_handle.protocol_config().sn_min,
@@ -562,13 +591,17 @@ fn test_group_sync_roundtrip() {
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet = steward_handle
-        .mls()
-        .unwrap()
+        .mls
         .build_message(&app_msg, b"test-app-id")
         .unwrap();
 
-    let result =
-        process_inbound_compat(&mut joiner.group, &sync_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &sync_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
 
     match &result {
         ProcessResult::GroupSyncReceived(received_sync) => {
@@ -582,7 +615,7 @@ fn test_group_sync_roundtrip() {
 
     if let ProcessResult::GroupSyncReceived(sync) = result {
         let config = StewardListConfig::new(sync.sn_min as usize, sync.sn_max as usize).unwrap();
-        let members = group_members(&joiner.group).unwrap();
+        let members = joiner.mls.as_ref().unwrap().members().unwrap();
 
         let all_present = sync
             .steward_members
@@ -695,13 +728,17 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet = steward_handle
-        .mls()
-        .unwrap()
+        .mls
         .build_message(&app_msg, b"test-app-id")
         .unwrap();
 
-    let result =
-        process_inbound_compat(&mut joiner.group, &sync_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &sync_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     let received = match result {
         ProcessResult::GroupSyncReceived(s) => s,
         other => panic!("Expected GroupSyncReceived, got {:?}", other),
@@ -783,7 +820,7 @@ fn test_group_sync_idempotent_for_existing_members() {
     joiner.accept_welcome_packet(&welcome_packet);
 
     // Manually give the joiner a steward list (simulating a previous sync)
-    let members = group_members(&joiner.group).unwrap();
+    let members = joiner.mls.as_ref().unwrap().members().unwrap();
     assert!(joiner.steward.install_list(0, &members, 1, 0).is_ok());
     assert!(joiner.steward.current_list().is_some());
 
@@ -804,14 +841,18 @@ fn test_group_sync_idempotent_for_existing_members() {
     };
     let app_msg: AppMessage = sync.into();
     let sync_packet = steward_handle
-        .mls()
-        .unwrap()
+        .mls
         .build_message(&app_msg, b"test-app-id")
         .unwrap();
 
     // Joiner processes sync — core still surfaces GroupSyncReceived
-    let result =
-        process_inbound_compat(&mut joiner.group, &sync_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &sync_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(result, ProcessResult::GroupSyncReceived(_)),
         "Core should still return GroupSyncReceived"
@@ -841,10 +882,10 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
         let joiner = setup_joiner_with_config(group_name, hex, config.clone());
         steward_add_joiner(&mut steward_handle, &joiner.kp_packet);
     }
-    let members = group_members(&steward_handle).unwrap();
+    let members = steward_handle.mls.members().unwrap();
     assert_eq!(members.len(), 4);
 
-    let epoch = steward_handle.mls().unwrap().current_epoch().unwrap();
+    let epoch = steward_handle.mls.current_epoch().unwrap();
     let accepted_round: u32 = 2;
     steward_handle
         .steward

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -4,7 +4,7 @@
 use de_mls::core::StewardListPlugin;
 use de_mls::core::{
     FreezeOutcome, ProcessResult, ProposalId, ScoreEvent, apply_consensus_result,
-    create_commit_candidate, finalize_freeze_round, group_members,
+    finalize_freeze_round,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC};
 use de_mls::identity::Identity;
@@ -16,7 +16,9 @@ use de_mls::protos::de_mls::messages::v1::{
 use prost::Message;
 
 mod common;
-use common::{process_inbound_compat, setup_joiner, setup_steward, steward_add_joiner};
+use common::{
+    build_commit_candidate, process_inbound_compat, setup_joiner, setup_steward, steward_add_joiner,
+};
 
 // ─────────────────────────── Tests ───────────────────────────
 
@@ -51,8 +53,9 @@ fn test_emergency_in_approved_queue_returns_error() {
     group.insert_approved_proposal(50, emergency_request);
     assert_eq!(group.approved_proposals_count(), 1);
 
-    let result = create_commit_candidate(
+    let result = build_commit_candidate(
         &mut group.group,
+        &group.mls,
         &group.steward,
         &group.identity,
         b"test-app-id",
@@ -98,7 +101,7 @@ fn test_violation_evidence_carries_steward_id_and_epoch() {
 fn test_mls_epoch_accessible_after_group_creation() {
     let group_name = "epoch-mls";
     let group = setup_steward(group_name, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let epoch = group.mls().unwrap().current_epoch().unwrap();
+    let epoch = group.mls.current_epoch().unwrap();
     assert_eq!(epoch, 0);
 }
 
@@ -107,12 +110,12 @@ fn test_clear_approved_proposals_does_not_change_mls_epoch() {
     let group_name = "epoch-no-change";
     let mut group = setup_steward(group_name, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-    assert_eq!(group.mls().unwrap().current_epoch().unwrap(), 0);
+    assert_eq!(group.mls.current_epoch().unwrap(), 0);
 
     group.insert_approved_proposal(1, GroupUpdateRequest { payload: None });
     group.clear_approved_proposals();
     // MLS epoch only advances on actual commit merge, not on clear_approved_proposals
-    assert_eq!(group.mls().unwrap().current_epoch().unwrap(), 0);
+    assert_eq!(group.mls.current_epoch().unwrap(), 0);
 }
 
 /// Test: apply_consensus_result errors on invalid (unparseable) payload.
@@ -139,7 +142,8 @@ fn test_emergency_mixed_with_regular_returns_error() {
 
     let joiner2 = setup_joiner(group_name, "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &joiner2.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -160,8 +164,9 @@ fn test_emergency_mixed_with_regular_returns_error() {
             .unwrap(),
     );
 
-    let result = create_commit_candidate(
+    let result = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -192,7 +197,8 @@ fn test_duplicate_batch_returns_noop() {
     let joiner2 = setup_joiner(group_name, "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
 
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &joiner2.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -205,8 +211,9 @@ fn test_duplicate_batch_returns_noop() {
     let proposal_id: ProposalId = 45;
     steward_handle.insert_approved_proposal(proposal_id, gur.clone());
     joiner.group.insert_approved_proposal(proposal_id, gur);
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -218,12 +225,17 @@ fn test_duplicate_batch_returns_noop() {
         .expect("Expected batch proposals packet");
 
     // Start freeze round so candidates get buffered
-    let epoch = joiner.group.mls().unwrap().current_epoch().unwrap();
+    let epoch = joiner.mls.as_ref().unwrap().current_epoch().unwrap();
     joiner.group.start_freeze_round(epoch);
 
     // First receive: candidate buffered → CommitCandidateReceived
-    let r1 =
-        process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let r1 = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(r1, ProcessResult::CommitCandidateReceived),
         "Expected CommitCandidateReceived, got {:?}",
@@ -231,8 +243,13 @@ fn test_duplicate_batch_returns_noop() {
     );
 
     // Second receive of same batch: should be detected as duplicate
-    let r2 =
-        process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let r2 = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(r2, ProcessResult::Noop),
         "Expected Noop (duplicate), got {:?}",
@@ -253,7 +270,7 @@ fn test_violation_does_not_corrupt_mls_state() {
     joiner.accept_welcome_packet(&welcome_packet);
 
     // After joining, MLS members should be accessible
-    let members = group_members(&joiner.group).unwrap();
+    let members = joiner.mls.as_ref().unwrap().members().unwrap();
     assert_eq!(
         members.len(),
         2,
@@ -276,7 +293,8 @@ fn test_candidate_ignored_without_freeze_round() {
     let joiner2 = setup_joiner(group_name, "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
 
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &joiner2.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -288,8 +306,9 @@ fn test_candidate_ignored_without_freeze_round() {
 
     let proposal_id: ProposalId = 44;
     steward_handle.insert_approved_proposal(proposal_id, gur.clone());
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -301,8 +320,13 @@ fn test_candidate_ignored_without_freeze_round() {
         .expect("Expected batch proposals packet");
 
     // Joiner has NO freeze round active → candidate ignored
-    let result =
-        process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(result, ProcessResult::Noop),
         "Expected Noop (no freeze round), got {:?}",
@@ -326,7 +350,8 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     // Add a third member proposal
     let joiner2 = setup_joiner(group_name, "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &joiner2.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -340,8 +365,9 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     steward_handle.insert_approved_proposal(proposal_id, gur.clone());
     joiner.group.insert_approved_proposal(proposal_id, gur);
 
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -353,12 +379,17 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         .expect("Expected batch proposals packet");
 
     // Start freeze round before receiving candidate
-    let epoch = joiner.group.mls().unwrap().current_epoch().unwrap();
+    let epoch = joiner.mls.as_ref().unwrap().current_epoch().unwrap();
     joiner.group.start_freeze_round(epoch);
 
     // Joiner receives candidate — should buffer it
-    let result =
-        process_inbound_compat(&mut joiner.group, &batch_packet.payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &batch_packet.payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(result, ProcessResult::CommitCandidateReceived),
         "Expected CommitCandidateReceived, got {:?}",
@@ -366,8 +397,14 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     );
 
     // Finalize: MLS commit staging authenticates the sender
-    let finalize =
-        finalize_freeze_round(&mut joiner.group, &joiner.steward, false, b"test-app-id").unwrap();
+    let finalize = finalize_freeze_round(
+        &mut joiner.group,
+        joiner.mls.as_ref().unwrap(),
+        &joiner.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
     let matched = matches!(
         &finalize.outcome,
         FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::GroupUpdated)
@@ -414,7 +451,7 @@ fn test_backup_commit_scores_absent_steward() {
 
     // After the join, both are MLS members. Regenerate the steward list
     // over [Alice, Bob] so both are stewards at the current epoch.
-    let epoch = alice_group.mls().unwrap().current_epoch().unwrap();
+    let epoch = alice_group.mls.current_epoch().unwrap();
     let members = vec![alice_id.clone(), bob_id.clone()];
     alice_group
         .steward
@@ -425,7 +462,8 @@ fn test_backup_commit_scores_absent_steward() {
     // Produce an approved proposal (invite Charlie) on both sides.
     let charlie = setup_joiner(group_name, charlie_hex);
     let gur = match process_inbound_compat(
-        &mut alice_group,
+        &mut alice_group.group,
+        Some(&alice_group.mls),
         &charlie.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -440,8 +478,9 @@ fn test_backup_commit_scores_absent_steward() {
 
     // Bob builds the commit (Alice never submits). His local candidate is
     // the only applicable entry when he finalises.
-    let _ = create_commit_candidate(
+    let _ = build_commit_candidate(
         &mut bob.group,
+        bob.mls.as_ref().unwrap(),
         &bob.steward,
         bob.identity.identity_bytes(),
         b"test-app-id",
@@ -455,8 +494,14 @@ fn test_backup_commit_scores_absent_steward() {
             .to_vec()
     };
 
-    let result =
-        finalize_freeze_round(&mut bob.group, &bob.steward, false, b"test-app-id").unwrap();
+    let result = finalize_freeze_round(
+        &mut bob.group,
+        bob.mls.as_ref().unwrap(),
+        &bob.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
 
     let matched = matches!(
         &result.outcome,
@@ -536,7 +581,8 @@ fn test_forged_steward_identity_scores_mls_sender() {
 
     let third = setup_joiner(group_name, third_hex);
     let result = process_inbound_compat(
-        &mut steward_handle,
+        &mut steward_handle.group,
+        Some(&steward_handle.mls),
         &third.kp_packet.payload,
         WELCOME_SUBTOPIC,
     )
@@ -550,8 +596,9 @@ fn test_forged_steward_identity_scores_mls_sender() {
     steward_handle.insert_approved_proposal(proposal_id, gur.clone());
     joiner.group.insert_approved_proposal(proposal_id, gur);
 
-    let packets = create_commit_candidate(
+    let packets = build_commit_candidate(
         &mut steward_handle.group,
+        &steward_handle.mls,
         &steward_handle.steward,
         &steward_handle.identity,
         b"test-app-id",
@@ -581,16 +628,27 @@ fn test_forged_steward_identity_scores_mls_sender() {
     let mut forged_payload = Vec::with_capacity(app_msg.encoded_len());
     app_msg.encode(&mut forged_payload).unwrap();
 
-    let result =
-        process_inbound_compat(&mut joiner.group, &forged_payload, APP_MSG_SUBTOPIC).unwrap();
+    let result = process_inbound_compat(
+        &mut joiner.group,
+        joiner.mls.as_ref(),
+        &forged_payload,
+        APP_MSG_SUBTOPIC,
+    )
+    .unwrap();
     assert!(
         matches!(result, ProcessResult::CommitCandidateReceived),
         "Expected CommitCandidateReceived after wire forgery, got {:?}",
         result
     );
 
-    let finalize =
-        finalize_freeze_round(&mut joiner.group, &joiner.steward, false, b"test-app-id").unwrap();
+    let finalize = finalize_freeze_round(
+        &mut joiner.group,
+        joiner.mls.as_ref().unwrap(),
+        &joiner.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
     assert!(
         matches!(finalize.outcome, FreezeOutcome::NoCandidate),
         "Expected NoCandidate after dropping the forged candidate, got {:?}",
@@ -624,11 +682,17 @@ fn test_no_valid_candidate_triggers_no_candidate() {
 
     // Start freeze round with no candidates
     group.insert_approved_proposal(1, GroupUpdateRequest { payload: None });
-    let epoch = group.mls().unwrap().current_epoch().unwrap();
+    let epoch = group.mls.current_epoch().unwrap();
     group.start_freeze_round(epoch);
 
-    let finalize =
-        finalize_freeze_round(&mut group.group, &group.steward, false, b"test-app-id").unwrap();
+    let finalize = finalize_freeze_round(
+        &mut group.group,
+        &group.mls,
+        &group.steward,
+        false,
+        b"test-app-id",
+    )
+    .unwrap();
     assert!(
         matches!(finalize.outcome, FreezeOutcome::NoCandidate),
         "Expected NoCandidate when no candidates buffered, got {:?}",

--- a/tests/scoring_integration.rs
+++ b/tests/scoring_integration.rs
@@ -5,10 +5,11 @@
 use prost::Message;
 
 use de_mls::core::{
-    Group, PeerScoringPlugin, PeerScoringService, ScoreEvent, ScoreOp, apply_consensus_result,
-    emergency_score_ops, group_members,
+    PeerScoringPlugin, PeerScoringService, ScoreEvent, ScoreOp, apply_consensus_result,
+    emergency_score_ops,
 };
 use de_mls::ds::WELCOME_SUBTOPIC;
+use de_mls::mls_crypto::MlsService;
 
 mod common;
 use common::{
@@ -22,9 +23,9 @@ fn sync_scoring_members<
     P: de_mls::core::ScoringProvider + Send + Sync + 'static,
 >(
     scoring: &mut PeerScoringService<S, P>,
-    group: &Group<TestMls>,
+    mls: Option<&TestMls>,
 ) {
-    let mls_members = group_members(group).unwrap();
+    let mls_members = mls.map(|m| m.members().unwrap()).unwrap_or_default();
     let scored = scoring.all_members_with_scores();
     let scored_ids: std::collections::HashSet<Vec<u8>> =
         scored.iter().map(|(id, _)| id.clone()).collect();
@@ -104,7 +105,7 @@ fn test_new_joiner_starts_with_default_scores() {
 
     // Bob builds his scoring from MLS members — gets defaults.
     let mut bob_scoring = make_scoring();
-    sync_scoring_members(&mut bob_scoring, &bob.group);
+    sync_scoring_members(&mut bob_scoring, bob.mls.as_ref());
 
     assert_eq!(bob_scoring.score_for(&alice_id), Some(DEFAULT_SCORE));
 }


### PR DESCRIPTION
**Group changes:** drops the `M` generic and the `mls: Option<M>` field. Removes `mls()`, `expect_mls()`, `attach_mls()`, `take_mls()`. `Group::create_group` no longer takes an MLS service. The `NoopMls` test stub goes away — `Group`'s pure-state tests no longer need an MLS impl.

**GroupEntry changes:** adds `mls: Option<M>` and the four accessor methods that used to live on `Group`. Joiner path constructs the entry with `mls: None` and stores the service via `entry.attach_mls(svc)` after the welcome arrives. Leave path uses `entry.take_mls()`. Adds protocol-function wrappers so coordinators don't have to destructure: `entry.create_commit_candidate(self_id, app_id)`, `entry.finalize_freeze_round(allow_subset, app_id)`, `entry.process_inbound(payload)`. Each pulls `group`, `mls`, `steward` from `&mut self` and runs the protocol logic directly.

**core/api signatures:** `process_commit_candidate`, `apply_local_candidate`, `apply_incoming_candidate`, `RoundContext::snapshot` all take `&mut Group` plus `&M` separately. `apply_consensus_result` and `forward_incoming_vote` drop the `M` generic — they only touch `Group`'s proposal queue. `validate_commit_candidate`, `check_commit_sender_authorized`, `record_applied_commit` drop the generic too. `core::api::create_commit_candidate`, `finalize_freeze_round`, `process_inbound`, `group_members` are gone — their bodies live as methods on `GroupEntry`.

**`group_members` cleanup:** the old `core::group_members(Option<&M>)` wrapper is dropped. Callers go directly through `MlsService::members()` (`entry.expect_mls()?.members()?`). The `Option`-as-empty-Vec convenience was load-bearing in maybe two spots and isn't worth the indirection.

**Test fixtures:** `StewardHandle` and `JoinerHandle` gain an `mls` field (`TestMls` / `Option<TestMls>`). `Deref<Target = Group>` keeps proposal-queue test calls working unchanged. `JoinerHandle::accept_welcome_packet` stores the service on `self.mls` rather than calling `group.attach_mls(svc)`. `process_inbound_compat` takes `Option<&TestMls>` as a separate argument. Since tests can't reach `pub(crate)` methods on `GroupEntry`, a `build_commit_candidate` test helper in `tests/common/mod.rs` mirrors `GroupEntry::create_commit_candidate`'s body. **Marked clearly as test scaffolding — keep in sync.** Long-term plan: once `GroupEntry` moves into core (post-state-machine extraction), tests will use the canonical method directly.

`Group::protocol_config: StewardListConfig` was a duplicate of `entry.steward.config()`. Only `allow_subset_candidates` was read in production. Drops the field, the `protocol_config()` / `set_protocol_config()` / `allow_subset_candidates()` accessors, and the redundant `Group::create_group` / `Group::prepare_to_join` config parameter. Two app callers (`freeze::poll_freeze_status`, `steward::send_group_sync`) now read from `entry.steward.config().allow_subset_candidates` directly. Joiner sync's `apply_group_sync_to_entry` drops the `entry.group.set_protocol_config(...)` call — `entry.steward.set_config(...)` already covers it.

