### PR TITLE
refactor(group-entry): consolidate epoch history, config, and recovery flag

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -62,7 +62,7 @@ pub(crate) async fn load_member_info(
         .collect())
 }
 
-/// Push refreshed approved-queue and epoch-history events to the UI.
+/// Push refreshed approved-queue and current-epoch state to the UI.
 pub(crate) async fn push_consensus_state(
     user: &UserRef,
     evt_tx: &UnboundedSender<AppEvent>,
@@ -77,15 +77,6 @@ pub(crate) async fn push_consensus_state(
         let _ = evt_tx.unbounded_send(AppEvent::CurrentEpochProposals {
             group_id: group_name.to_string(),
             proposals: display_batch(&proposals),
-        });
-    }
-
-    if let Ok(history) = user.read().await.get_epoch_history(group_name).await {
-        let epochs: Vec<Vec<(String, String)>> =
-            history.iter().map(|batch| display_batch(batch)).collect();
-        let _ = evt_tx.unbounded_send(AppEvent::EpochHistory {
-            group_id: group_name.to_string(),
-            epochs,
         });
     }
 

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -252,7 +252,7 @@ impl Gateway<WakuDeliveryService> {
 
     /// Get epoch history for a group (past batches of approved proposals).
     ///
-    /// Returns up to the last 10 epochs, each as a list of `(action, identity)` pairs.ƒ
+    /// Returns up to the last 10 epochs, each as a list of `(action, identity)` pairs.
     pub async fn get_epoch_history(
         &self,
         group_name: String,

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -252,13 +252,15 @@ impl Gateway<WakuDeliveryService> {
 
     /// Get epoch history for a group (past batches of approved proposals).
     ///
-    /// Returns up to the last 10 epochs, each as a list of `(action, identity)` pairs.
+    /// Returns up to the last 10 epochs, each as a list of `(action, identity)` pairs.ƒ
     pub async fn get_epoch_history(
         &self,
         group_name: String,
     ) -> anyhow::Result<Vec<Vec<(String, String)>>> {
-        let user_ref = self.user()?;
-        let history = user_ref.read().await.get_epoch_history(&group_name).await?;
-        Ok(history.iter().map(|batch| display_batch(batch)).collect())
+        let store = self.epoch_history.lock();
+        Ok(store
+            .get(&group_name)
+            .map(|history| history.iter().map(|b| display_batch(b)).collect())
+            .unwrap_or_default())
     }
 }

--- a/crates/de_mls_gateway/src/handler.rs
+++ b/crates/de_mls_gateway/src/handler.rs
@@ -19,6 +19,8 @@ use de_mls::{
 };
 use de_mls_ui_protocol::v1::AppEvent;
 
+use crate::{EpochHistoryStore, MAX_EPOCH_HISTORY, forwarder::display_batch};
+
 /// Event handler for the gateway layer.
 ///
 /// Sends outbound packets via the delivery service and forwards
@@ -27,6 +29,7 @@ pub struct GatewayEventHandler<DS: DeliveryService> {
     pub delivery: Arc<DS>,
     pub evt_tx: UnboundedSender<AppEvent>,
     pub topics: Arc<TopicFilter>,
+    pub epoch_history: EpochHistoryStore,
 }
 
 #[async_trait]
@@ -56,6 +59,7 @@ impl<DS: DeliveryService> GroupEventHandler for GatewayEventHandler<DS> {
 
     async fn on_leave_group(&self, group_name: &str) -> Result<(), CallbackError> {
         self.topics.remove_many(group_name).await;
+        self.epoch_history.lock().remove(group_name);
 
         let _ = self
             .evt_tx
@@ -94,6 +98,30 @@ impl<DS: DeliveryService> GroupEventHandler for GatewayEventHandler<DS> {
             proposal_id,
             action,
             address,
+        });
+        Ok(())
+    }
+
+    async fn on_commit_applied(
+        &self,
+        group_name: &str,
+        batch: Vec<GroupUpdateRequest>,
+    ) -> Result<(), CallbackError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let formatted: Vec<Vec<(String, String)>> = {
+            let mut store = self.epoch_history.lock();
+            let entry = store.entry(group_name.to_string()).or_default();
+            if entry.len() >= MAX_EPOCH_HISTORY {
+                entry.pop_front();
+            }
+            entry.push_back(batch);
+            entry.iter().map(|b| display_batch(b)).collect()
+        };
+        let _ = self.evt_tx.unbounded_send(AppEvent::EpochHistory {
+            group_id: group_name.to_string(),
+            epochs: formatted,
         });
         Ok(())
     }

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -11,12 +11,16 @@ pub(crate) mod forwarder;
 mod group;
 pub mod handler;
 
-use std::sync::{Arc, atomic::AtomicBool};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, atomic::AtomicBool},
+};
 
 use de_mls::{
     app::User,
     core::DefaultProvider,
     ds::{DeliveryService, WakuDeliveryService},
+    protos::de_mls::messages::v1::GroupUpdateRequest,
 };
 use de_mls_ui_protocol::v1::{AppCmd, AppEvent};
 use futures::{
@@ -62,6 +66,15 @@ pub fn init_core(core: Arc<CoreCtx<WakuDeliveryService>>) {
     GATEWAY.set_core(core);
 }
 
+/// Cap on the per-group rolling history of committed batches kept on the gateway.
+pub(crate) const MAX_EPOCH_HISTORY: usize = 10;
+
+/// Per-group rolling history of committed batches, populated by
+/// `on_commit_applied` and consumed by the History tab via
+/// `Gateway::get_epoch_history`. Cap is [`MAX_EPOCH_HISTORY`].
+pub(crate) type EpochHistoryStore =
+    Arc<parking_lot::Mutex<HashMap<String, VecDeque<Vec<GroupUpdateRequest>>>>>;
+
 pub struct Gateway<DS: DeliveryService> {
     // UI events (gateway -> UI)
     evt_tx: UnboundedSender<AppEvent>,
@@ -78,6 +91,10 @@ pub struct Gateway<DS: DeliveryService> {
 
     // Guards against spawning forwarders more than once
     started: AtomicBool,
+
+    // Per-group committed-batch history (UI cache). Shared by Arc with the
+    // gateway's GroupEventHandler so `on_commit_applied` can append.
+    epoch_history: EpochHistoryStore,
 }
 
 impl<DS: DeliveryService> Gateway<DS> {
@@ -90,6 +107,7 @@ impl<DS: DeliveryService> Gateway<DS> {
             core: RwLock::new(None),
             user: RwLock::new(None),
             started: AtomicBool::new(false),
+            epoch_history: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -156,6 +174,7 @@ impl Gateway<WakuDeliveryService> {
             delivery: Arc::new(core.app_state.delivery.clone()),
             evt_tx: self.evt_tx.clone(),
             topics: core.topics.clone(),
+            epoch_history: self.epoch_history.clone(),
         });
 
         let user = User::with_private_key(

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -123,3 +123,27 @@ impl GroupConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Steward-election proposals get the shorter `election_voting_delay`;
+    /// other kinds get `voting_delay`.
+    #[test]
+    fn voting_delay_dispatch_on_proposal_kind() {
+        let config = GroupConfig {
+            voting_delay: Duration::from_secs(7),
+            election_voting_delay: Duration::from_secs(3),
+            ..GroupConfig::default()
+        };
+        assert_eq!(
+            config.voting_delay_for(ProposalKind::Commit),
+            Duration::from_secs(7)
+        );
+        assert_eq!(
+            config.voting_delay_for(ProposalKind::StewardElection),
+            Duration::from_secs(3)
+        );
+    }
+}

--- a/src/app/phase_timer.rs
+++ b/src/app/phase_timer.rs
@@ -1,21 +1,18 @@
 //! App-side phase timer.
 //!
-//! Holds the wall-clock anchor (`started_at`) and the `Duration` knobs
-//! the timer-driven helpers consult: commit inactivity, freeze, recovery
-//! inactivity, proposal expiration, consensus timeout, voting delays.
-//! State transitions and the state enum live in
-//! [`crate::core::GroupStateMachine`]; `GroupEntry` composes the two and
-//! drives them through coordinator methods.
+//! Holds the wall-clock anchor (`started_at`) and the phase-anchor
+//! `Duration` knobs the timer-driven helpers consult: commit inactivity,
+//! freeze, recovery inactivity. State transitions and the state enum
+//! live in [`crate::core::GroupStateMachine`]; voting/consensus durations
+//! live in [`crate::app::GroupConfig`] on `GroupEntry`. `GroupEntry`
+//! composes the SM and the timer through coordinator methods.
 
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use tracing::info;
 
-use crate::{
-    app::config::GroupConfig,
-    core::{GroupState, ProposalKind},
-};
+use crate::{app::config::GroupConfig, core::GroupState};
 
 /// Notifies the integrator when a group transitions between [`GroupState`]
 /// variants. Fired from the app layer.
@@ -58,15 +55,6 @@ pub struct PhaseTimer {
     /// RFC §Inactivity Timer #2 — "Recovery inactivity" threshold; caller
     /// of `poll_steward_inactivity` picks which duration to apply.
     recovery_inactivity_duration: Duration,
-    /// Voting-proposal lifetime (RFC §Creating Voting Proposal).
-    proposal_expiration: Duration,
-    /// Library deadline per consensus session. Mismatched values across
-    /// nodes split outcomes.
-    consensus_timeout: Duration,
-    /// Per-member window before auto-vote fires. Local-only.
-    voting_delay: Duration,
-    /// Auto-vote delay for steward-election proposals. Local-only.
-    election_voting_delay: Duration,
 }
 
 impl Default for PhaseTimer {
@@ -77,19 +65,15 @@ impl Default for PhaseTimer {
 
 impl PhaseTimer {
     pub fn with_default_config() -> Self {
-        Self::with_config(GroupConfig::default())
+        Self::with_config(&GroupConfig::default())
     }
 
-    pub fn with_config(config: GroupConfig) -> Self {
+    pub fn with_config(config: &GroupConfig) -> Self {
         Self {
             started_at: None,
             commit_inactivity_duration: config.commit_inactivity_duration,
             freeze_duration: config.freeze_duration,
             recovery_inactivity_duration: config.recovery_inactivity_duration,
-            proposal_expiration: config.proposal_expiration,
-            consensus_timeout: config.consensus_timeout,
-            voting_delay: config.voting_delay,
-            election_voting_delay: config.election_voting_delay,
         }
     }
 
@@ -122,26 +106,9 @@ impl PhaseTimer {
         self.recovery_inactivity_duration
     }
 
-    pub fn proposal_expiration(&self) -> Duration {
-        self.proposal_expiration
-    }
-
-    pub fn consensus_timeout(&self) -> Duration {
-        self.consensus_timeout
-    }
-
-    /// Steward-election proposals use the shorter `election_voting_delay`
-    /// for fast recovery convergence.
-    pub fn voting_delay_for(&self, kind: ProposalKind) -> Duration {
-        if kind.is_steward_election() {
-            self.election_voting_delay
-        } else {
-            self.voting_delay
-        }
-    }
-
     // Setters below are called by `User::on_group_sync` to apply the
-    // steward's `TimingConfig`.
+    // steward's `TimingConfig`. Voting/consensus durations live in
+    // `GroupConfig` on the entry, written there directly.
 
     pub fn set_commit_inactivity_duration(&mut self, value: Duration) {
         self.commit_inactivity_duration = value;
@@ -153,14 +120,6 @@ impl PhaseTimer {
 
     pub fn set_recovery_inactivity_duration(&mut self, value: Duration) {
         self.recovery_inactivity_duration = value;
-    }
-
-    pub fn set_proposal_expiration(&mut self, value: Duration) {
-        self.proposal_expiration = value;
-    }
-
-    pub fn set_consensus_timeout(&mut self, value: Duration) {
-        self.consensus_timeout = value;
     }
 
     // ─────────────────────────── State-aware queries ───────────────────────────
@@ -267,7 +226,7 @@ mod tests {
     #[test]
     fn pending_join_expires_after_three_commit_inactivity_windows() {
         let config = GroupConfig::default();
-        let mut pt = PhaseTimer::with_config(config.clone());
+        let mut pt = PhaseTimer::with_config(&config);
         pt.start();
         assert!(!pt.is_pending_join_expired(GroupState::PendingJoin));
 
@@ -358,29 +317,8 @@ mod tests {
             recovery_inactivity_duration: short_inactivity(),
             ..GroupConfig::default()
         };
-        let pt = PhaseTimer::with_config(config);
+        let pt = PhaseTimer::with_config(&config);
         assert_eq!(pt.commit_inactivity_duration(), long_inactivity());
         assert_eq!(pt.recovery_inactivity_duration(), short_inactivity());
-    }
-
-    /// `voting_delay_for` dispatches on proposal kind: steward-election
-    /// proposals get the shorter `election_voting_delay`, others get
-    /// `voting_delay`.
-    #[test]
-    fn voting_delay_dispatch_on_proposal_kind() {
-        let config = GroupConfig {
-            voting_delay: Duration::from_secs(7),
-            election_voting_delay: Duration::from_secs(3),
-            ..GroupConfig::default()
-        };
-        let pt = PhaseTimer::with_config(config);
-        assert_eq!(
-            pt.voting_delay_for(ProposalKind::Commit),
-            Duration::from_secs(7)
-        );
-        assert_eq!(
-            pt.voting_delay_for(ProposalKind::StewardElection),
-            Duration::from_secs(3)
-        );
     }
 }

--- a/src/app/phase_timer.rs
+++ b/src/app/phase_timer.rs
@@ -107,8 +107,7 @@ impl PhaseTimer {
     }
 
     // Setters below are called by `User::on_group_sync` to apply the
-    // steward's `TimingConfig`. Voting/consensus durations live in
-    // `GroupConfig` on the entry, written there directly.
+    // steward's `TimingConfig`.
 
     pub fn set_commit_inactivity_duration(&mut self, value: Duration) {
         self.commit_inactivity_duration = value;

--- a/src/app/user/consensus.rs
+++ b/src/app/user/consensus.rs
@@ -160,7 +160,7 @@ impl<
         };
 
         let Some(consensus_timeout) = self
-            .with_entry(&group_name, |e| e.phase_timer.consensus_timeout())
+            .with_entry(&group_name, |e| e.config.consensus_timeout)
             .await
         else {
             return;
@@ -190,10 +190,10 @@ impl<
         let (proposal_expiration, consensus_timeout, liveness_criteria_yes, voting_delay) = self
             .with_entry(group_name, |e| {
                 (
-                    e.phase_timer.proposal_expiration(),
-                    e.phase_timer.consensus_timeout(),
-                    e.group.liveness_criteria_yes(),
-                    e.phase_timer.voting_delay_for(kind),
+                    e.config.proposal_expiration,
+                    e.config.consensus_timeout,
+                    e.config.liveness_criteria_yes,
+                    e.config.voting_delay_for(kind),
                 )
             })
             .await

--- a/src/app/user/consensus_events.rs
+++ b/src/app/user/consensus_events.rs
@@ -96,6 +96,12 @@ impl<
             return self.handle_election_accepted(group_name, election).await;
         }
 
+        if consensus_apply.enter_recovery_mode {
+            if let Some(entry_arc) = self.lookup_entry(group_name).await {
+                entry_arc.write().await.enter_recovery_mode();
+            }
+        }
+
         if consensus_apply.force_freezing {
             self.force_freezing_for_urgent_commit(group_name).await;
         }
@@ -210,7 +216,7 @@ impl<
             // `retry_round` stays > 0 until the next successful commit so
             // the immediate post-election inactivity check uses the
             // short retry window.
-            entry.group.exit_recovery_mode();
+            entry.exit_recovery_mode();
             if entry.current_state() == GroupState::Reelection {
                 entry.start_working();
                 true

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -267,7 +267,7 @@ impl<
         }
         // Recovery uses the shorter retry inactivity window so we don't
         // burn another full epoch waiting for a steward to commit.
-        let in_recovery = entry.group.is_in_recovery_mode() || entry.steward.retry_round() > 0;
+        let in_recovery = entry.is_in_recovery_mode() || entry.steward.retry_round() > 0;
         let inactivity = if in_recovery {
             entry.phase_timer.recovery_inactivity_duration()
         } else {

--- a/src/app/user/freeze.rs
+++ b/src/app/user/freeze.rs
@@ -106,7 +106,6 @@ impl<
             } else {
                 FreezeFinalizeResult::default()
             };
-            entry.archive_committed_batch(result.committed_batch.clone());
             // Apply locally-observed score events before releasing the
             // entry lock. These come from dropped candidates in the
             // phase-3 loop (RFC §Peer Scoring: direct local observation,
@@ -120,6 +119,16 @@ impl<
             };
             (result, cross)
         };
+
+        // Notify the integrator of the just-committed batch (UI history,
+        // audit logs, etc.). Fired outside the entry lock so the handler
+        // can take its own locks without deadlock risk.
+        if !finalize_result.committed_batch.is_empty() {
+            let batch: Vec<_> = finalize_result.committed_batch.values().cloned().collect();
+            if let Err(e) = self.handler.on_commit_applied(group_name, batch).await {
+                error!(group = group_name, error = %e, "on_commit_applied callback failed");
+            }
+        }
 
         // Lock split is intentional: `check_and_initiate_score_removals`
         // re-acquires the entry write lock and calls `initiate_proposal`

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -238,7 +238,7 @@ impl<
     /// list installs and closes the window.
     async fn maybe_close_recovery_window(&self, group_name: &str) {
         let in_recovery_mode = self
-            .with_entry(group_name, |entry| entry.group.is_in_recovery_mode())
+            .with_entry(group_name, |entry| entry.is_in_recovery_mode())
             .await
             .unwrap_or(false);
         if !in_recovery_mode {

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -128,8 +128,8 @@ impl<
             let Some((delay, vote)) = self
                 .with_entry(group_name, |e| {
                     (
-                        e.phase_timer.voting_delay_for(kind),
-                        e.group.liveness_criteria_yes(),
+                        e.config.voting_delay_for(kind),
+                        e.config.liveness_criteria_yes,
                     )
                 })
                 .await
@@ -398,12 +398,8 @@ impl<
         // `SCORE_BELOW_THRESHOLD` from their own event chain. Drop our
         // events to avoid duplicate proposals from joiners.
         let _events = entry.scoring.apply_snapshot(&snapshot);
-        entry
-            .group
-            .set_liveness_criteria_yes(sync.liveness_criteria_yes);
-        entry
-            .group
-            .set_pending_update_max_epochs(sync.pending_update_max_epochs);
+        entry.config.liveness_criteria_yes = sync.liveness_criteria_yes;
+        entry.config.pending_update_max_epochs = sync.pending_update_max_epochs;
         if let Some(timing) = &sync.timing {
             let pt = &mut entry.phase_timer;
             pt.set_commit_inactivity_duration(std::time::Duration::from_millis(
@@ -413,12 +409,10 @@ impl<
             pt.set_recovery_inactivity_duration(std::time::Duration::from_millis(
                 timing.recovery_inactivity_duration_ms,
             ));
-            pt.set_proposal_expiration(std::time::Duration::from_millis(
-                timing.proposal_expiration_ms,
-            ));
-            pt.set_consensus_timeout(std::time::Duration::from_millis(
-                timing.consensus_timeout_ms,
-            ));
+            entry.config.proposal_expiration =
+                std::time::Duration::from_millis(timing.proposal_expiration_ms);
+            entry.config.consensus_timeout =
+                std::time::Duration::from_millis(timing.consensus_timeout_ms);
         }
         Ok(())
     }

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -52,30 +52,25 @@ impl<
             return Err(UserError::GroupAlreadyExists);
         }
 
-        let max_reelection_attempts = config.max_reelection_attempts;
-        let liveness_criteria_yes = config.liveness_criteria_yes;
-        let pending_update_max_epochs = config.pending_update_max_epochs;
         let self_identity_bytes = self.identity().identity_bytes().to_vec();
-        let (mut group, mls_opt, state_machine, phase_timer) = if is_creation {
+        let (group, mls_opt, state_machine, phase_timer) = if is_creation {
             let mls = (self.mls_creator_factory)(group_name.to_string())?;
             let group = Group::create_group(group_name, self_identity_bytes.clone());
             let state_machine = GroupStateMachine::new_as_member();
-            let phase_timer = PhaseTimer::with_config(config.clone());
+            let phase_timer = PhaseTimer::with_config(&config);
             (group, Some(mls), state_machine, phase_timer)
         } else {
             let group = Group::prepare_to_join(group_name, self_identity_bytes.clone());
             let state_machine = GroupStateMachine::new_as_pending_join();
             // Anchor the timer at "now" so `is_pending_join_expired` can
-            // detect the 3× epoch-duration timeout.
-            let mut phase_timer = PhaseTimer::with_config(config.clone());
+            // detect the 3× commit-inactivity timeout.
+            let mut phase_timer = PhaseTimer::with_config(&config);
             phase_timer.start();
             (group, None, state_machine, phase_timer)
         };
-        group.set_liveness_criteria_yes(liveness_criteria_yes);
-        group.set_pending_update_max_epochs(pending_update_max_epochs);
 
         let mut steward = self.make_steward_plugin(group_name, &config.protocol);
-        steward.set_max_retries(max_reelection_attempts);
+        steward.set_max_retries(config.max_reelection_attempts);
         // Creator path: bootstrap the list with self as sole steward at
         // epoch 0. Joiner path leaves the plug-in empty until `GroupSync`.
         if is_creation {
@@ -107,6 +102,7 @@ impl<
                 mls_opt,
                 state_machine,
                 phase_timer,
+                config,
                 scoring,
                 steward,
             ))),
@@ -178,8 +174,8 @@ impl<
             let mut entry = entry_arc.write().await;
             entry.group.store_voting_proposal(proposal_id, request);
             (
-                entry.phase_timer.proposal_expiration(),
-                entry.phase_timer.consensus_timeout(),
+                entry.config.proposal_expiration,
+                entry.config.consensus_timeout,
             )
         };
 

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -62,9 +62,15 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// Per-group state machine. Coordinator methods on this entry update
     /// it together with `phase_timer` so the two never drift.
     state_machine: GroupStateMachine,
-    /// Wall-clock anchor + duration knobs combined with `state_machine`
-    /// by the entry's coordinator methods.
+    /// Wall-clock anchor + phase-anchor durations combined with
+    /// `state_machine` by the entry's coordinator methods.
     phase_timer: PhaseTimer,
+    /// Per-group durable config — voting/consensus knobs and the two
+    /// `Group`-level flags (`liveness_criteria_yes`,
+    /// `pending_update_max_epochs`). Read by app-layer coordinators;
+    /// joiner-sync writes through this directly. Plug-ins keep their own
+    /// internal config slices (`StewardListConfig`, `ScoringConfig`).
+    pub(crate) config: GroupConfig,
     /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
     /// `RwLock`, no separate `Mutex` needed.
@@ -84,6 +90,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
         mls: Option<M>,
         state_machine: GroupStateMachine,
         phase_timer: PhaseTimer,
+        config: GroupConfig,
         scoring: Sc,
         steward: St,
     ) -> Self {
@@ -92,6 +99,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
             mls,
             state_machine,
             phase_timer,
+            config,
             scoring,
             steward,
         }

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -11,7 +11,7 @@
 //! tasks just take their own handle via `self.clone()`.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
@@ -32,8 +32,8 @@ use crate::{
         BufferedCommitCandidate, CoreError, DeMlsProvider, DefaultProvider,
         DeterministicStewardList, FreezeFinalizeResult, Group, GroupEventHandler, GroupState,
         GroupStateMachine, PeerScoringEvent, PeerScoringPlugin, PeerScoringService, ProcessResult,
-        ProposalId, ProposalKind, ProviderConsensus, ScoringConfig, StewardListConfig,
-        StewardListPlugin, compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
+        ProposalKind, ProviderConsensus, ScoringConfig, StewardListConfig, StewardListPlugin,
+        compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     identity::{Identity, WalletIdentity},
@@ -41,9 +41,7 @@ use crate::{
         CommitCandidate as MlsCommitCandidate, KeyPackageBytes, MemoryDeMlsStorage, MlsCommitInput,
         MlsCredentials, MlsError, MlsService, OpenMlsService,
     },
-    protos::de_mls::messages::v1::{
-        AppMessage, CommitCandidate, GroupUpdateRequest, group_update_request::Payload,
-    },
+    protos::de_mls::messages::v1::{AppMessage, CommitCandidate, group_update_request::Payload},
 };
 
 mod consensus;
@@ -54,10 +52,6 @@ mod lifecycle;
 mod messaging;
 mod query;
 mod steward;
-
-/// Cap on the per-group UI history of committed batches. App-layer
-/// concern only; protocol logic in `core::Group` is history-agnostic.
-const MAX_EPOCH_HISTORY: usize = 10;
 
 pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> {
     group: Group,
@@ -80,11 +74,6 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// eligibility from MLS members + `Group::is_pending_removal` and
     /// passes it on every position query.
     steward: St,
-    /// Per-group rolling history of committed batches, most recent last.
-    /// Bounded at [`MAX_EPOCH_HISTORY`]. Populated by
-    /// [`GroupEntry::archive_committed_batch`] from the snapshot
-    /// returned by `Group::clear_approved_proposals`.
-    epoch_history: VecDeque<HashMap<ProposalId, GroupUpdateRequest>>,
 }
 
 impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, Sc, St> {
@@ -105,7 +94,6 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
             phase_timer,
             scoring,
             steward,
-            epoch_history: VecDeque::new(),
         }
     }
 
@@ -400,17 +388,6 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
     pub(crate) fn process_inbound(&mut self, payload: &[u8]) -> Result<ProcessResult, CoreError> {
         let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
         process_inbound(&mut self.group, mls, payload)
-    }
-
-    /// Append a just-committed batch to the bounded UI history.
-    fn archive_committed_batch(&mut self, snapshot: HashMap<ProposalId, GroupUpdateRequest>) {
-        if snapshot.is_empty() {
-            return;
-        }
-        if self.epoch_history.len() >= MAX_EPOCH_HISTORY {
-            self.epoch_history.pop_front();
-        }
-        self.epoch_history.push_back(snapshot);
     }
 }
 

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -80,6 +80,12 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// eligibility from MLS members + `Group::is_pending_removal` and
     /// passes it on every position query.
     steward: St,
+    /// Cross-cutting recovery flag (RFC §Layer 3 Anti-Deadlock ECP).
+    /// Set when an accepted Deadlock ECP relaxes the steward gate so any
+    /// member may produce the next commit; cleared when a fresh election
+    /// lands. Read by the freeze coordinator, the create-commit path, and
+    /// `core::finalize_freeze_round` (via `in_recovery` parameter).ƒ
+    recovery_mode: bool,
 }
 
 impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, Sc, St> {
@@ -102,7 +108,22 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
             config,
             scoring,
             steward,
+            recovery_mode: false,
         }
+    }
+
+    // ── Recovery-mode flag (Layer 3 Anti-Deadlock) ──────────────────
+
+    pub(crate) fn is_in_recovery_mode(&self) -> bool {
+        self.recovery_mode
+    }
+
+    pub(crate) fn enter_recovery_mode(&mut self) {
+        self.recovery_mode = true;
+    }
+
+    pub(crate) fn exit_recovery_mode(&mut self) {
+        self.recovery_mode = false;
     }
 
     // ── State-machine + phase-timer coordinators ────────────────────
@@ -232,7 +253,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
         app_id: &[u8],
     ) -> Result<Option<OutboundPacket>, CoreError> {
         let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
-        if !self.steward.is_steward(self_identity) && !self.group.is_in_recovery_mode() {
+        if !self.steward.is_steward(self_identity) && !self.recovery_mode {
             return Err(CoreError::NotASteward);
         }
 
@@ -385,6 +406,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> GroupEntry<M, 
             &mut self.group,
             mls,
             &self.steward,
+            self.recovery_mode,
             allow_subset_candidates,
             app_id,
         )

--- a/src/app/user/mod.rs
+++ b/src/app/user/mod.rs
@@ -65,11 +65,9 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// Wall-clock anchor + phase-anchor durations combined with
     /// `state_machine` by the entry's coordinator methods.
     phase_timer: PhaseTimer,
-    /// Per-group durable config — voting/consensus knobs and the two
-    /// `Group`-level flags (`liveness_criteria_yes`,
-    /// `pending_update_max_epochs`). Read by app-layer coordinators;
-    /// joiner-sync writes through this directly. Plug-ins keep their own
-    /// internal config slices (`StewardListConfig`, `ScoringConfig`).
+    /// Per-group durable config: voting/consensus durations,
+    /// `liveness_criteria_yes`, `pending_update_max_epochs`. Read by
+    /// app-layer coordinators; joiner-sync writes through this directly.
     pub(crate) config: GroupConfig,
     /// Per-group peer-score plug-in. Lives next to `state_machine` as
     /// app-layer wiring; protocol decisions read it via the entry's
@@ -80,11 +78,11 @@ pub(crate) struct GroupEntry<M: MlsService, Sc: PeerScoringPlugin, St: StewardLi
     /// eligibility from MLS members + `Group::is_pending_removal` and
     /// passes it on every position query.
     steward: St,
-    /// Cross-cutting recovery flag (RFC §Layer 3 Anti-Deadlock ECP).
-    /// Set when an accepted Deadlock ECP relaxes the steward gate so any
-    /// member may produce the next commit; cleared when a fresh election
-    /// lands. Read by the freeze coordinator, the create-commit path, and
-    /// `core::finalize_freeze_round` (via `in_recovery` parameter).ƒ
+    /// Recovery flag (RFC §Layer 3 Anti-Deadlock ECP). Set when an
+    /// accepted Deadlock ECP relaxes the steward gate so any member may
+    /// produce the next commit; cleared when a fresh election lands.
+    /// Read by the freeze coordinator, the create-commit path, and
+    /// `core::finalize_freeze_round` (via `in_recovery` parameter).
     recovery_mode: bool,
 }
 

--- a/src/app/user/query.rs
+++ b/src/app/user/query.rs
@@ -178,18 +178,4 @@ impl<
         .await
         .ok_or(UserError::GroupNotFound)
     }
