### PR TITLE
refactor(state-machine): split SM and PhaseTimer onto GroupEntry

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -9,8 +9,8 @@ pub use crate::core::{
 use crate::core::{ProposalKind, StewardListConfig};
 
 /// Wall-clock window the steward waits before batching approved proposals
-/// into a commit.
-pub const DEFAULT_EPOCH_DURATION: Duration = Duration::from_secs(60);
+/// into a commit (RFC §Inactivity Timer #1, "Commit inactivity").
+pub const DEFAULT_COMMIT_INACTIVITY_DURATION: Duration = Duration::from_secs(60);
 
 /// Lifetime of a voting proposal before it expires unvoted
 /// (RFC §Creating Voting Proposal).
@@ -20,9 +20,10 @@ pub const DEFAULT_PROPOSAL_EXPIRATION: Duration = Duration::from_secs(600);
 /// vote can stay open. MUST be `> voting_delay`.
 pub const DEFAULT_CONSENSUS_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Inactivity window during recovery. Reset to `epoch_duration` after a
-/// successful commit.
-pub const DEFAULT_RETRY_INACTIVITY_DURATION: Duration = Duration::from_secs(5);
+/// Inactivity window during Layer 2 / Layer 3 recovery
+/// (RFC §Inactivity Timer #2, "Recovery inactivity"). Typically shorter
+/// than `commit_inactivity_duration` so retries don't burn a full epoch.
+pub const DEFAULT_RECOVERY_INACTIVITY_DURATION: Duration = Duration::from_secs(5);
 
 /// Per-member window to cast a manual vote before the app auto-votes
 /// using `liveness_criteria_yes`. MUST be `< consensus_timeout`.
@@ -44,12 +45,15 @@ fn default_protocol_config() -> StewardListConfig {
 /// App-layer timing + embedded core-layer [`StewardListConfig`].
 #[derive(Debug, Clone)]
 pub struct GroupConfig {
-    pub epoch_duration: Duration,
-    /// Freeze window before deterministic selection. Defaults to `epoch_duration / 2`.
+    /// RFC §Inactivity Timer #1: how long the epoch steward has to commit
+    /// approved proposals before honest members enter the freeze round.
+    pub commit_inactivity_duration: Duration,
+    /// Freeze window before deterministic selection. Defaults to
+    /// `commit_inactivity_duration / 2`.
     pub freeze_duration: Duration,
-    /// Inactivity window during recovery. Much shorter than
-    /// `epoch_duration` so retries don't burn another full epoch.
-    pub retry_inactivity_duration: Duration,
+    /// RFC §Inactivity Timer #2: shorter inactivity window applied during
+    /// Layer 2 / Layer 3 recovery so retries don't burn a full epoch.
+    pub recovery_inactivity_duration: Duration,
     /// How long a proposal stays active before expiring (RFC §Creating Voting Proposal).
     pub proposal_expiration: Duration,
     pub consensus_timeout: Duration,
@@ -62,7 +66,7 @@ pub struct GroupConfig {
     pub max_reelection_attempts: u32,
     /// Per-member window to cast a manual vote before the app auto-casts
     /// using `liveness_criteria_yes`. Relationship invariant:
-    /// `voting_delay < consensus_timeout < epoch_duration`. See
+    /// `voting_delay < consensus_timeout < commit_inactivity_duration`. See
     /// [`DEFAULT_VOTING_DELAY`].
     pub voting_delay: Duration,
     /// Auto-vote delay for steward-election proposals (see
@@ -82,9 +86,9 @@ pub struct GroupConfig {
 impl Default for GroupConfig {
     fn default() -> Self {
         Self {
-            epoch_duration: DEFAULT_EPOCH_DURATION,
-            freeze_duration: DEFAULT_EPOCH_DURATION / 2,
-            retry_inactivity_duration: DEFAULT_RETRY_INACTIVITY_DURATION,
+            commit_inactivity_duration: DEFAULT_COMMIT_INACTIVITY_DURATION,
+            freeze_duration: DEFAULT_COMMIT_INACTIVITY_DURATION / 2,
+            recovery_inactivity_duration: DEFAULT_RECOVERY_INACTIVITY_DURATION,
             proposal_expiration: DEFAULT_PROPOSAL_EXPIRATION,
             consensus_timeout: DEFAULT_CONSENSUS_TIMEOUT,
             pending_update_max_epochs: DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
@@ -100,11 +104,12 @@ impl Default for GroupConfig {
 }
 
 impl GroupConfig {
-    /// Default config with a custom epoch; freeze becomes `epoch_duration / 2`.
-    pub fn with_epoch_duration(epoch_duration: Duration) -> Self {
+    /// Default config with a custom commit-inactivity window; freeze becomes
+    /// `commit_inactivity_duration / 2`.
+    pub fn with_commit_inactivity_duration(commit_inactivity_duration: Duration) -> Self {
         Self {
-            epoch_duration,
-            freeze_duration: epoch_duration / 2,
+            commit_inactivity_duration,
+            freeze_duration: commit_inactivity_duration / 2,
             ..Self::default()
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,9 +6,11 @@
 //! then drive it from a transport receive loop
 //! ([`crate::app::User::process_inbound_packet`]) and a periodic poll
 //! ([`crate::app::User::check_member_freeze`],
-//! [`crate::app::User::poll_freeze_status`]). [`crate::app::PhaseTimer`]
-//! owns the per-group state transitions
-//! (`PendingJoin → Working → Freezing → Selection → Reelection → Leaving`).
+//! [`crate::app::User::poll_freeze_status`]).
+//! [`crate::core::GroupStateMachine`] holds the per-group state enum
+//! (`PendingJoin → Working → Freezing → Selection → Reelection → Leaving`)
+//! and [`crate::app::PhaseTimer`] holds the wall-clock anchor + duration
+//! knobs; `GroupEntry` composes them through coordinator methods.
 //!
 //! Use directly for epoch-based steward chat; build a custom app layer if you
 //! need a different consensus model, state machine, or epoch timing.
@@ -21,11 +23,12 @@ mod peer_scoring;
 mod phase_timer;
 mod user;
 
+pub use crate::core::GroupState;
 pub use config::{
-    DEFAULT_CONSENSUS_TIMEOUT, DEFAULT_ELECTION_VOTING_DELAY, DEFAULT_EPOCH_DURATION,
+    DEFAULT_COMMIT_INACTIVITY_DURATION, DEFAULT_CONSENSUS_TIMEOUT, DEFAULT_ELECTION_VOTING_DELAY,
     DEFAULT_LIVENESS_CRITERIA_YES, DEFAULT_MAX_RETRIES, DEFAULT_PEER_SCORE,
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_PROPOSAL_EXPIRATION,
-    DEFAULT_RETRY_INACTIVITY_DURATION, DEFAULT_THRESHOLD_PEER_SCORE, DEFAULT_VOTING_DELAY,
+    DEFAULT_RECOVERY_INACTIVITY_DURATION, DEFAULT_THRESHOLD_PEER_SCORE, DEFAULT_VOTING_DELAY,
     GroupConfig,
 };
 pub use consensus_bridge::{
@@ -37,7 +40,7 @@ pub use display::{
 };
 pub use error::UserError;
 pub use peer_scoring::{FixedScoringProvider, InMemoryPeerScoreStorage};
-pub use phase_timer::{FreezeTimeoutStatus, GroupState, PhaseTimer, StateChangeHandler};
+pub use phase_timer::{FreezeTimeoutStatus, PhaseTimer, StateChangeHandler};
 pub use user::{
     DefaultMlsService, DefaultPeerScoring, DefaultStewardList, KeyPackageGenerator,
     MlsCreatorFactory, MlsWelcomeFactory, ScoringFactory, StewardFactory, User,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,7 +6,7 @@
 //! then drive it from a transport receive loop
 //! ([`crate::app::User::process_inbound_packet`]) and a periodic poll
 //! ([`crate::app::User::check_member_freeze`],
-//! [`crate::app::User::poll_freeze_status`]). [`crate::app::GroupStateMachine`]
+//! [`crate::app::User::poll_freeze_status`]). [`crate::app::PhaseTimer`]
 //! owns the per-group state transitions
 //! (`PendingJoin → Working → Freezing → Selection → Reelection → Leaving`).
 //!
@@ -18,7 +18,7 @@ mod consensus_bridge;
 mod display;
 mod error;
 mod peer_scoring;
-mod state_machine;
+mod phase_timer;
 mod user;
 
 pub use config::{
@@ -37,7 +37,7 @@ pub use display::{
 };
 pub use error::UserError;
 pub use peer_scoring::{FixedScoringProvider, InMemoryPeerScoreStorage};
-pub use state_machine::{FreezeTimeoutStatus, GroupState, GroupStateMachine, StateChangeHandler};
+pub use phase_timer::{FreezeTimeoutStatus, GroupState, PhaseTimer, StateChangeHandler};
 pub use user::{
     DefaultMlsService, DefaultPeerScoring, DefaultStewardList, KeyPackageGenerator,
     MlsCreatorFactory, MlsWelcomeFactory, ScoringFactory, StewardFactory, User,

--- a/src/app/phase_timer.rs
+++ b/src/app/phase_timer.rs
@@ -1,11 +1,11 @@
-//! App-side wrapper around [`crate::core::GroupStateMachine`].
+//! App-side phase timer.
 //!
-//! Adds the timer-driven behaviour the core SM intentionally lacks:
-//! a `started_at` (`Instant`), the `Duration` knobs (epoch, freeze,
-//! retry inactivity, proposal expiration, consensus timeout, voting
-//! delays), and the helpers that combine state + duration to answer
-//! "is this phase timed out?". State transitions delegate to the core
-//! SM and additionally maintain `started_at`.
+//! Holds the wall-clock anchor (`started_at`) and the `Duration` knobs
+//! the timer-driven helpers consult: commit inactivity, freeze, recovery
+//! inactivity, proposal expiration, consensus timeout, voting delays.
+//! State transitions and the state enum live in
+//! [`crate::core::GroupStateMachine`]; `GroupEntry` composes the two and
+//! drives them through coordinator methods.
 
 use std::time::{Duration, Instant};
 
@@ -14,15 +14,11 @@ use tracing::info;
 
 use crate::{
     app::config::GroupConfig,
-    core::{GroupStateMachine as CoreStateMachine, ProposalKind},
+    core::{GroupState, ProposalKind},
 };
 
-// `GroupState` re-exported so `crate::app::GroupState` callsites work
-// unchanged. The enum itself lives in core.
-pub use crate::core::GroupState;
-
 /// Notifies the integrator when a group transitions between [`GroupState`]
-/// variants. Fires from the app layer only — core never calls it.
+/// variants. Fired from the app layer.
 #[async_trait]
 pub trait StateChangeHandler: Send + Sync {
     async fn on_state_changed(&self, group_name: &str, state: GroupState);
@@ -43,27 +39,25 @@ pub enum FreezeTimeoutStatus {
     },
 }
 
-/// App-side state machine: the passive core SM plus a phase timer and
-/// the duration knobs the timer-driven helpers consult.
-///
-/// Transitions delegate to the core SM and additionally maintain the
-/// phase timer. Timer queries (`is_freeze_timed_out`, etc.) live here
-/// because they need wall-clock time.
+/// App-side phase timer: a wall-clock anchor plus the duration knobs the
+/// timer-driven helpers consult. State queries take the current
+/// [`GroupState`] as a parameter; [`crate::app::User`] composes them
+/// with [`crate::core::GroupStateMachine`] through `GroupEntry`.
 #[derive(Debug, Clone)]
 pub struct PhaseTimer {
-    inner: CoreStateMachine,
-    /// Meaning depends on the current core state:
+    /// Meaning depends on the current state (set by the coordinator):
     /// - `PendingJoin`: time the join was initiated.
     /// - `Working`: time the first approved proposal arrived (drives the
     ///   steward-inactivity timer).
     /// - `Freezing`: time the freeze window started.
     /// - Other states: `None`.
     started_at: Option<Instant>,
-    epoch_duration: Duration,
+    /// RFC §Inactivity Timer #1 — "Commit inactivity" threshold.
+    commit_inactivity_duration: Duration,
     freeze_duration: Duration,
-    /// Short inactivity window used during recovery; caller of
-    /// `check_steward_inactivity` picks which duration to apply.
-    retry_inactivity_duration: Duration,
+    /// RFC §Inactivity Timer #2 — "Recovery inactivity" threshold; caller
+    /// of `poll_steward_inactivity` picks which duration to apply.
+    recovery_inactivity_duration: Duration,
     /// Voting-proposal lifetime (RFC §Creating Voting Proposal).
     proposal_expiration: Duration,
     /// Library deadline per consensus session. Mismatched values across
@@ -77,22 +71,21 @@ pub struct PhaseTimer {
 
 impl Default for PhaseTimer {
     fn default() -> Self {
-        Self::new_as_member()
+        Self::with_default_config()
     }
 }
 
 impl PhaseTimer {
-    pub fn new_as_member() -> Self {
-        Self::new_as_member_with_config(GroupConfig::default())
+    pub fn with_default_config() -> Self {
+        Self::with_config(GroupConfig::default())
     }
 
-    pub fn new_as_member_with_config(config: GroupConfig) -> Self {
+    pub fn with_config(config: GroupConfig) -> Self {
         Self {
-            inner: CoreStateMachine::new_as_member(),
             started_at: None,
-            epoch_duration: config.epoch_duration,
+            commit_inactivity_duration: config.commit_inactivity_duration,
             freeze_duration: config.freeze_duration,
-            retry_inactivity_duration: config.retry_inactivity_duration,
+            recovery_inactivity_duration: config.recovery_inactivity_duration,
             proposal_expiration: config.proposal_expiration,
             consensus_timeout: config.consensus_timeout,
             voting_delay: config.voting_delay,
@@ -100,34 +93,33 @@ impl PhaseTimer {
         }
     }
 
-    pub fn new_as_pending_join_with_config(config: GroupConfig) -> Self {
-        Self {
-            inner: CoreStateMachine::new_as_pending_join(),
-            started_at: Some(Instant::now()),
-            epoch_duration: config.epoch_duration,
-            freeze_duration: config.freeze_duration,
-            retry_inactivity_duration: config.retry_inactivity_duration,
-            proposal_expiration: config.proposal_expiration,
-            consensus_timeout: config.consensus_timeout,
-            voting_delay: config.voting_delay,
-            election_voting_delay: config.election_voting_delay,
-        }
+    /// Anchor the timer at "now". Called by the coordinator when entering
+    /// a phase whose timeout matters (PendingJoin, Freezing, on first
+    /// approved proposal in Working).
+    pub fn start(&mut self) {
+        self.started_at = Some(Instant::now());
     }
 
-    pub fn current_state(&self) -> GroupState {
-        self.inner.current_state()
+    /// Drop the anchor. Called by the coordinator when leaving a
+    /// time-bounded phase.
+    pub fn clear(&mut self) {
+        self.started_at = None;
     }
 
-    pub fn epoch_duration(&self) -> Duration {
-        self.epoch_duration
+    pub fn started_at(&self) -> Option<Instant> {
+        self.started_at
+    }
+
+    pub fn commit_inactivity_duration(&self) -> Duration {
+        self.commit_inactivity_duration
     }
 
     pub fn freeze_duration(&self) -> Duration {
         self.freeze_duration
     }
 
-    pub fn retry_inactivity_duration(&self) -> Duration {
-        self.retry_inactivity_duration
+    pub fn recovery_inactivity_duration(&self) -> Duration {
+        self.recovery_inactivity_duration
     }
 
     pub fn proposal_expiration(&self) -> Duration {
@@ -151,16 +143,16 @@ impl PhaseTimer {
     // Setters below are called by `User::on_group_sync` to apply the
     // steward's `TimingConfig`.
 
-    pub fn set_epoch_duration(&mut self, value: Duration) {
-        self.epoch_duration = value;
+    pub fn set_commit_inactivity_duration(&mut self, value: Duration) {
+        self.commit_inactivity_duration = value;
     }
 
     pub fn set_freeze_duration(&mut self, value: Duration) {
         self.freeze_duration = value;
     }
 
-    pub fn set_retry_inactivity_duration(&mut self, value: Duration) {
-        self.retry_inactivity_duration = value;
+    pub fn set_recovery_inactivity_duration(&mut self, value: Duration) {
+        self.recovery_inactivity_duration = value;
     }
 
     pub fn set_proposal_expiration(&mut self, value: Duration) {
@@ -171,63 +163,20 @@ impl PhaseTimer {
         self.consensus_timeout = value;
     }
 
-    // ─────────────────────────── State transitions ───────────────────────────
+    // ─────────────────────────── State-aware queries ───────────────────────────
 
-    pub fn start_working(&mut self) {
-        self.inner.start_working();
-        self.started_at = None;
-        info!(state = "Working", "state transition");
-    }
-
-    pub fn start_freezing(&mut self) {
-        self.inner.start_freezing();
-        self.started_at = Some(Instant::now());
-        info!(state = "Freezing", "state transition");
-    }
-
-    /// Bypass the inactivity timer and enter Freezing immediately. Returns
-    /// `true` on transition (only fires from `Working` or `Reelection`).
-    pub fn force_freezing(&mut self) -> bool {
-        if self.inner.force_freezing() {
-            self.started_at = Some(Instant::now());
-            info!(state = "Freezing", "state transition (forced)");
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn start_selection(&mut self) {
-        self.inner.start_selection();
-        info!(state = "Selection", "state transition");
-    }
-
-    pub fn start_reelection(&mut self) {
-        self.inner.start_reelection();
-        self.started_at = None;
-        info!(state = "Reelection", "state transition");
-    }
-
-    /// Caller must ensure a valid transition. `User::leave_group` handles
-    /// the PendingJoin and already-Leaving cases separately.
-    pub fn start_leaving(&mut self) {
-        self.inner.start_leaving();
-        info!(state = "Leaving", "state transition");
-    }
-
-    // ─────────────────────────── Pending Join ───────────────────────────
-
-    /// `true` once 3× epoch-duration has passed in `PendingJoin` without a
-    /// welcome — the join attempt is abandoned and local state torn down.
-    pub fn is_pending_join_expired(&self) -> bool {
-        if self.current_state() != GroupState::PendingJoin {
+    /// `true` once 3× `commit_inactivity_duration` has passed in
+    /// `PendingJoin` without a welcome — the join attempt is abandoned
+    /// and local state torn down.
+    pub fn is_pending_join_expired(&self, state: GroupState) -> bool {
+        if state != GroupState::PendingJoin {
             return false;
         }
 
         if let Some(started_at) = self.started_at {
-            // Pipeline: consensus (~15s) + epoch_duration + freeze_duration (epoch/2)
-            // = ~1.5× epoch + consensus overhead. Use 3× epoch for safety margin.
-            let max_wait = self.epoch_duration * 3;
+            // Pipeline: consensus (~15s) + commit_inactivity + freeze (≈ commit/2)
+            // = ~1.5× commit-inactivity + consensus overhead. Use 3× for safety margin.
+            let max_wait = self.commit_inactivity_duration * 3;
             if Instant::now() >= started_at + max_wait {
                 return true;
             }
@@ -236,11 +185,9 @@ impl PhaseTimer {
         false
     }
 
-    // ─────────────────────────── Freeze Timeout ───────────────────────────
-
     /// `true` once the freeze window elapsed while in `Freezing`.
-    pub fn is_freeze_timed_out(&self) -> bool {
-        if self.current_state() != GroupState::Freezing {
+    pub fn is_freeze_timed_out(&self, state: GroupState) -> bool {
+        if state != GroupState::Freezing {
             return false;
         }
 
@@ -250,30 +197,26 @@ impl PhaseTimer {
 
         false
     }
-    // ─────────────────────────── Proposal Timer (Member Inactivity) ───────────────────────────
 
-    pub fn clear_proposal_timer(&mut self) {
-        self.started_at = None;
-    }
-
-    /// Drives the "steward waited too long to commit" transition into
-    /// `Freezing`. Call each poll tick; returns `true` exactly on the tick
-    /// that transitions.
+    /// Polls the steward-inactivity timer. Returns `true` when the
+    /// inactivity window has elapsed and the caller should transition to
+    /// `Freezing`. Self-starts the timer on the first call with approved
+    /// work; returns `false` outside `Working` or with no approved work.
     ///
     /// - The timer anchors on the *first* approved proposal — a burst of
     ///   approvals doesn't reset it.
-    /// - `start_working` clears the timer, so the next tick with leftover
-    ///   approved work starts a fresh window (matters for auto-approved
-    ///   self-leaves that survive a reelection round).
+    /// - The coordinator's `start_working` clears the anchor, so the next
+    ///   tick with leftover approved work starts a fresh window (matters
+    ///   for auto-approved self-leaves that survive a reelection round).
     /// - `inactivity_duration` is supplied by the caller (long during
     ///   normal operation, short during recovery).
-    /// - No-op outside `Working`.
-    pub fn check_steward_inactivity(
+    pub fn poll_steward_inactivity(
         &mut self,
+        state: GroupState,
         approved_proposals_count: usize,
         inactivity_duration: Duration,
     ) -> bool {
-        if self.current_state() != GroupState::Working || approved_proposals_count == 0 {
+        if state != GroupState::Working || approved_proposals_count == 0 {
             return false;
         }
 
@@ -294,7 +237,6 @@ impl PhaseTimer {
             return false;
         }
 
-        self.start_freezing();
         info!(
             inactivity_ms = inactivity_duration.as_millis() as u64,
             approved = approved_proposals_count,
@@ -308,62 +250,6 @@ impl PhaseTimer {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_pending_join_timeout() {
-        let config = GroupConfig::default();
-        let mut state_machine = PhaseTimer::new_as_pending_join_with_config(config.clone());
-        assert!(!state_machine.is_pending_join_expired());
-
-        // Backdate past the 3× epoch_duration expiration threshold.
-        let past = config.epoch_duration * 3 + Duration::from_secs(1);
-        state_machine.started_at = Some(Instant::now() - past);
-        assert!(state_machine.is_pending_join_expired());
-    }
-
-    #[test]
-    fn test_pending_join_not_expired_when_working() {
-        // is_pending_join_expired is meaningful only in PendingJoin.
-        let state_machine = PhaseTimer::new_as_member();
-        assert!(!state_machine.is_pending_join_expired());
-    }
-
-    #[test]
-    fn test_freeze_timeout_not_in_freezing() {
-        let state_machine = PhaseTimer::new_as_member();
-        // Not in Freezing → not timed out
-        assert!(!state_machine.is_freeze_timed_out());
-    }
-
-    #[test]
-    fn test_freeze_timeout_fresh_freezing() {
-        let mut state_machine = PhaseTimer::new_as_member();
-        state_machine.start_freezing();
-        // Just entered Freezing → not timed out yet
-        assert!(!state_machine.is_freeze_timed_out());
-    }
-
-    #[test]
-    fn test_freeze_timeout_expired() {
-        let mut state_machine = PhaseTimer::new_as_member();
-        state_machine.start_freezing();
-        // Backdate phase start well past freeze duration.
-        state_machine.started_at = Some(Instant::now() - Duration::from_secs(30));
-        assert!(state_machine.is_freeze_timed_out());
-    }
-
-    #[test]
-    fn test_freeze_timeout_cleared_on_working() {
-        let mut state_machine = PhaseTimer::new_as_member();
-        state_machine.start_freezing();
-        assert!(state_machine.started_at.is_some());
-
-        state_machine.start_working();
-        assert!(state_machine.started_at.is_none());
-        assert!(!state_machine.is_freeze_timed_out());
-    }
-
-    // ─────────────────────────── Proposal Timer Tests ───────────────────────────
-
     fn long_inactivity() -> Duration {
         Duration::from_secs(60)
     }
@@ -373,97 +259,128 @@ mod tests {
     }
 
     #[test]
-    fn test_inactivity_timer_self_starts_on_first_check_with_approved() {
-        let mut sm = PhaseTimer::new_as_member();
-        assert!(sm.started_at.is_none());
-
-        // First call with approved work: timer starts, no transition yet.
-        assert!(!sm.check_steward_inactivity(1, long_inactivity()));
-        assert!(sm.started_at.is_some());
+    fn pending_join_not_expired_when_unset() {
+        let pt = PhaseTimer::with_default_config();
+        assert!(!pt.is_pending_join_expired(GroupState::PendingJoin));
     }
 
     #[test]
-    fn test_inactivity_timer_not_restarted_while_running() {
-        let mut sm = PhaseTimer::new_as_member();
-        sm.check_steward_inactivity(1, long_inactivity());
-        let first_time = sm.started_at.unwrap();
+    fn pending_join_expires_after_three_commit_inactivity_windows() {
+        let config = GroupConfig::default();
+        let mut pt = PhaseTimer::with_config(config.clone());
+        pt.start();
+        assert!(!pt.is_pending_join_expired(GroupState::PendingJoin));
+
+        // Backdate past the 3× commit_inactivity_duration expiration threshold.
+        let past = config.commit_inactivity_duration * 3 + Duration::from_secs(1);
+        pt.started_at = Some(Instant::now() - past);
+        assert!(pt.is_pending_join_expired(GroupState::PendingJoin));
+    }
+
+    #[test]
+    fn pending_join_check_only_in_pending_join() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.start();
+        pt.started_at = Some(Instant::now() - Duration::from_secs(100_000));
+        // Even with a stale anchor, non-PendingJoin states never expire.
+        assert!(!pt.is_pending_join_expired(GroupState::Working));
+    }
+
+    #[test]
+    fn freeze_timeout_only_in_freezing() {
+        let pt = PhaseTimer::with_default_config();
+        assert!(!pt.is_freeze_timed_out(GroupState::Working));
+    }
+
+    #[test]
+    fn freeze_timeout_fresh_anchor_not_timed_out() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.start();
+        assert!(!pt.is_freeze_timed_out(GroupState::Freezing));
+    }
+
+    #[test]
+    fn freeze_timeout_expired() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.started_at = Some(Instant::now() - Duration::from_secs(30));
+        assert!(pt.is_freeze_timed_out(GroupState::Freezing));
+    }
+
+    #[test]
+    fn inactivity_self_starts_on_first_check_with_approved() {
+        let mut pt = PhaseTimer::with_default_config();
+        assert!(pt.started_at.is_none());
+
+        // First call with approved work: timer starts, no transition yet.
+        assert!(!pt.poll_steward_inactivity(GroupState::Working, 1, long_inactivity()));
+        assert!(pt.started_at.is_some());
+    }
+
+    #[test]
+    fn inactivity_not_restarted_while_running() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.poll_steward_inactivity(GroupState::Working, 1, long_inactivity());
+        let first_time = pt.started_at.unwrap();
 
         std::thread::sleep(Duration::from_millis(5));
 
         // Same-or-more approved → same timer.
-        sm.check_steward_inactivity(2, long_inactivity());
-        assert_eq!(sm.started_at.unwrap(), first_time);
+        pt.poll_steward_inactivity(GroupState::Working, 2, long_inactivity());
+        assert_eq!(pt.started_at.unwrap(), first_time);
     }
 
     #[test]
-    fn test_steward_inactivity_triggers_freezing() {
-        let mut sm = PhaseTimer::new_as_member();
-        sm.started_at = Some(Instant::now() - Duration::from_secs(1));
-
-        assert!(sm.check_steward_inactivity(1, Duration::from_millis(50)));
-        assert_eq!(sm.current_state(), GroupState::Freezing);
+    fn inactivity_triggers_freeze_signal() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.started_at = Some(Instant::now() - Duration::from_secs(1));
+        assert!(pt.poll_steward_inactivity(GroupState::Working, 1, Duration::from_millis(50)));
     }
 
     #[test]
-    fn test_check_inactivity_uses_caller_supplied_duration() {
-        let mut sm = PhaseTimer::new_as_member();
-        sm.started_at = Some(Instant::now() - Duration::from_millis(100));
-        assert!(!sm.check_steward_inactivity(1, long_inactivity()));
-        assert_eq!(sm.current_state(), GroupState::Working);
-
-        assert!(sm.check_steward_inactivity(1, Duration::from_millis(50)));
-        assert_eq!(sm.current_state(), GroupState::Freezing);
+    fn inactivity_uses_caller_supplied_duration() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.started_at = Some(Instant::now() - Duration::from_millis(100));
+        assert!(!pt.poll_steward_inactivity(GroupState::Working, 1, long_inactivity()));
+        assert!(pt.poll_steward_inactivity(GroupState::Working, 1, Duration::from_millis(50)));
     }
 
     #[test]
-    fn test_retry_inactivity_duration_threaded_from_config() {
+    fn inactivity_skips_outside_working() {
+        let mut pt = PhaseTimer::with_default_config();
+        pt.started_at = Some(Instant::now() - Duration::from_secs(1));
+        assert!(!pt.poll_steward_inactivity(GroupState::Freezing, 1, Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn recovery_inactivity_threaded_from_config() {
         let config = GroupConfig {
-            epoch_duration: long_inactivity(),
-            retry_inactivity_duration: short_inactivity(),
+            commit_inactivity_duration: long_inactivity(),
+            recovery_inactivity_duration: short_inactivity(),
             ..GroupConfig::default()
         };
-        let sm = PhaseTimer::new_as_member_with_config(config);
-        assert_eq!(sm.epoch_duration(), long_inactivity());
-        assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
+        let pt = PhaseTimer::with_config(config);
+        assert_eq!(pt.commit_inactivity_duration(), long_inactivity());
+        assert_eq!(pt.recovery_inactivity_duration(), short_inactivity());
     }
 
     /// `voting_delay_for` dispatches on proposal kind: steward-election
     /// proposals get the shorter `election_voting_delay`, others get
     /// `voting_delay`.
     #[test]
-    fn test_voting_delay_dispatch_on_proposal_kind() {
+    fn voting_delay_dispatch_on_proposal_kind() {
         let config = GroupConfig {
             voting_delay: Duration::from_secs(7),
             election_voting_delay: Duration::from_secs(3),
             ..GroupConfig::default()
         };
-        let sm = PhaseTimer::new_as_member_with_config(config);
+        let pt = PhaseTimer::with_config(config);
         assert_eq!(
-            sm.voting_delay_for(ProposalKind::Commit),
+            pt.voting_delay_for(ProposalKind::Commit),
             Duration::from_secs(7)
         );
         assert_eq!(
-            sm.voting_delay_for(ProposalKind::StewardElection),
+            pt.voting_delay_for(ProposalKind::StewardElection),
             Duration::from_secs(3)
         );
-    }
-
-    #[test]
-    fn test_force_freezing_sets_started_at() {
-        let mut sm = PhaseTimer::new_as_member();
-        assert!(sm.force_freezing());
-        assert_eq!(sm.current_state(), GroupState::Freezing);
-        assert!(sm.started_at.is_some());
-    }
-
-    #[test]
-    fn test_steward_inactivity_skips_if_already_freezing() {
-        let mut sm = PhaseTimer::new_as_member();
-        sm.started_at = Some(Instant::now() - Duration::from_secs(1));
-        sm.start_freezing();
-
-        // Already in Freezing — should not re-trigger
-        assert!(!sm.check_steward_inactivity(1, Duration::from_millis(50)));
-        assert_eq!(sm.current_state(), GroupState::Freezing);
     }
 }

--- a/src/app/phase_timer.rs
+++ b/src/app/phase_timer.rs
@@ -1,51 +1,31 @@
-//! Per-group FSM: PendingJoin → Working → Freezing → Selection → Reelection → Leaving.
+//! App-side wrapper around [`crate::core::GroupStateMachine`].
+//!
+//! Adds the timer-driven behaviour the core SM intentionally lacks:
+//! a `started_at` (`Instant`), the `Duration` knobs (epoch, freeze,
+//! retry inactivity, proposal expiration, consensus timeout, voting
+//! delays), and the helpers that combine state + duration to answer
+//! "is this phase timed out?". State transitions delegate to the core
+//! SM and additionally maintain `started_at`.
 
-use std::{
-    fmt::Display,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use tracing::info;
 
-use crate::{app::config::GroupConfig, core::ProposalKind};
+use crate::{
+    app::config::GroupConfig,
+    core::{GroupStateMachine as CoreStateMachine, ProposalKind},
+};
+
+// `GroupState` re-exported so `crate::app::GroupState` callsites work
+// unchanged. The enum itself lives in core.
+pub use crate::core::GroupState;
 
 /// Notifies the integrator when a group transitions between [`GroupState`]
 /// variants. Fires from the app layer only — core never calls it.
 #[async_trait]
 pub trait StateChangeHandler: Send + Sync {
     async fn on_state_changed(&self, group_name: &str, state: GroupState);
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum GroupState {
-    /// Waiting for the welcome after sending our key package.
-    PendingJoin,
-    /// Normal operation — chat and membership requests flow freely.
-    Working,
-    /// Collecting commit candidates for this epoch.
-    Freezing,
-    /// Deterministic selection across the buffered candidates.
-    Selection,
-    /// Steward list unusable; only emergency proposals accepted until a new
-    /// election lands.
-    Reelection,
-    /// We asked to leave; waiting for our removal commit to arrive.
-    Leaving,
-}
-
-impl Display for GroupState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let state = match self {
-            GroupState::PendingJoin => "PendingJoin",
-            GroupState::Working => "Working",
-            GroupState::Freezing => "Freezing",
-            GroupState::Selection => "Selection",
-            GroupState::Reelection => "Reelection",
-            GroupState::Leaving => "Leaving",
-        };
-        write!(f, "{state}")
-    }
 }
 
 /// What a freeze-timeout poll returned.
@@ -63,16 +43,22 @@ pub enum FreezeTimeoutStatus {
     },
 }
 
+/// App-side state machine: the passive core SM plus a phase timer and
+/// the duration knobs the timer-driven helpers consult.
+///
+/// Transitions delegate to the core SM and additionally maintain the
+/// phase timer. Timer queries (`is_freeze_timed_out`, etc.) live here
+/// because they need wall-clock time.
 #[derive(Debug, Clone)]
-pub struct GroupStateMachine {
-    state: GroupState,
-    /// Meaning depends on `state`:
+pub struct PhaseTimer {
+    inner: CoreStateMachine,
+    /// Meaning depends on the current core state:
     /// - `PendingJoin`: time the join was initiated.
     /// - `Working`: time the first approved proposal arrived (drives the
     ///   steward-inactivity timer).
     /// - `Freezing`: time the freeze window started.
     /// - Other states: `None`.
-    phase_timer: Option<Instant>,
+    started_at: Option<Instant>,
     epoch_duration: Duration,
     freeze_duration: Duration,
     /// Short inactivity window used during recovery; caller of
@@ -89,21 +75,21 @@ pub struct GroupStateMachine {
     election_voting_delay: Duration,
 }
 
-impl Default for GroupStateMachine {
+impl Default for PhaseTimer {
     fn default() -> Self {
         Self::new_as_member()
     }
 }
 
-impl GroupStateMachine {
+impl PhaseTimer {
     pub fn new_as_member() -> Self {
         Self::new_as_member_with_config(GroupConfig::default())
     }
 
     pub fn new_as_member_with_config(config: GroupConfig) -> Self {
         Self {
-            state: GroupState::Working,
-            phase_timer: None,
+            inner: CoreStateMachine::new_as_member(),
+            started_at: None,
             epoch_duration: config.epoch_duration,
             freeze_duration: config.freeze_duration,
             retry_inactivity_duration: config.retry_inactivity_duration,
@@ -116,8 +102,8 @@ impl GroupStateMachine {
 
     pub fn new_as_pending_join_with_config(config: GroupConfig) -> Self {
         Self {
-            state: GroupState::PendingJoin,
-            phase_timer: Some(Instant::now()),
+            inner: CoreStateMachine::new_as_pending_join(),
+            started_at: Some(Instant::now()),
             epoch_duration: config.epoch_duration,
             freeze_duration: config.freeze_duration,
             retry_inactivity_duration: config.retry_inactivity_duration,
@@ -129,7 +115,7 @@ impl GroupStateMachine {
     }
 
     pub fn current_state(&self) -> GroupState {
-        self.state.clone()
+        self.inner.current_state()
     }
 
     pub fn epoch_duration(&self) -> Duration {
@@ -185,45 +171,47 @@ impl GroupStateMachine {
         self.consensus_timeout = value;
     }
 
+    // ─────────────────────────── State transitions ───────────────────────────
+
     pub fn start_working(&mut self) {
-        self.state = GroupState::Working;
-        self.phase_timer = None;
+        self.inner.start_working();
+        self.started_at = None;
         info!(state = "Working", "state transition");
     }
 
     pub fn start_freezing(&mut self) {
-        self.state = GroupState::Freezing;
-        self.phase_timer = Some(Instant::now());
+        self.inner.start_freezing();
+        self.started_at = Some(Instant::now());
         info!(state = "Freezing", "state transition");
     }
 
     /// Bypass the inactivity timer and enter Freezing immediately. Returns
     /// `true` on transition (only fires from `Working` or `Reelection`).
     pub fn force_freezing(&mut self) -> bool {
-        match self.state {
-            GroupState::Working | GroupState::Reelection => {
-                self.start_freezing();
-                true
-            }
-            _ => false,
+        if self.inner.force_freezing() {
+            self.started_at = Some(Instant::now());
+            info!(state = "Freezing", "state transition (forced)");
+            true
+        } else {
+            false
         }
     }
 
     pub fn start_selection(&mut self) {
-        self.state = GroupState::Selection;
+        self.inner.start_selection();
         info!(state = "Selection", "state transition");
     }
 
     pub fn start_reelection(&mut self) {
-        self.state = GroupState::Reelection;
-        self.phase_timer = None;
+        self.inner.start_reelection();
+        self.started_at = None;
         info!(state = "Reelection", "state transition");
     }
 
     /// Caller must ensure a valid transition. `User::leave_group` handles
     /// the PendingJoin and already-Leaving cases separately.
     pub fn start_leaving(&mut self) {
-        self.state = GroupState::Leaving;
+        self.inner.start_leaving();
         info!(state = "Leaving", "state transition");
     }
 
@@ -232,11 +220,11 @@ impl GroupStateMachine {
     /// `true` once 3× epoch-duration has passed in `PendingJoin` without a
     /// welcome — the join attempt is abandoned and local state torn down.
     pub fn is_pending_join_expired(&self) -> bool {
-        if self.state != GroupState::PendingJoin {
+        if self.current_state() != GroupState::PendingJoin {
             return false;
         }
 
-        if let Some(started_at) = self.phase_timer {
+        if let Some(started_at) = self.started_at {
             // Pipeline: consensus (~15s) + epoch_duration + freeze_duration (epoch/2)
             // = ~1.5× epoch + consensus overhead. Use 3× epoch for safety margin.
             let max_wait = self.epoch_duration * 3;
@@ -252,11 +240,11 @@ impl GroupStateMachine {
 
     /// `true` once the freeze window elapsed while in `Freezing`.
     pub fn is_freeze_timed_out(&self) -> bool {
-        if self.state != GroupState::Freezing {
+        if self.current_state() != GroupState::Freezing {
             return false;
         }
 
-        if let Some(started_at) = self.phase_timer {
+        if let Some(started_at) = self.started_at {
             return Instant::now() >= started_at + self.freeze_duration;
         }
 
@@ -265,7 +253,7 @@ impl GroupStateMachine {
     // ─────────────────────────── Proposal Timer (Member Inactivity) ───────────────────────────
 
     pub fn clear_proposal_timer(&mut self) {
-        self.phase_timer = None;
+        self.started_at = None;
     }
 
     /// Drives the "steward waited too long to commit" transition into
@@ -285,14 +273,14 @@ impl GroupStateMachine {
         approved_proposals_count: usize,
         inactivity_duration: Duration,
     ) -> bool {
-        if self.state != GroupState::Working || approved_proposals_count == 0 {
+        if self.current_state() != GroupState::Working || approved_proposals_count == 0 {
             return false;
         }
 
-        let first_approved = match self.phase_timer {
+        let first_approved = match self.started_at {
             Some(t) => t,
             None => {
-                self.phase_timer = Some(Instant::now());
+                self.started_at = Some(Instant::now());
                 info!(
                     approved = approved_proposals_count,
                     inactivity_ms = inactivity_duration.as_millis() as u64,
@@ -323,32 +311,32 @@ mod tests {
     #[test]
     fn test_pending_join_timeout() {
         let config = GroupConfig::default();
-        let mut state_machine = GroupStateMachine::new_as_pending_join_with_config(config.clone());
+        let mut state_machine = PhaseTimer::new_as_pending_join_with_config(config.clone());
         assert!(!state_machine.is_pending_join_expired());
 
         // Backdate past the 3× epoch_duration expiration threshold.
         let past = config.epoch_duration * 3 + Duration::from_secs(1);
-        state_machine.phase_timer = Some(Instant::now() - past);
+        state_machine.started_at = Some(Instant::now() - past);
         assert!(state_machine.is_pending_join_expired());
     }
 
     #[test]
     fn test_pending_join_not_expired_when_working() {
         // is_pending_join_expired is meaningful only in PendingJoin.
-        let state_machine = GroupStateMachine::new_as_member();
+        let state_machine = PhaseTimer::new_as_member();
         assert!(!state_machine.is_pending_join_expired());
     }
 
     #[test]
     fn test_freeze_timeout_not_in_freezing() {
-        let state_machine = GroupStateMachine::new_as_member();
+        let state_machine = PhaseTimer::new_as_member();
         // Not in Freezing → not timed out
         assert!(!state_machine.is_freeze_timed_out());
     }
 
     #[test]
     fn test_freeze_timeout_fresh_freezing() {
-        let mut state_machine = GroupStateMachine::new_as_member();
+        let mut state_machine = PhaseTimer::new_as_member();
         state_machine.start_freezing();
         // Just entered Freezing → not timed out yet
         assert!(!state_machine.is_freeze_timed_out());
@@ -356,21 +344,21 @@ mod tests {
 
     #[test]
     fn test_freeze_timeout_expired() {
-        let mut state_machine = GroupStateMachine::new_as_member();
+        let mut state_machine = PhaseTimer::new_as_member();
         state_machine.start_freezing();
         // Backdate phase start well past freeze duration.
-        state_machine.phase_timer = Some(Instant::now() - Duration::from_secs(30));
+        state_machine.started_at = Some(Instant::now() - Duration::from_secs(30));
         assert!(state_machine.is_freeze_timed_out());
     }
 
     #[test]
     fn test_freeze_timeout_cleared_on_working() {
-        let mut state_machine = GroupStateMachine::new_as_member();
+        let mut state_machine = PhaseTimer::new_as_member();
         state_machine.start_freezing();
-        assert!(state_machine.phase_timer.is_some());
+        assert!(state_machine.started_at.is_some());
 
         state_machine.start_working();
-        assert!(state_machine.phase_timer.is_none());
+        assert!(state_machine.started_at.is_none());
         assert!(!state_machine.is_freeze_timed_out());
     }
 
@@ -386,31 +374,31 @@ mod tests {
 
     #[test]
     fn test_inactivity_timer_self_starts_on_first_check_with_approved() {
-        let mut sm = GroupStateMachine::new_as_member();
-        assert!(sm.phase_timer.is_none());
+        let mut sm = PhaseTimer::new_as_member();
+        assert!(sm.started_at.is_none());
 
         // First call with approved work: timer starts, no transition yet.
         assert!(!sm.check_steward_inactivity(1, long_inactivity()));
-        assert!(sm.phase_timer.is_some());
+        assert!(sm.started_at.is_some());
     }
 
     #[test]
     fn test_inactivity_timer_not_restarted_while_running() {
-        let mut sm = GroupStateMachine::new_as_member();
+        let mut sm = PhaseTimer::new_as_member();
         sm.check_steward_inactivity(1, long_inactivity());
-        let first_time = sm.phase_timer.unwrap();
+        let first_time = sm.started_at.unwrap();
 
         std::thread::sleep(Duration::from_millis(5));
 
         // Same-or-more approved → same timer.
         sm.check_steward_inactivity(2, long_inactivity());
-        assert_eq!(sm.phase_timer.unwrap(), first_time);
+        assert_eq!(sm.started_at.unwrap(), first_time);
     }
 
     #[test]
     fn test_steward_inactivity_triggers_freezing() {
-        let mut sm = GroupStateMachine::new_as_member();
-        sm.phase_timer = Some(Instant::now() - Duration::from_secs(1));
+        let mut sm = PhaseTimer::new_as_member();
+        sm.started_at = Some(Instant::now() - Duration::from_secs(1));
 
         assert!(sm.check_steward_inactivity(1, Duration::from_millis(50)));
         assert_eq!(sm.current_state(), GroupState::Freezing);
@@ -418,8 +406,8 @@ mod tests {
 
     #[test]
     fn test_check_inactivity_uses_caller_supplied_duration() {
-        let mut sm = GroupStateMachine::new_as_member();
-        sm.phase_timer = Some(Instant::now() - Duration::from_millis(100));
+        let mut sm = PhaseTimer::new_as_member();
+        sm.started_at = Some(Instant::now() - Duration::from_millis(100));
         assert!(!sm.check_steward_inactivity(1, long_inactivity()));
         assert_eq!(sm.current_state(), GroupState::Working);
 
@@ -434,7 +422,7 @@ mod tests {
             retry_inactivity_duration: short_inactivity(),
             ..GroupConfig::default()
         };
-        let sm = GroupStateMachine::new_as_member_with_config(config);
+        let sm = PhaseTimer::new_as_member_with_config(config);
         assert_eq!(sm.epoch_duration(), long_inactivity());
         assert_eq!(sm.retry_inactivity_duration(), short_inactivity());
     }
@@ -449,7 +437,7 @@ mod tests {
             election_voting_delay: Duration::from_secs(3),
             ..GroupConfig::default()
         };
-        let sm = GroupStateMachine::new_as_member_with_config(config);
+        let sm = PhaseTimer::new_as_member_with_config(config);
         assert_eq!(
             sm.voting_delay_for(ProposalKind::Commit),
             Duration::from_secs(7)
@@ -461,41 +449,17 @@ mod tests {
     }
 
     #[test]
-    fn test_force_freezing_from_working() {
-        let mut sm = GroupStateMachine::new_as_member();
-        assert_eq!(sm.current_state(), GroupState::Working);
+    fn test_force_freezing_sets_started_at() {
+        let mut sm = PhaseTimer::new_as_member();
         assert!(sm.force_freezing());
         assert_eq!(sm.current_state(), GroupState::Freezing);
-        assert!(sm.phase_timer.is_some());
-    }
-
-    #[test]
-    fn test_force_freezing_from_reelection() {
-        let mut sm = GroupStateMachine::new_as_member();
-        sm.start_reelection();
-        assert!(sm.force_freezing());
-        assert_eq!(sm.current_state(), GroupState::Freezing);
-    }
-
-    #[test]
-    fn test_force_freezing_noop_in_mid_cycle_or_terminal_states() {
-        for state_setup in [
-            |sm: &mut GroupStateMachine| sm.start_freezing(),
-            |sm: &mut GroupStateMachine| sm.start_selection(),
-            |sm: &mut GroupStateMachine| sm.start_leaving(),
-        ] {
-            let mut sm = GroupStateMachine::new_as_member();
-            state_setup(&mut sm);
-            let before = sm.current_state();
-            assert!(!sm.force_freezing());
-            assert_eq!(sm.current_state(), before);
-        }
+        assert!(sm.started_at.is_some());
     }
 
     #[test]
     fn test_steward_inactivity_skips_if_already_freezing() {
-        let mut sm = GroupStateMachine::new_as_member();
-        sm.phase_timer = Some(Instant::now() - Duration::from_secs(1));
+        let mut sm = PhaseTimer::new_as_member();
+        sm.started_at = Some(Instant::now() - Duration::from_secs(1));
         sm.start_freezing();
 
         // Already in Freezing — should not re-trigger

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -67,7 +67,7 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        let state = entry.state_machine.current_state();
+        let state = entry.phase_timer.current_state();
 
         match state {
             GroupState::Reelection => {
@@ -160,7 +160,7 @@ impl<
         };
 
         let Some(consensus_timeout) = self
-            .with_entry(&group_name, |e| e.state_machine.consensus_timeout())
+            .with_entry(&group_name, |e| e.phase_timer.consensus_timeout())
             .await
         else {
             return;
@@ -190,10 +190,10 @@ impl<
         let (proposal_expiration, consensus_timeout, liveness_criteria_yes, voting_delay) = self
             .with_entry(group_name, |e| {
                 (
-                    e.state_machine.proposal_expiration(),
-                    e.state_machine.consensus_timeout(),
+                    e.phase_timer.proposal_expiration(),
+                    e.phase_timer.consensus_timeout(),
                     e.group.liveness_criteria_yes(),
-                    e.state_machine.voting_delay_for(kind),
+                    e.phase_timer.voting_delay_for(kind),
                 )
             })
             .await
@@ -370,7 +370,7 @@ impl<
 
         let (pending_join, members_for_rotation, current_epoch) = {
             let entry = entry_arc.read().await;
-            let pending = entry.state_machine.current_state() == GroupState::PendingJoin;
+            let pending = entry.phase_timer.current_state() == GroupState::PendingJoin;
             match (pending, entry.mls()) {
                 (true, _) | (false, None) => (pending, Vec::new(), 0u64),
                 (false, Some(mls)) => (false, entry.group_members()?, mls.current_epoch()?),
@@ -400,7 +400,7 @@ impl<
                 .steward
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == self_identity);
-            let state = entry.state_machine.current_state();
+            let state = entry.phase_timer.current_state();
             let total = entry.group.pending_update_count();
             let should = is_es && state == GroupState::Working;
             (inserted, is_es, state, total, should)
@@ -445,7 +445,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         {
             let entry = entry_arc.read().await;
-            let state = entry.state_machine.current_state();
+            let state = entry.phase_timer.current_state();
             if state == GroupState::Freezing || state == GroupState::Selection {
                 return Err(UserError::GroupBlocked(state.to_string()));
             }

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -67,7 +67,7 @@ impl<
             .await
             .ok_or(UserError::GroupNotFound)?;
         let entry = entry_arc.read().await;
-        let state = entry.phase_timer.current_state();
+        let state = entry.current_state();
 
         match state {
             GroupState::Reelection => {
@@ -370,7 +370,7 @@ impl<
 
         let (pending_join, members_for_rotation, current_epoch) = {
             let entry = entry_arc.read().await;
-            let pending = entry.phase_timer.current_state() == GroupState::PendingJoin;
+            let pending = entry.current_state() == GroupState::PendingJoin;
             match (pending, entry.mls()) {
                 (true, _) | (false, None) => (pending, Vec::new(), 0u64),
                 (false, Some(mls)) => (false, entry.group_members()?, mls.current_epoch()?),
@@ -400,7 +400,7 @@ impl<
                 .steward
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == self_identity);
-            let state = entry.phase_timer.current_state();
+            let state = entry.current_state();
             let total = entry.group.pending_update_count();
             let should = is_es && state == GroupState::Working;
             (inserted, is_es, state, total, should)
@@ -445,7 +445,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         {
             let entry = entry_arc.read().await;
-            let state = entry.phase_timer.current_state();
+            let state = entry.current_state();
             if state == GroupState::Freezing || state == GroupState::Selection {
                 return Err(UserError::GroupBlocked(state.to_string()));
             }

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -133,7 +133,7 @@ impl<
     /// Bypass the inactivity timer so the urgent commit fires now.
     async fn force_freezing_for_urgent_commit(&self, group_name: &str) {
         let transitioned = match self.lookup_entry(group_name).await {
-            Some(entry_arc) => entry_arc.write().await.state_machine.force_freezing(),
+            Some(entry_arc) => entry_arc.write().await.phase_timer.force_freezing(),
             None => false,
         };
         if transitioned {
@@ -211,8 +211,8 @@ impl<
             // the immediate post-election inactivity check uses the
             // short retry window.
             entry.group.exit_recovery_mode();
-            if entry.state_machine.current_state() == GroupState::Reelection {
-                entry.state_machine.start_working();
+            if entry.phase_timer.current_state() == GroupState::Reelection {
+                entry.phase_timer.start_working();
                 true
             } else {
                 false
@@ -302,8 +302,8 @@ impl<
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
                 entry.group.resolve_emergency(proposal_id);
-                if entry.state_machine.current_state() == GroupState::Reelection {
-                    entry.state_machine.start_working();
+                if entry.phase_timer.current_state() == GroupState::Reelection {
+                    entry.phase_timer.start_working();
                     true
                 } else {
                     false

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -133,7 +133,7 @@ impl<
     /// Bypass the inactivity timer so the urgent commit fires now.
     async fn force_freezing_for_urgent_commit(&self, group_name: &str) {
         let transitioned = match self.lookup_entry(group_name).await {
-            Some(entry_arc) => entry_arc.write().await.phase_timer.force_freezing(),
+            Some(entry_arc) => entry_arc.write().await.force_freezing(),
             None => false,
         };
         if transitioned {
@@ -211,8 +211,8 @@ impl<
             // the immediate post-election inactivity check uses the
             // short retry window.
             entry.group.exit_recovery_mode();
-            if entry.phase_timer.current_state() == GroupState::Reelection {
-                entry.phase_timer.start_working();
+            if entry.current_state() == GroupState::Reelection {
+                entry.start_working();
                 true
             } else {
                 false
@@ -302,8 +302,8 @@ impl<
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
                 entry.group.resolve_emergency(proposal_id);
-                if entry.phase_timer.current_state() == GroupState::Reelection {
-                    entry.phase_timer.start_working();
+                if entry.current_state() == GroupState::Reelection {
+                    entry.start_working();
                     true
                 } else {
                     false

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -32,8 +32,8 @@ impl<
         let (state, expired) = match self
             .with_entry(group_name, |entry| {
                 (
-                    entry.state_machine.current_state(),
-                    entry.state_machine.is_pending_join_expired(),
+                    entry.phase_timer.current_state(),
+                    entry.phase_timer.is_pending_join_expired(),
                 )
             })
             .await
@@ -71,7 +71,7 @@ impl<
         let has_proposals = {
             let mut entry = entry_arc.write().await;
 
-            let state = entry.state_machine.current_state();
+            let state = entry.phase_timer.current_state();
             if state != GroupState::Freezing {
                 return Ok(FreezeTimeoutStatus::NotFreezing);
             }
@@ -83,11 +83,11 @@ impl<
                 .current_list()
                 .is_some_and(|list| entry.group.freeze_candidate_count() >= list.len());
 
-            if !all_candidates_in && !entry.state_machine.is_freeze_timed_out() {
+            if !all_candidates_in && !entry.phase_timer.is_freeze_timed_out() {
                 return Ok(FreezeTimeoutStatus::StillFreezing);
             }
 
-            entry.state_machine.start_selection();
+            entry.phase_timer.start_selection();
             entry.group.approved_proposals_count() > 0
         };
 
@@ -173,8 +173,8 @@ impl<
                         // Approved batch (and in-flight votes) survive so
                         // the recovered steward commits the same proposals
                         // once the next election lands.
-                        entry.state_machine.clear_proposal_timer();
-                        entry.state_machine.start_reelection();
+                        entry.phase_timer.clear_proposal_timer();
+                        entry.phase_timer.start_reelection();
 
                         // Local observation → direct peer-score penalty,
                         // no ECP round-trip. Each honest member records
@@ -208,7 +208,7 @@ impl<
                         (GroupState::Reelection, cross)
                     } else {
                         entry.group.clear_freeze_round();
-                        entry.state_machine.start_working();
+                        entry.phase_timer.start_working();
                         (GroupState::Working, false)
                     }
                 };
@@ -249,7 +249,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let mut entry = entry_arc.write().await;
 
-        let state = entry.state_machine.current_state();
+        let state = entry.phase_timer.current_state();
         if state == GroupState::PendingJoin || state == GroupState::Leaving {
             return Ok(false);
         }
@@ -264,12 +264,12 @@ impl<
         // burn another full epoch waiting for a steward to commit.
         let in_recovery = entry.group.is_in_recovery_mode() || entry.steward.retry_round() > 0;
         let inactivity = if in_recovery {
-            entry.state_machine.retry_inactivity_duration()
+            entry.phase_timer.retry_inactivity_duration()
         } else {
-            entry.state_machine.epoch_duration()
+            entry.phase_timer.epoch_duration()
         };
         let entered_freezing = entry
-            .state_machine
+            .phase_timer
             .check_steward_inactivity(proposal_count, inactivity);
         if entered_freezing {
             let epoch = entry.expect_mls()?.current_epoch()?;
@@ -295,7 +295,7 @@ impl<
                 None
             };
 
-            let new_state = entry.state_machine.current_state();
+            let new_state = entry.phase_timer.current_state();
             info!(
                 group = group_name,
                 state = %new_state,

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -31,10 +31,7 @@ impl<
     pub async fn check_pending_join(&self, group_name: &str) -> Result<bool, UserError> {
         let (state, expired) = match self
             .with_entry(group_name, |entry| {
-                (
-                    entry.phase_timer.current_state(),
-                    entry.phase_timer.is_pending_join_expired(),
-                )
+                (entry.current_state(), entry.is_pending_join_expired())
             })
             .await
         {
@@ -71,7 +68,7 @@ impl<
         let has_proposals = {
             let mut entry = entry_arc.write().await;
 
-            let state = entry.phase_timer.current_state();
+            let state = entry.current_state();
             if state != GroupState::Freezing {
                 return Ok(FreezeTimeoutStatus::NotFreezing);
             }
@@ -83,11 +80,11 @@ impl<
                 .current_list()
                 .is_some_and(|list| entry.group.freeze_candidate_count() >= list.len());
 
-            if !all_candidates_in && !entry.phase_timer.is_freeze_timed_out() {
+            if !all_candidates_in && !entry.is_freeze_timed_out() {
                 return Ok(FreezeTimeoutStatus::StillFreezing);
             }
 
-            entry.phase_timer.start_selection();
+            entry.start_selection();
             entry.group.approved_proposals_count() > 0
         };
 
@@ -173,8 +170,7 @@ impl<
                         // Approved batch (and in-flight votes) survive so
                         // the recovered steward commits the same proposals
                         // once the next election lands.
-                        entry.phase_timer.clear_proposal_timer();
-                        entry.phase_timer.start_reelection();
+                        entry.start_reelection();
 
                         // Local observation → direct peer-score penalty,
                         // no ECP round-trip. Each honest member records
@@ -208,7 +204,7 @@ impl<
                         (GroupState::Reelection, cross)
                     } else {
                         entry.group.clear_freeze_round();
-                        entry.phase_timer.start_working();
+                        entry.start_working();
                         (GroupState::Working, false)
                     }
                 };
@@ -240,8 +236,8 @@ impl<
     }
 
     /// Drives Working → Freezing when the steward has sat on approved
-    /// proposals for more than `epoch_duration`. Any member polls — not
-    /// just the steward — so a fault gets picked up group-wide.
+    /// proposals for more than `commit_inactivity_duration`. Any member
+    /// polls — not just the steward — so a fault gets picked up group-wide.
     pub async fn check_member_freeze(&self, group_name: &str) -> Result<bool, UserError> {
         let entry_arc = self
             .lookup_entry(group_name)
@@ -249,7 +245,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let mut entry = entry_arc.write().await;
 
-        let state = entry.phase_timer.current_state();
+        let state = entry.current_state();
         if state == GroupState::PendingJoin || state == GroupState::Leaving {
             return Ok(false);
         }
@@ -264,13 +260,11 @@ impl<
         // burn another full epoch waiting for a steward to commit.
         let in_recovery = entry.group.is_in_recovery_mode() || entry.steward.retry_round() > 0;
         let inactivity = if in_recovery {
-            entry.phase_timer.retry_inactivity_duration()
+            entry.phase_timer.recovery_inactivity_duration()
         } else {
-            entry.phase_timer.epoch_duration()
+            entry.phase_timer.commit_inactivity_duration()
         };
-        let entered_freezing = entry
-            .phase_timer
-            .check_steward_inactivity(proposal_count, inactivity);
+        let entered_freezing = entry.check_steward_inactivity(proposal_count, inactivity);
         if entered_freezing {
             let epoch = entry.expect_mls()?.current_epoch()?;
             entry.group.ensure_freeze_round(epoch);
@@ -295,7 +289,7 @@ impl<
                 None
             };
 
-            let new_state = entry.phase_timer.current_state();
+            let new_state = entry.current_state();
             info!(
                 group = group_name,
                 state = %new_state,

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -173,8 +173,8 @@ impl<
 
         let state = {
             let mut entry = entry_arc.write().await;
-            entry.phase_timer.start_working();
-            entry.phase_timer.current_state()
+            entry.start_working();
+            entry.current_state()
         };
         self.state_handler.on_state_changed(name, state).await;
         Ok(())
@@ -205,7 +205,7 @@ impl<
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
                 entry.steward.reset_retry();
-                let state = entry.phase_timer.current_state();
+                let state = entry.current_state();
                 if matches!(
                     state,
                     GroupState::Working
@@ -213,7 +213,7 @@ impl<
                         | GroupState::Selection
                         | GroupState::Reelection
                 ) {
-                    entry.phase_timer.start_working();
+                    entry.start_working();
                     true
                 } else {
                     false
@@ -281,11 +281,11 @@ impl<
         };
         let (transitioned, outbound) = {
             let mut entry = entry_arc.write().await;
-            if entry.phase_timer.current_state() != GroupState::Working {
+            if entry.current_state() != GroupState::Working {
                 return Ok(());
             }
 
-            entry.phase_timer.start_freezing();
+            entry.start_freezing();
             let epoch = entry.expect_mls()?.current_epoch()?;
             entry.group.ensure_freeze_round(epoch);
 
@@ -405,16 +405,18 @@ impl<
             .group
             .set_pending_update_max_epochs(sync.pending_update_max_epochs);
         if let Some(timing) = &sync.timing {
-            let sm = &mut entry.phase_timer;
-            sm.set_epoch_duration(std::time::Duration::from_millis(timing.epoch_duration_ms));
-            sm.set_freeze_duration(std::time::Duration::from_millis(timing.freeze_duration_ms));
-            sm.set_retry_inactivity_duration(std::time::Duration::from_millis(
-                timing.retry_inactivity_duration_ms,
+            let pt = &mut entry.phase_timer;
+            pt.set_commit_inactivity_duration(std::time::Duration::from_millis(
+                timing.commit_inactivity_duration_ms,
             ));
-            sm.set_proposal_expiration(std::time::Duration::from_millis(
+            pt.set_freeze_duration(std::time::Duration::from_millis(timing.freeze_duration_ms));
+            pt.set_recovery_inactivity_duration(std::time::Duration::from_millis(
+                timing.recovery_inactivity_duration_ms,
+            ));
+            pt.set_proposal_expiration(std::time::Duration::from_millis(
                 timing.proposal_expiration_ms,
             ));
-            sm.set_consensus_timeout(std::time::Duration::from_millis(
+            pt.set_consensus_timeout(std::time::Duration::from_millis(
                 timing.consensus_timeout_ms,
             ));
         }
@@ -617,21 +619,21 @@ fn validate_group_sync(
 
 /// Name of the first zero-valued field in `timing`, or `None` if all
 /// fields are non-zero. Zero in any timing field would short-circuit the
-/// timer it drives (consensus_timeout firing immediately, epoch_duration
-/// breaking the inactivity tracker, etc.).
+/// timer it drives (consensus_timeout firing immediately,
+/// commit_inactivity breaking the inactivity tracker, etc.).
 fn first_zero_timing_field(
     timing: &crate::protos::de_mls::messages::v1::TimingConfig,
 ) -> Option<&'static str> {
-    if timing.epoch_duration_ms == 0 {
-        Some("epoch_duration_ms")
+    if timing.commit_inactivity_duration_ms == 0 {
+        Some("commit_inactivity_duration_ms")
     } else if timing.freeze_duration_ms == 0 {
         Some("freeze_duration_ms")
     } else if timing.proposal_expiration_ms == 0 {
         Some("proposal_expiration_ms")
     } else if timing.consensus_timeout_ms == 0 {
         Some("consensus_timeout_ms")
-    } else if timing.retry_inactivity_duration_ms == 0 {
-        Some("retry_inactivity_duration_ms")
+    } else if timing.recovery_inactivity_duration_ms == 0 {
+        Some("recovery_inactivity_duration_ms")
     } else {
         None
     }
@@ -644,11 +646,11 @@ mod tests {
 
     fn nonzero_timing() -> TimingConfig {
         TimingConfig {
-            epoch_duration_ms: 60_000,
+            commit_inactivity_duration_ms: 60_000,
             freeze_duration_ms: 30_000,
             proposal_expiration_ms: 3_600_000,
             consensus_timeout_ms: 30_000,
-            retry_inactivity_duration_ms: 5_000,
+            recovery_inactivity_duration_ms: 5_000,
         }
     }
 
@@ -703,9 +705,9 @@ mod tests {
     fn each_zero_field_is_detected() {
         let cases = [
             (
-                "epoch_duration_ms",
+                "commit_inactivity_duration_ms",
                 TimingConfig {
-                    epoch_duration_ms: 0,
+                    commit_inactivity_duration_ms: 0,
                     ..nonzero_timing()
                 },
             ),
@@ -731,9 +733,9 @@ mod tests {
                 },
             ),
             (
-                "retry_inactivity_duration_ms",
+                "recovery_inactivity_duration_ms",
                 TimingConfig {
-                    retry_inactivity_duration_ms: 0,
+                    recovery_inactivity_duration_ms: 0,
                     ..nonzero_timing()
                 },
             ),

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -128,7 +128,7 @@ impl<
             let Some((delay, vote)) = self
                 .with_entry(group_name, |e| {
                     (
-                        e.state_machine.voting_delay_for(kind),
+                        e.phase_timer.voting_delay_for(kind),
                         e.group.liveness_criteria_yes(),
                     )
                 })
@@ -173,8 +173,8 @@ impl<
 
         let state = {
             let mut entry = entry_arc.write().await;
-            entry.state_machine.start_working();
-            entry.state_machine.current_state()
+            entry.phase_timer.start_working();
+            entry.phase_timer.current_state()
         };
         self.state_handler.on_state_changed(name, state).await;
         Ok(())
@@ -205,7 +205,7 @@ impl<
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
                 entry.steward.reset_retry();
-                let state = entry.state_machine.current_state();
+                let state = entry.phase_timer.current_state();
                 if matches!(
                     state,
                     GroupState::Working
@@ -213,7 +213,7 @@ impl<
                         | GroupState::Selection
                         | GroupState::Reelection
                 ) {
-                    entry.state_machine.start_working();
+                    entry.phase_timer.start_working();
                     true
                 } else {
                     false
@@ -281,11 +281,11 @@ impl<
         };
         let (transitioned, outbound) = {
             let mut entry = entry_arc.write().await;
-            if entry.state_machine.current_state() != GroupState::Working {
+            if entry.phase_timer.current_state() != GroupState::Working {
                 return Ok(());
             }
 
-            entry.state_machine.start_freezing();
+            entry.phase_timer.start_freezing();
             let epoch = entry.expect_mls()?.current_epoch()?;
             entry.group.ensure_freeze_round(epoch);
 
@@ -405,7 +405,7 @@ impl<
             .group
             .set_pending_update_max_epochs(sync.pending_update_max_epochs);
         if let Some(timing) = &sync.timing {
-            let sm = &mut entry.state_machine;
+            let sm = &mut entry.phase_timer;
             sm.set_epoch_duration(std::time::Duration::from_millis(timing.epoch_duration_ms));
             sm.set_freeze_duration(std::time::Duration::from_millis(timing.freeze_duration_ms));
             sm.set_retry_inactivity_duration(std::time::Duration::from_millis(

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -7,8 +7,8 @@ use tracing::info;
 
 use crate::{
     app::{
-        GroupConfig, GroupState, GroupStateMachine, ProposalParams, StateChangeHandler, User,
-        UserError, submit_self_leave_proposal, user::GroupEntry,
+        GroupConfig, GroupState, PhaseTimer, ProposalParams, StateChangeHandler, User, UserError,
+        submit_self_leave_proposal, user::GroupEntry,
     },
     core::{
         DeMlsProvider, Group, GroupEventHandler, PeerScoringPlugin, StewardListPlugin,
@@ -56,15 +56,15 @@ impl<
         let liveness_criteria_yes = config.liveness_criteria_yes;
         let pending_update_max_epochs = config.pending_update_max_epochs;
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
-        let (mut group, mls_opt, state_machine) = if is_creation {
+        let (mut group, mls_opt, phase_timer) = if is_creation {
             let mls = (self.mls_creator_factory)(group_name.to_string())?;
             let group = Group::create_group(group_name, self_identity_bytes.clone());
-            let state_machine = GroupStateMachine::new_as_member_with_config(config.clone());
-            (group, Some(mls), state_machine)
+            let phase_timer = PhaseTimer::new_as_member_with_config(config.clone());
+            (group, Some(mls), phase_timer)
         } else {
             let group = Group::prepare_to_join(group_name, self_identity_bytes.clone());
-            let state_machine = GroupStateMachine::new_as_pending_join_with_config(config.clone());
-            (group, None, state_machine)
+            let phase_timer = PhaseTimer::new_as_pending_join_with_config(config.clone());
+            (group, None, phase_timer)
         };
         group.set_liveness_criteria_yes(liveness_criteria_yes);
         group.set_pending_update_max_epochs(pending_update_max_epochs);
@@ -87,11 +87,11 @@ impl<
             let _events = scoring.add_member(&self_identity_bytes);
         }
 
-        let initial_state = state_machine.current_state();
+        let initial_state = phase_timer.current_state();
         if initial_state == GroupState::PendingJoin {
             info!(
                 group = group_name,
-                timeout_s = state_machine.epoch_duration().as_secs() * 3,
+                timeout_s = phase_timer.epoch_duration().as_secs() * 3,
                 "pending join, awaiting welcome"
             );
         }
@@ -100,7 +100,7 @@ impl<
             Arc::new(RwLock::new(GroupEntry::new(
                 group,
                 mls_opt,
-                state_machine,
+                phase_timer,
                 scoring,
                 steward,
             ))),
@@ -125,7 +125,7 @@ impl<
 
         let is_pending_join = self
             .with_entry(group_name, |entry| {
-                entry.state_machine.current_state() == GroupState::PendingJoin
+                entry.phase_timer.current_state() == GroupState::PendingJoin
             })
             .await
             .ok_or(UserError::GroupNotFound)?;
@@ -172,8 +172,8 @@ impl<
             let mut entry = entry_arc.write().await;
             entry.group.store_voting_proposal(proposal_id, request);
             (
-                entry.state_machine.proposal_expiration(),
-                entry.state_machine.consensus_timeout(),
+                entry.phase_timer.proposal_expiration(),
+                entry.phase_timer.consensus_timeout(),
             )
         };
 

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -11,8 +11,8 @@ use crate::{
         submit_self_leave_proposal, user::GroupEntry,
     },
     core::{
-        DeMlsProvider, Group, GroupEventHandler, PeerScoringPlugin, StewardListPlugin,
-        auto_approved_leave_proposal_id,
+        DeMlsProvider, Group, GroupEventHandler, GroupStateMachine, PeerScoringPlugin,
+        StewardListPlugin, auto_approved_leave_proposal_id,
     },
     identity::Identity,
     mls_crypto::MlsService,
@@ -56,15 +56,20 @@ impl<
         let liveness_criteria_yes = config.liveness_criteria_yes;
         let pending_update_max_epochs = config.pending_update_max_epochs;
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
-        let (mut group, mls_opt, phase_timer) = if is_creation {
+        let (mut group, mls_opt, state_machine, phase_timer) = if is_creation {
             let mls = (self.mls_creator_factory)(group_name.to_string())?;
             let group = Group::create_group(group_name, self_identity_bytes.clone());
-            let phase_timer = PhaseTimer::new_as_member_with_config(config.clone());
-            (group, Some(mls), phase_timer)
+            let state_machine = GroupStateMachine::new_as_member();
+            let phase_timer = PhaseTimer::with_config(config.clone());
+            (group, Some(mls), state_machine, phase_timer)
         } else {
             let group = Group::prepare_to_join(group_name, self_identity_bytes.clone());
-            let phase_timer = PhaseTimer::new_as_pending_join_with_config(config.clone());
-            (group, None, phase_timer)
+            let state_machine = GroupStateMachine::new_as_pending_join();
+            // Anchor the timer at "now" so `is_pending_join_expired` can
+            // detect the 3× epoch-duration timeout.
+            let mut phase_timer = PhaseTimer::with_config(config.clone());
+            phase_timer.start();
+            (group, None, state_machine, phase_timer)
         };
         group.set_liveness_criteria_yes(liveness_criteria_yes);
         group.set_pending_update_max_epochs(pending_update_max_epochs);
@@ -87,11 +92,11 @@ impl<
             let _events = scoring.add_member(&self_identity_bytes);
         }
 
-        let initial_state = phase_timer.current_state();
+        let initial_state = state_machine.current_state();
         if initial_state == GroupState::PendingJoin {
             info!(
                 group = group_name,
-                timeout_s = phase_timer.epoch_duration().as_secs() * 3,
+                timeout_s = phase_timer.commit_inactivity_duration().as_secs() * 3,
                 "pending join, awaiting welcome"
             );
         }
@@ -100,6 +105,7 @@ impl<
             Arc::new(RwLock::new(GroupEntry::new(
                 group,
                 mls_opt,
+                state_machine,
                 phase_timer,
                 scoring,
                 steward,
@@ -125,7 +131,7 @@ impl<
 
         let is_pending_join = self
             .with_entry(group_name, |entry| {
-                entry.phase_timer.current_state() == GroupState::PendingJoin
+                entry.current_state() == GroupState::PendingJoin
             })
             .await
             .ok_or(UserError::GroupNotFound)?;

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -55,7 +55,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let packet = {
             let entry = entry_arc.read().await;
-            let state = entry.phase_timer.current_state();
+            let state = entry.current_state();
             if matches!(
                 state,
                 GroupState::PendingJoin | GroupState::Freezing | GroupState::Selection
@@ -91,7 +91,7 @@ impl<
                 .await
                 .ok_or(UserError::GroupNotFound)?;
             let entry = entry_arc.read().await;
-            let state = entry.phase_timer.current_state();
+            let state = entry.current_state();
             if state != GroupState::Working {
                 return Err(UserError::GroupBlocked(state.to_string()));
             }

--- a/src/app/user/messaging.rs
+++ b/src/app/user/messaging.rs
@@ -55,7 +55,7 @@ impl<
             .ok_or(UserError::GroupNotFound)?;
         let packet = {
             let entry = entry_arc.read().await;
-            let state = entry.state_machine.current_state();
+            let state = entry.phase_timer.current_state();
             if matches!(
                 state,
                 GroupState::PendingJoin | GroupState::Freezing | GroupState::Selection
@@ -91,7 +91,7 @@ impl<
                 .await
                 .ok_or(UserError::GroupNotFound)?;
             let entry = entry_arc.read().await;
-            let state = entry.state_machine.current_state();
+            let state = entry.phase_timer.current_state();
             if state != GroupState::Working {
                 return Err(UserError::GroupBlocked(state.to_string()));
             }

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -14,6 +14,7 @@ use std::{
     collections::{HashMap, VecDeque},
     str::FromStr,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use alloy::signers::local::PrivateKeySigner;
@@ -29,10 +30,10 @@ use crate::{
     },
     core::{
         BufferedCommitCandidate, CoreError, DeMlsProvider, DefaultProvider,
-        DeterministicStewardList, FreezeFinalizeResult, Group, GroupEventHandler, PeerScoringEvent,
-        PeerScoringPlugin, PeerScoringService, ProcessResult, ProposalId, ProposalKind,
-        ProviderConsensus, ScoringConfig, StewardListConfig, StewardListPlugin,
-        compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
+        DeterministicStewardList, FreezeFinalizeResult, Group, GroupEventHandler, GroupState,
+        GroupStateMachine, PeerScoringEvent, PeerScoringPlugin, PeerScoringService, ProcessResult,
+        ProposalId, ProposalKind, ProviderConsensus, ScoringConfig, StewardListConfig,
+        StewardListPlugin, compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     identity::{Identity, WalletIdentity},
@@ -64,6 +65,11 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// haven't accepted a welcome yet; once attached via
     /// [`Self::attach_mls`] it stays `Some` for the entry's lifetime.
     mls: Option<M>,
+    /// Per-group state machine. Coordinator methods on this entry update
+    /// it together with `phase_timer` so the two never drift.
+    state_machine: GroupStateMachine,
+    /// Wall-clock anchor + duration knobs combined with `state_machine`
+    /// by the entry's coordinator methods.
     phase_timer: PhaseTimer,
     /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
@@ -87,6 +93,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
     pub(crate) fn new(
         group: Group,
         mls: Option<M>,
+        state_machine: GroupStateMachine,
         phase_timer: PhaseTimer,
         scoring: Sc,
         steward: St,
@@ -94,11 +101,87 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
         Self {
             group,
             mls,
+            state_machine,
             phase_timer,
             scoring,
             steward,
             epoch_history: VecDeque::new(),
         }
+    }
+
+    // ── State-machine + phase-timer coordinators ────────────────────
+
+    pub(crate) fn current_state(&self) -> GroupState {
+        self.state_machine.current_state()
+    }
+
+    pub(crate) fn start_working(&mut self) {
+        self.state_machine.start_working();
+        self.phase_timer.clear();
+        info!(state = "Working", "state transition");
+    }
+
+    pub(crate) fn start_freezing(&mut self) {
+        self.state_machine.start_freezing();
+        self.phase_timer.start();
+        info!(state = "Freezing", "state transition");
+    }
+
+    /// Bypass the inactivity timer and enter Freezing immediately. Returns
+    /// `true` on transition (only fires from `Working` or `Reelection`).
+    pub(crate) fn force_freezing(&mut self) -> bool {
+        if self.state_machine.force_freezing() {
+            self.phase_timer.start();
+            info!(state = "Freezing", "state transition (forced)");
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn start_selection(&mut self) {
+        self.state_machine.start_selection();
+        info!(state = "Selection", "state transition");
+    }
+
+    pub(crate) fn start_reelection(&mut self) {
+        self.state_machine.start_reelection();
+        self.phase_timer.clear();
+        info!(state = "Reelection", "state transition");
+    }
+
+    /// `true` once 3× `commit_inactivity_duration` has passed in
+    /// `PendingJoin` without a welcome.
+    pub(crate) fn is_pending_join_expired(&self) -> bool {
+        self.phase_timer
+            .is_pending_join_expired(self.state_machine.current_state())
+    }
+
+    /// `true` once the freeze window elapsed while in `Freezing`.
+    pub(crate) fn is_freeze_timed_out(&self) -> bool {
+        self.phase_timer
+            .is_freeze_timed_out(self.state_machine.current_state())
+    }
+
+    /// Drives the "steward waited too long to commit" transition into
+    /// `Freezing`. Call each poll tick; returns `true` exactly on the tick
+    /// that transitions. Self-starts the timer on the first tick with
+    /// approved work; no-op outside `Working`.
+    pub(crate) fn check_steward_inactivity(
+        &mut self,
+        approved_proposals_count: usize,
+        inactivity_duration: Duration,
+    ) -> bool {
+        let state = self.state_machine.current_state();
+        let should_freeze = self.phase_timer.poll_steward_inactivity(
+            state,
+            approved_proposals_count,
+            inactivity_duration,
+        );
+        if should_freeze {
+            self.start_freezing();
+        }
+        should_freeze
     }
 
     /// Borrow the MLS service, if attached. `None` for joiners

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -24,7 +24,7 @@ use tracing::info;
 
 use crate::{
     app::{
-        FixedScoringProvider, GroupConfig, GroupStateMachine, InMemoryPeerScoreStorage,
+        FixedScoringProvider, GroupConfig, InMemoryPeerScoreStorage, PhaseTimer,
         StateChangeHandler, UserError,
     },
     core::{
@@ -64,7 +64,7 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// haven't accepted a welcome yet; once attached via
     /// [`Self::attach_mls`] it stays `Some` for the entry's lifetime.
     mls: Option<M>,
-    state_machine: GroupStateMachine,
+    phase_timer: PhaseTimer,
     /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
     /// `RwLock`, no separate `Mutex` needed.
@@ -87,14 +87,14 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
     pub(crate) fn new(
         group: Group,
         mls: Option<M>,
-        state_machine: GroupStateMachine,
+        phase_timer: PhaseTimer,
         scoring: Sc,
         steward: St,
     ) -> Self {
         Self {
             group,
             mls,
-            state_machine,
+            phase_timer,
             scoring,
             steward,
             epoch_history: VecDeque::new(),

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -19,7 +19,7 @@ impl<
 > User<P, M, Sc, St, I, H, SCH>
 {
     pub async fn get_group_state(&self, group_name: &str) -> Result<GroupState, UserError> {
-        self.with_entry(group_name, |e| e.phase_timer.current_state())
+        self.with_entry(group_name, |e| e.current_state())
             .await
             .ok_or(UserError::GroupNotFound)
     }

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -19,7 +19,7 @@ impl<
 > User<P, M, Sc, St, I, H, SCH>
 {
     pub async fn get_group_state(&self, group_name: &str) -> Result<GroupState, UserError> {
-        self.with_entry(group_name, |e| e.state_machine.current_state())
+        self.with_entry(group_name, |e| e.phase_timer.current_state())
             .await
             .ok_or(UserError::GroupNotFound)
     }

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -403,13 +403,16 @@ impl<
             };
 
             let timing = TimingConfig {
-                epoch_duration_ms: entry.phase_timer.epoch_duration().as_millis() as u64,
+                commit_inactivity_duration_ms: entry
+                    .phase_timer
+                    .commit_inactivity_duration()
+                    .as_millis() as u64,
                 freeze_duration_ms: entry.phase_timer.freeze_duration().as_millis() as u64,
                 proposal_expiration_ms: entry.phase_timer.proposal_expiration().as_millis() as u64,
                 consensus_timeout_ms: entry.phase_timer.consensus_timeout().as_millis() as u64,
-                retry_inactivity_duration_ms: entry
+                recovery_inactivity_duration_ms: entry
                     .phase_timer
-                    .retry_inactivity_duration()
+                    .recovery_inactivity_duration()
                     .as_millis() as u64,
             };
 

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -403,13 +403,12 @@ impl<
             };
 
             let timing = TimingConfig {
-                epoch_duration_ms: entry.state_machine.epoch_duration().as_millis() as u64,
-                freeze_duration_ms: entry.state_machine.freeze_duration().as_millis() as u64,
-                proposal_expiration_ms: entry.state_machine.proposal_expiration().as_millis()
-                    as u64,
-                consensus_timeout_ms: entry.state_machine.consensus_timeout().as_millis() as u64,
+                epoch_duration_ms: entry.phase_timer.epoch_duration().as_millis() as u64,
+                freeze_duration_ms: entry.phase_timer.freeze_duration().as_millis() as u64,
+                proposal_expiration_ms: entry.phase_timer.proposal_expiration().as_millis() as u64,
+                consensus_timeout_ms: entry.phase_timer.consensus_timeout().as_millis() as u64,
                 retry_inactivity_duration_ms: entry
-                    .state_machine
+                    .phase_timer
                     .retry_inactivity_duration()
                     .as_millis() as u64,
             };

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,6 +22,7 @@ mod peer_scoring;
 mod process_result;
 mod proposal_kind;
 mod provider;
+mod state_machine;
 mod steward_list_plugin;
 
 // ── Core group operations ──
@@ -53,6 +54,9 @@ pub use group::{
 
 // ── Proposal classification ──
 pub use proposal_kind::ProposalKind;
+
+// ── State machine (passive: state enum + named transitions) ──
+pub use state_machine::{GroupState, GroupStateMachine};
 
 // ── Steward list ──
 pub use steward_list_plugin::{

--- a/src/core/state_machine.rs
+++ b/src/core/state_machine.rs
@@ -1,0 +1,181 @@
+//! Passive per-group state machine.
+//!
+//! Holds the [`GroupState`] enum and exposes named transition
+//! methods. Nothing else — no timing, no I/O, no timers, no logging.
+//! The app layer wraps this with a timer-driven controller (phase
+//! timer, freeze-window checks, inactivity threshold) — see
+//! [`crate::app::PhaseTimer`].
+
+use std::fmt::Display;
+
+/// The lifecycle state of a per-group session.
+///
+/// Transitions are driven by the app layer through the named methods
+/// on [`GroupStateMachine`]. The protocol rules (e.g. "force-freezing
+/// only fires from Working or Reelection") are enforced here; timing
+/// rules ("freeze times out after `freeze_duration`") live in the app
+/// layer's wrapper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupState {
+    /// Joiner waiting for a welcome.
+    PendingJoin,
+    /// Normal operation: members vote, the steward batches and commits.
+    Working,
+    /// Members have stopped accepting new proposals; commit candidates
+    /// are buffered for deterministic selection.
+    Freezing,
+    /// Selection phase: the freeze-round candidate has been picked and
+    /// is being merged.
+    Selection,
+    /// Recovery: a steward election is in flight after a missed commit.
+    Reelection,
+    /// Leaving: this user has filed a self-leave and is awaiting the
+    /// commit that removes them.
+    Leaving,
+}
+
+impl Display for GroupState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GroupState::PendingJoin => write!(f, "PendingJoin"),
+            GroupState::Working => write!(f, "Working"),
+            GroupState::Freezing => write!(f, "Freezing"),
+            GroupState::Selection => write!(f, "Selection"),
+            GroupState::Reelection => write!(f, "Reelection"),
+            GroupState::Leaving => write!(f, "Leaving"),
+        }
+    }
+}
+
+/// Passive state machine — just the state enum + named transitions.
+/// No timer, no I/O. The app layer wraps this with timer-driven
+/// behaviour.
+#[derive(Debug, Clone)]
+pub struct GroupStateMachine {
+    state: GroupState,
+}
+
+impl Default for GroupStateMachine {
+    fn default() -> Self {
+        Self::new_as_member()
+    }
+}
+
+impl GroupStateMachine {
+    /// Member starts in `Working` (creator path, or post-join).
+    pub fn new_as_member() -> Self {
+        Self {
+            state: GroupState::Working,
+        }
+    }
+
+    /// Joiner starts in `PendingJoin` until the welcome arrives.
+    pub fn new_as_pending_join() -> Self {
+        Self {
+            state: GroupState::PendingJoin,
+        }
+    }
+
+    pub fn current_state(&self) -> GroupState {
+        self.state.clone()
+    }
+
+    pub fn start_working(&mut self) {
+        self.state = GroupState::Working;
+    }
+
+    pub fn start_freezing(&mut self) {
+        self.state = GroupState::Freezing;
+    }
+
+    /// Transition to `Freezing` only from `Working` or `Reelection`
+    /// (RFC: bypass the inactivity timer for ECP-driven freezes).
+    /// Returns `true` on actual transition; `false` is a no-op.
+    pub fn force_freezing(&mut self) -> bool {
+        match self.state {
+            GroupState::Working | GroupState::Reelection => {
+                self.state = GroupState::Freezing;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn start_selection(&mut self) {
+        self.state = GroupState::Selection;
+    }
+
+    pub fn start_reelection(&mut self) {
+        self.state = GroupState::Reelection;
+    }
+
+    /// Caller must ensure a valid transition. The leave path handles
+    /// `PendingJoin` and already-`Leaving` cases separately at the app
+    /// layer.
+    pub fn start_leaving(&mut self) {
+        self.state = GroupState::Leaving;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_as_member_starts_working() {
+        let sm = GroupStateMachine::new_as_member();
+        assert_eq!(sm.current_state(), GroupState::Working);
+    }
+
+    #[test]
+    fn new_as_pending_join_starts_pending() {
+        let sm = GroupStateMachine::new_as_pending_join();
+        assert_eq!(sm.current_state(), GroupState::PendingJoin);
+    }
+
+    #[test]
+    fn named_transitions_set_state() {
+        let mut sm = GroupStateMachine::new_as_member();
+        sm.start_freezing();
+        assert_eq!(sm.current_state(), GroupState::Freezing);
+        sm.start_selection();
+        assert_eq!(sm.current_state(), GroupState::Selection);
+        sm.start_reelection();
+        assert_eq!(sm.current_state(), GroupState::Reelection);
+        sm.start_leaving();
+        assert_eq!(sm.current_state(), GroupState::Leaving);
+        sm.start_working();
+        assert_eq!(sm.current_state(), GroupState::Working);
+    }
+
+    #[test]
+    fn force_freezing_from_working_transitions() {
+        let mut sm = GroupStateMachine::new_as_member();
+        assert!(sm.force_freezing());
+        assert_eq!(sm.current_state(), GroupState::Freezing);
+    }
+
+    #[test]
+    fn force_freezing_from_reelection_transitions() {
+        let mut sm = GroupStateMachine::new_as_member();
+        sm.start_reelection();
+        assert!(sm.force_freezing());
+        assert_eq!(sm.current_state(), GroupState::Freezing);
+    }
+
+    /// `force_freezing` is a no-op outside `Working`/`Reelection`.
+    #[test]
+    fn force_freezing_noop_outside_working_reelection() {
+        for setup in [
+            |sm: &mut GroupStateMachine| sm.start_freezing(),
+            |sm: &mut GroupStateMachine| sm.start_selection(),
+            |sm: &mut GroupStateMachine| sm.start_leaving(),
+        ] {
+            let mut sm = GroupStateMachine::new_as_member();
+            setup(&mut sm);
+            let before = sm.current_state();
+            assert!(!sm.force_freezing());
+            assert_eq!(sm.current_state(), before);
+        }
+    }
+}

--- a/src/core/state_machine.rs
+++ b/src/core/state_machine.rs
@@ -1,20 +1,14 @@
-//! Passive per-group state machine.
+//! Per-group state machine.
 //!
-//! Holds the [`GroupState`] enum and exposes named transition
-//! methods. Nothing else — no timing, no I/O, no timers, no logging.
-//! The app layer wraps this with a timer-driven controller (phase
-//! timer, freeze-window checks, inactivity threshold) — see
+//! Holds the [`GroupState`] enum and exposes named transition methods.
+//! The app layer wraps this with a timer-driven controller — see
 //! [`crate::app::PhaseTimer`].
 
 use std::fmt::Display;
 
-/// The lifecycle state of a per-group session.
-///
-/// Transitions are driven by the app layer through the named methods
-/// on [`GroupStateMachine`]. The protocol rules (e.g. "force-freezing
-/// only fires from Working or Reelection") are enforced here; timing
-/// rules ("freeze times out after `freeze_duration`") live in the app
-/// layer's wrapper.
+/// The lifecycle state of a per-group session. Transitions are driven
+/// by the app layer through the named methods on [`GroupStateMachine`];
+/// timing rules live in [`crate::app::PhaseTimer`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupState {
     /// Joiner waiting for a welcome.
@@ -47,9 +41,8 @@ impl Display for GroupState {
     }
 }
 
-/// Passive state machine — just the state enum + named transitions.
-/// No timer, no I/O. The app layer wraps this with timer-driven
-/// behaviour.
+/// State enum + named transitions. The app layer wraps this with
+/// timer-driven behaviour through [`crate::app::PhaseTimer`].
 #[derive(Debug, Clone)]
 pub struct GroupStateMachine {
     state: GroupState,
@@ -109,9 +102,7 @@ impl GroupStateMachine {
         self.state = GroupState::Reelection;
     }
 
-    /// Caller must ensure a valid transition. The leave path handles
-    /// `PendingJoin` and already-`Leaving` cases separately at the app
-    /// layer.
+    /// Caller must ensure a valid transition.
     pub fn start_leaving(&mut self) {
         self.state = GroupState::Leaving;
     }

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -130,11 +130,11 @@ message PeerScore {
 }
 
 message TimingConfig {
-  uint64 epoch_duration_ms = 1;
+  uint64 commit_inactivity_duration_ms = 1; // RFC §Inactivity Timer #1
   uint64 freeze_duration_ms = 2;
   uint64 proposal_expiration_ms = 3;
   uint64 consensus_timeout_ms = 4;
-  uint64 retry_inactivity_duration_ms = 5; // Inactivity window during recovery
+  uint64 recovery_inactivity_duration_ms = 5; // RFC §Inactivity Timer #2
 }
 
 enum Outcome {

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -107,7 +107,7 @@ async fn settle() {
 async fn concurrent_joins_leave_joiners_with_empty_buffer() {
     let group = "recovery-test";
     let cfg = GroupConfig {
-        epoch_duration: Duration::from_millis(50),
+        commit_inactivity_duration: Duration::from_millis(50),
         freeze_duration: Duration::from_millis(10),
         protocol: StewardListConfig::new(1, 5).unwrap(),
         ..GroupConfig::default()


### PR DESCRIPTION
Move the passive state machine into core and split it from the timer-driven controller. `core::GroupStateMachine` holds the `GroupState` enum and named transitions with no timing, no I/O. `app::PhaseTimer` holds the wall-clock anchor and duration knobs. `GroupEntry` owns one of each and exposes coordinator methods (`start_freezing`, `force_freezing`, `start_working`, …) that update both atomically so they never drift.

Coordinator-method callsites moved off `entry.phase_timer.<sm-method>()` to `entry.<sm-method>()`; duration getters stay on `entry.phase_timer.<getter>()`.

Timer-name alignment with the upstream RFC §Inactivity Timer:
- `epoch_duration` → `commit_inactivity_duration` 
- `retry_inactivity_duration` → `recovery_inactivity_duration`

Renames cover `GroupConfig` fields, default constants, getters/setters, the `TimingConfig` proto, and all callers/tests.

Known gaps: RFC §Inactivity Timer ("Voting inactivity" — submitted update never opens a consensus session) is not implemented; tracked separately. `GroupState::Leaving` variant is read as a guard but no transition path leads to it (pre-existing dormancy).