-
-    pub async fn get_epoch_history(
-        &self,
-        group_name: &str,
-    ) -> Result<Vec<Vec<GroupUpdateRequest>>, UserError> {
-        self.with_entry(group_name, |e| {
-            e.epoch_history
-                .iter()
-                .map(|batch| batch.values().cloned().collect())
-                .collect()
-        })
-        .await
-        .ok_or(UserError::GroupNotFound)
-    }
 }

--- a/src/app/user/steward.rs
+++ b/src/app/user/steward.rs
@@ -274,7 +274,7 @@ impl<
             (
                 mls.current_epoch()?,
                 entry.group_members()?,
-                entry.group.pending_update_max_epochs(),
+                entry.config.pending_update_max_epochs,
             )
         };
 
@@ -408,8 +408,8 @@ impl<
                     .commit_inactivity_duration()
                     .as_millis() as u64,
                 freeze_duration_ms: entry.phase_timer.freeze_duration().as_millis() as u64,
-                proposal_expiration_ms: entry.phase_timer.proposal_expiration().as_millis() as u64,
-                consensus_timeout_ms: entry.phase_timer.consensus_timeout().as_millis() as u64,
+                proposal_expiration_ms: entry.config.proposal_expiration.as_millis() as u64,
+                consensus_timeout_ms: entry.config.consensus_timeout.as_millis() as u64,
                 recovery_inactivity_duration_ms: entry
                     .phase_timer
                     .recovery_inactivity_duration()
@@ -438,9 +438,9 @@ impl<
                 timing: Some(timing),
                 retry_round: list.retry_round(),
                 max_reelection_attempts: entry.steward.max_retries(),
-                liveness_criteria_yes: entry.group.liveness_criteria_yes(),
+                liveness_criteria_yes: entry.config.liveness_criteria_yes,
                 threshold_peer_score: entry.scoring.threshold(),
-                pending_update_max_epochs: entry.group.pending_update_max_epochs(),
+                pending_update_max_epochs: entry.config.pending_update_max_epochs,
             };
 
             let app_msg: AppMessage = sync.into();

--- a/src/core/api/freeze.rs
+++ b/src/core/api/freeze.rs
@@ -151,6 +151,7 @@ pub fn finalize_freeze_round<M: MlsService>(
     group: &mut Group,
     mls: &M,
     steward: &dyn StewardListPlugin,
+    in_recovery: bool,
     allow_subset_candidates: bool,
     app_id: &[u8],
 ) -> Result<FreezeFinalizeResult, CoreError> {
@@ -177,7 +178,7 @@ pub fn finalize_freeze_round<M: MlsService>(
         return Ok(FreezeFinalizeResult::default());
     }
 
-    apply_in_priority_order(group, mls, steward, sorted, &ctx, app_id)
+    apply_in_priority_order(group, mls, steward, in_recovery, sorted, &ctx, app_id)
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -301,6 +302,7 @@ fn apply_in_priority_order<M: MlsService>(
     group: &mut Group,
     mls: &M,
     steward: &dyn StewardListPlugin,
+    in_recovery: bool,
     sorted: Vec<BufferedCommitCandidate>,
     ctx: &RoundContext,
     app_id: &[u8],
@@ -332,6 +334,7 @@ fn apply_in_priority_order<M: MlsService>(
                 group,
                 mls,
                 steward,
+                in_recovery,
                 chosen,
                 &ctx.mls_actions,
                 ctx.current_epoch,
@@ -509,6 +512,7 @@ fn apply_incoming_candidate<M: MlsService>(
     group: &mut Group,
     mls: &M,
     steward: &dyn StewardListPlugin,
+    in_recovery: bool,
     chosen: BufferedCommitCandidate,
     expected_actions: &[MlsProposalOutput],
     current_epoch: u64,
@@ -542,7 +546,7 @@ fn apply_incoming_candidate<M: MlsService>(
 
     // Commit sender must be on the steward list (RFC §"Commit validation service").
     if let Some(violation) =
-        check_commit_sender_authorized(group, steward, &commit_sender, current_epoch)
+        check_commit_sender_authorized(group, steward, in_recovery, &commit_sender, current_epoch)
     {
         mls.discard_staged_commit()?;
         return Ok(CandidateOutcome::Drop(
@@ -724,10 +728,11 @@ fn expected_action_for_request(req: &GroupUpdateRequest) -> Option<MlsProposalOu
 fn check_commit_sender_authorized(
     group: &Group,
     steward: &dyn StewardListPlugin,
+    in_recovery: bool,
     commit_sender: &[u8],
     epoch: u64,
 ) -> Option<ViolationEvidence> {
-    if group.is_in_recovery_mode() {
+    if in_recovery {
         return None;
     }
     steward.current_list()?;

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -30,6 +30,12 @@ pub struct ConsensusApplyResult {
     pub election: Option<StewardElectionProposal>,
     pub force_freezing: bool,
     pub queued_remove_target: Option<Vec<u8>>,
+    /// `true` when an accepted Layer-3 Deadlock ECP signals "open recovery
+    /// mode." App caller flips `GroupEntry::recovery_mode` on; cleared on
+    /// the next accepted election. Mode flag lives on `GroupEntry`, not
+    /// in `Group` (cross-cutting flag, not plug-in-internal — see
+    /// `plugin-narrow-domain.md`).
+    pub enter_recovery_mode: bool,
 }
 
 /// Extract emergency evidence from a `GroupUpdateRequest`, if present.
@@ -199,6 +205,7 @@ pub fn apply_consensus_result(
     }
 
     let mut force_freezing = false;
+    let mut enter_recovery_mode = false;
 
     if approved {
         if is_owner {
@@ -229,8 +236,9 @@ pub fn apply_consensus_result(
             force_freezing = true;
         } else if evidence.as_ref().is_some_and(is_deadlock) {
             // Layer 3: relax the steward gate so any member can produce
-            // the next commit. Cleared when a fresh election lands.
-            group.enter_recovery_mode();
+            // the next commit. App caller flips `GroupEntry::recovery_mode`
+            // when it sees this flag; cleared when a fresh election lands.
+            enter_recovery_mode = true;
             force_freezing = true;
         }
     } else if is_owner {
@@ -258,6 +266,7 @@ pub fn apply_consensus_result(
         election: None,
         force_freezing,
         queued_remove_target: removal_target,
+        enter_recovery_mode,
     })
 }
 
@@ -468,9 +477,8 @@ mod tests {
     }
 
     #[test]
-    fn ecp_deadlock_yes_opens_recovery_mode_and_force_freezes() {
+    fn ecp_deadlock_yes_signals_recovery_mode_and_force_freezes() {
         let mut group = make_group("deadlock-yes", member(1));
-        assert!(!group.is_in_recovery_mode());
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();
@@ -480,7 +488,10 @@ mod tests {
             result.force_freezing,
             "Deadlock YES must signal force-Freezing"
         );
-        assert!(group.is_in_recovery_mode(), "recovery_mode must be open");
+        assert!(
+            result.enter_recovery_mode,
+            "Deadlock YES must signal recovery-mode open"
+        );
         assert_eq!(
             group.approved_proposals_count(),
             0,
@@ -490,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    fn ecp_deadlock_no_does_not_open_recovery_mode() {
+    fn ecp_deadlock_no_does_not_signal_recovery_mode() {
         let mut group = make_group("deadlock-no", member(1));
 
         let request = deadlock_request(member(1));
@@ -498,6 +509,6 @@ mod tests {
         let result = apply_consensus_result(&mut group, 201, false, &payload).unwrap();
 
         assert!(!result.force_freezing);
-        assert!(!group.is_in_recovery_mode());
+        assert!(!result.enter_recovery_mode);
     }
 }

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -31,10 +31,8 @@ pub struct ConsensusApplyResult {
     pub force_freezing: bool,
     pub queued_remove_target: Option<Vec<u8>>,
     /// `true` when an accepted Layer-3 Deadlock ECP signals "open recovery
-    /// mode." App caller flips `GroupEntry::recovery_mode` on; cleared on
-    /// the next accepted election. Mode flag lives on `GroupEntry`, not
-    /// in `Group` (cross-cutting flag, not plug-in-internal — see
-    /// `plugin-narrow-domain.md`).
+    /// mode." Caller flips the recovery-mode flag on; cleared on the next
+    /// accepted election.
     pub enter_recovery_mode: bool,
 }
 

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -64,4 +64,17 @@ pub trait GroupEventHandler: Send + Sync {
     ) -> Result<(), CallbackError> {
         Ok(())
     }
+
+    /// A freeze round just merged a commit; `batch` is the set of approved
+    /// proposals that landed in that commit. Fired once per accepted commit
+    /// (whether the local node was the steward or not), in insertion order
+    /// of the approved queue. Integrators that maintain a UI history view
+    /// or audit log consume this; the default impl is a no-op.
+    async fn on_commit_applied(
+        &self,
+        _group_name: &str,
+        _batch: Vec<GroupUpdateRequest>,
+    ) -> Result<(), CallbackError> {
+        Ok(())
+    }
 }

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -131,10 +131,6 @@ pub struct Group {
     /// `RemoveMember(target)` entry; other approvals wait so they don't
     /// dilute the fast-removal intent.
     urgent_commit_target: Option<Vec<u8>>,
-    /// While `true`, `create_commit_candidate` bypasses the steward gate
-    /// so any member can produce the recovery commit. Set by Layer-3
-    /// Deadlock ECP, cleared on accepted election.
-    recovery_mode: bool,
 }
 
 pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
@@ -156,7 +152,6 @@ impl Group {
             pending_updates: HashMap::new(),
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
-            recovery_mode: false,
         }
     }
 
@@ -388,22 +383,6 @@ impl Group {
         });
         self.approved_order
             .retain(|pid| self.approved_proposals.contains_key(pid));
-    }
-
-    // ─────────────────────────── Layer 3 Recovery Mode ───────────────────────────
-
-    /// While set, `create_commit_candidate` bypasses the `is_steward()`
-    /// gate so any member can produce the recovery commit.
-    pub fn enter_recovery_mode(&mut self) {
-        self.recovery_mode = true;
-    }
-
-    pub fn is_in_recovery_mode(&self) -> bool {
-        self.recovery_mode
-    }
-
-    pub fn exit_recovery_mode(&mut self) {
-        self.recovery_mode = false;
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election

--- a/src/core/group.rs
+++ b/src/core/group.rs
@@ -135,12 +135,6 @@ pub struct Group {
     /// so any member can produce the recovery commit. Set by Layer-3
     /// Deadlock ECP, cleared on accepted election.
     recovery_mode: bool,
-    /// Auto-vote default and consensus tie-break rule (RFC §Creating
-    /// Voting Proposal).
-    liveness_criteria_yes: bool,
-    /// Max age (in epochs) of a buffered membership update before the
-    /// epoch steward drops it.
-    pending_update_max_epochs: u32,
 }
 
 pub const DEFAULT_LIVENESS_CRITERIA_YES: bool = true;
@@ -163,8 +157,6 @@ impl Group {
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
             recovery_mode: false,
-            liveness_criteria_yes: DEFAULT_LIVENESS_CRITERIA_YES,
-            pending_update_max_epochs: DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
         }
     }
 
@@ -575,24 +567,6 @@ impl Group {
         self.approved_proposals
             .get(&pid)
             .is_some_and(|req| is_auto_approved_entry(pid, req))
-    }
-
-    // ─────────────────────────── GroupSync-Tunable Fields ───────────────────────────
-
-    pub fn liveness_criteria_yes(&self) -> bool {
-        self.liveness_criteria_yes
-    }
-
-    pub fn set_liveness_criteria_yes(&mut self, value: bool) {
-        self.liveness_criteria_yes = value;
-    }
-
-    pub fn pending_update_max_epochs(&self) -> u32 {
-        self.pending_update_max_epochs
-    }
-
-    pub fn set_pending_update_max_epochs(&mut self, value: u32) {
-        self.pending_update_max_epochs = value;
     }
 
     /// Drop a buffered update by target identity.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -360,6 +360,11 @@ pub struct StewardHandle {
     pub mls: TestMls,
     pub steward: DeterministicStewardList,
     pub identity: Vec<u8>,
+    /// Mirrors `GroupEntry.config.liveness_criteria_yes` from production.
+    /// Tests own this directly because the handle isn't a `GroupEntry`.
+    pub liveness_criteria_yes: bool,
+    /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
+    pub pending_update_max_epochs: u32,
 }
 
 impl StewardHandle {
@@ -406,6 +411,8 @@ pub fn setup_steward_with_config(
         mls,
         steward,
         identity: identity_bytes,
+        liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
+        pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
     }
 }
 
@@ -421,6 +428,10 @@ pub struct JoinerHandle {
     pub mls: Option<TestMls>,
     pub steward: DeterministicStewardList,
     pub kp_packet: OutboundPacket,
+    /// Mirrors `GroupEntry.config.liveness_criteria_yes` from production.
+    pub liveness_criteria_yes: bool,
+    /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
+    pub pending_update_max_epochs: u32,
 }
 
 impl JoinerHandle {
@@ -480,6 +491,8 @@ pub fn setup_joiner_with_config(
         mls: None,
         steward,
         kp_packet,
+        liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
+        pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -144,10 +144,11 @@ pub fn build_commit_candidate(
     group: &mut Group,
     mls: &TestMls,
     steward: &DeterministicStewardList,
+    in_recovery: bool,
     self_identity: &[u8],
     app_id: &[u8],
 ) -> Result<Option<OutboundPacket>, CoreError> {
-    if !steward.is_steward(self_identity) && !group.is_in_recovery_mode() {
+    if !steward.is_steward(self_identity) && !in_recovery {
         return Err(CoreError::NotASteward);
     }
     if group.approved_proposals().is_empty() {
@@ -365,6 +366,9 @@ pub struct StewardHandle {
     pub liveness_criteria_yes: bool,
     /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
     pub pending_update_max_epochs: u32,
+    /// Mirrors `GroupEntry.recovery_mode`. Defaults to `false`; tests
+    /// exercising Layer-3 paths flip it directly.
+    pub recovery_mode: bool,
 }
 
 impl StewardHandle {
@@ -413,6 +417,7 @@ pub fn setup_steward_with_config(
         identity: identity_bytes,
         liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
         pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
+        recovery_mode: false,
     }
 }
 
@@ -432,6 +437,8 @@ pub struct JoinerHandle {
     pub liveness_criteria_yes: bool,
     /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
     pub pending_update_max_epochs: u32,
+    /// Mirrors `GroupEntry.recovery_mode`.
+    pub recovery_mode: bool,
 }
 
 impl JoinerHandle {
@@ -493,6 +500,7 @@ pub fn setup_joiner_with_config(
         kp_packet,
         liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
         pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
+        recovery_mode: false,
     }
 }
 
@@ -540,6 +548,7 @@ pub fn steward_add_joiner(
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        steward_handle.recovery_mode,
         &self_id,
         b"test-app-id",
     )
@@ -549,6 +558,7 @@ pub fn steward_add_joiner(
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        steward_handle.recovery_mode,
         false,
         b"test-app-id",
     )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -361,13 +361,8 @@ pub struct StewardHandle {
     pub mls: TestMls,
     pub steward: DeterministicStewardList,
     pub identity: Vec<u8>,
-    /// Mirrors `GroupEntry.config.liveness_criteria_yes` from production.
-    /// Tests own this directly because the handle isn't a `GroupEntry`.
     pub liveness_criteria_yes: bool,
-    /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
     pub pending_update_max_epochs: u32,
-    /// Mirrors `GroupEntry.recovery_mode`. Defaults to `false`; tests
-    /// exercising Layer-3 paths flip it directly.
     pub recovery_mode: bool,
 }
 
@@ -433,11 +428,8 @@ pub struct JoinerHandle {
     pub mls: Option<TestMls>,
     pub steward: DeterministicStewardList,
     pub kp_packet: OutboundPacket,
-    /// Mirrors `GroupEntry.config.liveness_criteria_yes` from production.
     pub liveness_criteria_yes: bool,
-    /// Mirrors `GroupEntry.config.pending_update_max_epochs`.
     pub pending_update_max_epochs: u32,
-    /// Mirrors `GroupEntry.recovery_mode`.
     pub recovery_mode: bool,
 }
 

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -229,6 +229,7 @@ fn test_process_inbound_leave_group() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -261,6 +262,7 @@ fn test_process_inbound_leave_group() {
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
         &joiner.steward,
+        false,
         false,
         b"test-app-id",
     )
@@ -314,6 +316,7 @@ fn test_rejoin_after_eviction() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -338,6 +341,7 @@ fn test_rejoin_after_eviction() {
         joiner.mls.as_ref().unwrap(),
         &joiner.steward,
         false,
+        false,
         b"test-app-id",
     )
     .unwrap();
@@ -352,6 +356,7 @@ fn test_rejoin_after_eviction() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         false,
         b"test-app-id",
     )
@@ -440,6 +445,7 @@ fn test_process_inbound_raw_commit_payload_is_ignored() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -678,14 +678,11 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut steward_handle = setup_steward_with_config(group_name, steward_hex, steward_protocol);
     let mut joiner = setup_joiner_with_config(group_name, joiner_hex, default_steward_config());
 
-    steward_handle.set_liveness_criteria_yes(STEWARD_LIVENESS_YES);
-    steward_handle.set_pending_update_max_epochs(STEWARD_PENDING_MAX_EPOCHS);
+    steward_handle.liveness_criteria_yes = STEWARD_LIVENESS_YES;
+    steward_handle.pending_update_max_epochs = STEWARD_PENDING_MAX_EPOCHS;
 
-    assert_ne!(joiner.group.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
-    assert_ne!(
-        joiner.group.pending_update_max_epochs(),
-        STEWARD_PENDING_MAX_EPOCHS
-    );
+    assert_ne!(joiner.liveness_criteria_yes, STEWARD_LIVENESS_YES);
+    assert_ne!(joiner.pending_update_max_epochs, STEWARD_PENDING_MAX_EPOCHS);
     assert_ne!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
     assert_ne!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
 
@@ -714,9 +711,9 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         timing: None,
         retry_round: steward_list.retry_round(),
         max_reelection_attempts: steward_handle.steward.max_retries(),
-        liveness_criteria_yes: steward_handle.liveness_criteria_yes(),
+        liveness_criteria_yes: steward_handle.liveness_criteria_yes,
         threshold_peer_score: STEWARD_THRESHOLD,
-        pending_update_max_epochs: steward_handle.pending_update_max_epochs(),
+        pending_update_max_epochs: steward_handle.pending_update_max_epochs,
     };
     let app_msg: AppMessage = sync.clone().into();
     let sync_packet = steward_handle
@@ -749,18 +746,11 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         StewardListConfig::new(received.sn_min as usize, received.sn_max as usize).unwrap();
     applied_protocol.allow_subset_candidates = received.allow_subset_candidates;
     joiner.steward.set_config(applied_protocol);
-    joiner
-        .group
-        .set_liveness_criteria_yes(received.liveness_criteria_yes);
-    joiner
-        .group
-        .set_pending_update_max_epochs(received.pending_update_max_epochs);
+    joiner.liveness_criteria_yes = received.liveness_criteria_yes;
+    joiner.pending_update_max_epochs = received.pending_update_max_epochs;
 
-    assert_eq!(joiner.group.liveness_criteria_yes(), STEWARD_LIVENESS_YES);
-    assert_eq!(
-        joiner.group.pending_update_max_epochs(),
-        STEWARD_PENDING_MAX_EPOCHS
-    );
+    assert_eq!(joiner.liveness_criteria_yes, STEWARD_LIVENESS_YES);
+    assert_eq!(joiner.pending_update_max_epochs, STEWARD_PENDING_MAX_EPOCHS);
     assert_eq!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
     assert_eq!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
 

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -57,6 +57,7 @@ fn test_emergency_in_approved_queue_returns_error() {
         &mut group.group,
         &group.mls,
         &group.steward,
+        false,
         &group.identity,
         b"test-app-id",
     );
@@ -168,6 +169,7 @@ fn test_emergency_mixed_with_regular_returns_error() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     );
@@ -215,6 +217,7 @@ fn test_duplicate_batch_returns_noop() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -310,6 +313,7 @@ fn test_candidate_ignored_without_freeze_round() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -369,6 +373,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -401,6 +406,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
         &joiner.steward,
+        false,
         false,
         b"test-app-id",
     )
@@ -482,6 +488,7 @@ fn test_backup_commit_scores_absent_steward() {
         &mut bob.group,
         bob.mls.as_ref().unwrap(),
         &bob.steward,
+        false,
         bob.identity.identity_bytes(),
         b"test-app-id",
     )
@@ -498,6 +505,7 @@ fn test_backup_commit_scores_absent_steward() {
         &mut bob.group,
         bob.mls.as_ref().unwrap(),
         &bob.steward,
+        false,
         false,
         b"test-app-id",
     )
@@ -600,6 +608,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
         &mut steward_handle.group,
         &steward_handle.mls,
         &steward_handle.steward,
+        false,
         &steward_handle.identity,
         b"test-app-id",
     )
@@ -646,6 +655,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
         joiner.mls.as_ref().unwrap(),
         &joiner.steward,
         false,
+        false,
         b"test-app-id",
     )
     .unwrap();
@@ -689,6 +699,7 @@ fn test_no_valid_candidate_triggers_no_candidate() {
         &mut group.group,
         &group.mls,
         &group.steward,
+        false,
         false,
         b"test-app-id",
     )


### PR DESCRIPTION
Four-commit branch that pulls per-group state out of `core::Group` and the UI cache out of `GroupEntry`, leaving `Group` smaller (proposal queues, freeze-round, dedup caches only) and `GroupEntry` as the canonical app-level composition layer.

Commit 1 — `epoch-history`: drops `GroupEntry::epoch_history` (a UI cache, not protocol state). Core fires a new `GroupEventHandler::on_commit_applied(group_name, batch)` callback after each merged commit; the gateway's handler accumulates per-group history (bounded at 10) and pushes `AppEvent::EpochHistory`. UI updates become event-driven instead of polled. Default trait method is a no-op for integrators without a UI history view.

Commit 2 — `config`: introduces `config: GroupConfig` field on `GroupEntry`. Drops `liveness_criteria_yes` + `pending_update_max_epochs` from `Group`; drops `proposal_expiration` / `consensus_timeout` / `voting_delay` / `election_voting_delay` from `PhaseTimer`. Coordinators read `entry.config.X`. Joiner-sync writes to `entry.config` directly; `PhaseTimer` keeps only phase-anchor durations.

Commit 3 — `recovery-mode`: moves the Layer-3 anti-deadlock flag from `Group` to `GroupEntry` as a top-level field. `core::ConsensusApplyResult` gains an `enter_recovery_mode: bool` flag; `core::finalize_freeze_round` takes an `in_recovery: bool` parameter.

Commit 4 — `docs`: tightens doc comments to describe current state only.
