### PR TITLE
refactor(identity): cache self-identity on User, drop from Conversation

### DIFF
--- a/src/app/orchestrator/consensus.rs
+++ b/src/app/orchestrator/consensus.rs
@@ -198,7 +198,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let (proposal_id, unbundled) = submit_proposal::<P>(
             conversation_name,
             &request,
-            self.identity().identity_bytes(),
+            self.self_identity(),
             &self.consensus_service,
             ProposalParams {
                 expected_voters,
@@ -402,7 +402,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
 
             // Only the epoch steward proposes immediately. The buffer
             // survives freeze rounds so a later steward can retry.
-            let self_identity = self.identity().identity_bytes();
+            let self_identity = self.self_identity();
             let eligible = entry
                 .handle
                 .conversation

--- a/src/app/orchestrator/freeze.rs
+++ b/src/app/orchestrator/freeze.rs
@@ -90,10 +90,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let mut entry = entry_arc.write().await;
             let allow_subset = entry.handle.steward.config().allow_subset_candidates;
             let result = if entry.handle.mls().is_some() {
-                match entry
-                    .handle
-                    .finalize_freeze_round(allow_subset, &self.app_id)
-                {
+                match entry.handle.finalize_freeze_round(
+                    allow_subset,
+                    &self.app_id,
+                    self.self_identity(),
+                ) {
                     Ok(result) => result,
                     Err(e) => {
                         error!(conversation = conversation_name, error = %e, "freeze finalize failed");
@@ -197,7 +198,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                         let accuse_target = match entry.handle.mls() {
                             Some(mls) => {
                                 let violation_epoch = mls.current_epoch()?;
-                                let self_identity = self.identity().identity_bytes();
+                                let self_identity = self.self_identity();
                                 let members = entry.handle.conversation_members()?;
                                 let eligible =
                                     entry.handle.conversation.steward_eligibility(&members);
@@ -291,11 +292,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             // Stewards build their own candidate under the same lock.
             // Candidate-build failure must not block the freeze transition —
             // peers' candidates still get processed.
-            let self_identity = self.identity().identity_bytes().to_vec();
-            let outbound = if entry.handle.steward.is_steward(&self_identity) {
+            let self_identity = self.self_identity();
+            let outbound = if entry.handle.steward.is_steward(self_identity) {
                 match entry
                     .handle
-                    .create_commit_candidate(&self_identity, &self.app_id)
+                    .create_commit_candidate(self_identity, &self.app_id)
                 {
                     Ok(packets) => packets,
                     Err(e) => {

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -294,7 +294,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let epoch = entry.handle.expect_mls()?.current_epoch()?;
             entry.handle.conversation.ensure_freeze_round(epoch);
 
-            let self_identity = self.identity().identity_bytes().to_vec();
+            let self_identity = self.self_identity().to_vec();
             let outbound = if entry.handle.steward.is_steward(&self_identity) {
                 match entry
                     .handle
@@ -525,10 +525,10 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                     .lookup_entry(conversation_name)
                     .await
                     .ok_or(UserError::ConversationNotFound)?;
-                let self_id = self.identity().identity_bytes().to_vec();
+                let self_id = self.self_identity();
                 let already_in = {
                     let entry = entry_arc.read().await;
-                    entry.handle.steward.is_steward(&self_id) || entry.handle.mls().is_some()
+                    entry.handle.steward.is_steward(self_id) || entry.handle.mls().is_some()
                 };
                 if already_in {
                     return Ok(());

--- a/src/app/orchestrator/lifecycle.rs
+++ b/src/app/orchestrator/lifecycle.rs
@@ -48,15 +48,14 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             return Err(UserError::ConversationAlreadyExists);
         }
 
-        let self_identity_bytes = self.identity().identity_bytes().to_vec();
+        let self_identity_bytes = self.self_identity().to_vec();
         let (conversation, mls_opt, state_machine, phase_timer) = if is_creation {
             let mls = self.plugins.create_mls(conversation_name.to_string())?;
-            let conversation = Conversation::create(conversation_name, self_identity_bytes.clone());
+            let conversation = Conversation::create(conversation_name);
             let state_machine = ConversationStateMachine::new_as_member();
             (conversation, Some(mls), state_machine, PhaseTimer::new())
         } else {
-            let conversation =
-                Conversation::prepare_to_join(conversation_name, self_identity_bytes.clone());
+            let conversation = Conversation::prepare_to_join(conversation_name);
             let state_machine = ConversationStateMachine::new_as_pending_join();
             // Anchor the timer at "now" so `is_pending_join_expired` can
             // detect the 3× commit-inactivity timeout.
@@ -136,7 +135,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             return Ok(());
         }
 
-        let self_identity = self.identity().identity_bytes().to_vec();
+        let self_identity = self.self_identity().to_vec();
 
         // Idempotent: a second click after a successful submit finds the
         // approved entry and short-circuits.

--- a/src/app/orchestrator/mod.rs
+++ b/src/app/orchestrator/mod.rs
@@ -63,6 +63,10 @@ pub struct User<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventH
     /// service, and MLS credentials are captured by the plug-in bundle (built
     /// once from this identity at `User` init).
     identity: Arc<dyn Identity>,
+    /// `identity.identity_bytes()` materialised once at construction so every
+    /// orchestrator method that needs the local identity bytes reads them
+    /// without re-walking the `Identity` trait + allocating a fresh `Vec`.
+    self_identity: Arc<[u8]>,
     /// Per-user plug-in bundle: builds MLS services + key packages, plus
     /// per-conversation scoring and steward-list plug-ins on demand.
     plugins: Arc<GP>,
@@ -95,6 +99,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler> Clo
     fn clone(&self) -> Self {
         Self {
             identity: Arc::clone(&self.identity),
+            self_identity: Arc::clone(&self.self_identity),
             plugins: Arc::clone(&self.plugins),
             conversations: Arc::clone(&self.conversations),
             consensus_service: Arc::clone(&self.consensus_service),
@@ -119,8 +124,10 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         handler: Arc<H>,
         default_conversation_config: ConversationConfig,
     ) -> Self {
+        let self_identity: Arc<[u8]> = Arc::from(identity.identity_bytes());
         Self {
             identity,
+            self_identity,
             plugins,
             conversations: Arc::new(RwLock::new(HashMap::new())),
             consensus_service,
@@ -195,6 +202,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
     /// User level.
     pub(crate) fn identity(&self) -> &dyn Identity {
         self.identity.as_ref()
+    }
+
+    /// Borrow the local identity bytes. Cached at construction; cheap to call.
+    pub(crate) fn self_identity(&self) -> &[u8] {
+        &self.self_identity
     }
 
     /// Wallet address as checksummed hex.

--- a/src/app/orchestrator/query.rs
+++ b/src/app/orchestrator/query.rs
@@ -82,7 +82,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         &self,
         conversation_name: &str,
     ) -> Result<bool, UserError> {
-        let self_id = self.identity().identity_bytes().to_vec();
+        let self_id = self.self_identity().to_vec();
         self.with_entry(conversation_name, |e| e.handle.steward.is_steward(&self_id))
             .await
             .ok_or(UserError::ConversationNotFound)

--- a/src/app/orchestrator/steward.rs
+++ b/src/app/orchestrator/steward.rs
@@ -88,7 +88,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let mls = entry.handle.expect_mls()?;
             let epoch = mls.current_epoch()?;
             let mls_members = entry.handle.conversation_members()?;
-            let self_identity = self.identity().identity_bytes();
+            let self_identity = self.self_identity();
 
             // `has_election_in_flight` is a proposal-queue check, not a
             // steward-list one — gated here, before the plug-in call.
@@ -182,7 +182,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let entry = entry_arc.read().await;
             let mls = entry.handle.expect_mls()?;
             let mls_members = entry.handle.conversation_members()?;
-            let self_id = self.identity().identity_bytes();
+            let self_id = self.self_identity();
             // Deadlock proposer = election proposer with the stricter
             // predicate (MLS-present and not queued for removal).
             let mls_set: std::collections::HashSet<&[u8]> =
@@ -328,7 +328,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 Some(mls) => (mls.current_epoch()?, entry.handle.conversation_members()?),
                 None => (0, Vec::new()),
             };
-            let self_identity = self.identity().identity_bytes();
+            let self_identity = self.self_identity();
             let eligible = entry.handle.conversation.steward_eligibility(&members);
             let is_live = entry
                 .handle
@@ -487,7 +487,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             .lookup_entry(conversation_name)
             .await
             .ok_or(UserError::ConversationNotFound)?;
-        let self_id = self.identity().identity_bytes();
+        let self_id = self.self_identity();
 
         // Reactive entry: callers chain into this after a scoring apply
         // emitted a downward cross, so we expect at least one tracked

--- a/src/app/session_runner.rs
+++ b/src/app/session_runner.rs
@@ -199,7 +199,7 @@ mod tests {
             ..ConversationConfig::default()
         };
         let mut runner = SessionRunner::new(
-            Conversation::prepare_to_join("g", b"me".to_vec()),
+            Conversation::prepare_to_join("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_pending_join(),
             PhaseTimer::new(),
@@ -213,7 +213,7 @@ mod tests {
 
     fn make_runner_working() -> SessionRunner<UnusedMls, StubScoring, StubSteward> {
         SessionRunner::new(
-            Conversation::create("g", b"me".to_vec()),
+            Conversation::create("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_member(),
             PhaseTimer::new(),

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -287,10 +287,6 @@ mod tests {
         ids.iter().map(|&id| member(id)).collect()
     }
 
-    fn make_conversation(name: &str, identity: Vec<u8>) -> Conversation {
-        Conversation::create(name, identity)
-    }
-
     fn election_request(stewards: Vec<Vec<u8>>, epoch: u64) -> ConversationUpdateRequest {
         ConversationUpdateRequest {
             payload: Some(conversation_update_request::Payload::StewardElection(
@@ -308,7 +304,7 @@ mod tests {
     #[test]
     fn election_yes_owner_returns_outcome_and_clears_queue() {
         let config = StewardListConfig::new(2, 5).unwrap();
-        let mut conversation = make_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
         let mems = members(&[1, 2, 3, 4, 5]);
         let sn = mems.len().min(config.sn_max);
         let list = StewardList::generate(10, b"test-conversation", &mems, sn, config, 0).unwrap();
@@ -334,7 +330,7 @@ mod tests {
     /// NO on an election returns no outcome and leaves the approved queue empty.
     #[test]
     fn election_no_returns_empty() {
-        let mut conversation = make_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
         let request = election_request(vec![member(1), member(2)], 10);
 
         let proposal_id = 43;
@@ -356,7 +352,7 @@ mod tests {
     /// (non-owner path), and doesn't touch any proposal queues.
     #[test]
     fn election_yes_nonowner_returns_outcome_without_queue_side_effects() {
-        let mut conversation = make_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
         let request = election_request(vec![member(1), member(2), member(3)], 5);
 
         let proposal_id = 44;
@@ -386,7 +382,7 @@ mod tests {
     /// when an entry for the same target is already in `approved_proposals`.
     #[test]
     fn removal_deduped_when_target_already_pending() {
-        let mut conversation = make_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
         let target = member(7);
 
         // First removal — non-owner path inserts straight into approved.
@@ -417,7 +413,7 @@ mod tests {
     /// queue does not retain an outcome we deliberately discarded.
     #[test]
     fn removal_dedup_clears_owner_voting_entry() {
-        let mut conversation = make_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
         let target = member(7);
 
         // Pre-existing approved removal from an unrelated path.
@@ -459,7 +455,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_yes_marks_urgent_and_force_freezes() {
-        let mut conversation = make_conversation("urgent-yes", member(1));
+        let mut conversation = Conversation::create("urgent-yes");
         let target = member(7);
 
         let request = score_below_threshold_request(target.clone(), member(1));
@@ -483,7 +479,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_no_does_not_mark_urgent() {
-        let mut conversation = make_conversation("urgent-no", member(1));
+        let mut conversation = Conversation::create("urgent-no");
         let request = score_below_threshold_request(member(7), member(1));
         let payload = request.encode_to_vec();
 
@@ -503,7 +499,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_yes_signals_recovery_mode_and_force_freezes() {
-        let mut conversation = make_conversation("deadlock-yes", member(1));
+        let mut conversation = Conversation::create("deadlock-yes");
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();
@@ -527,7 +523,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_no_does_not_signal_recovery_mode() {
-        let mut conversation = make_conversation("deadlock-no", member(1));
+        let mut conversation = Conversation::create("deadlock-no");
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -94,15 +94,10 @@ pub(crate) struct FreezeRound {
 /// Per-conversation protocol state. Stewards batch commits; members vote.
 /// Construct with [`Conversation::create`] or [`Conversation::prepare_to_join`].
 ///
-/// Pure proposal-queue and freeze-round bookkeeping — MLS state lives
-/// on the per-conversation [`crate::mls_crypto::MlsService`] instance held on
-/// `ConversationHandle`, alongside the steward-list plug-in. `Conversation` itself has
-/// no `M` generic.
+/// Proposal-queue and freeze-round bookkeeping.
 pub struct Conversation {
     /// The name of the conversation.
     conversation_name: String,
-    /// This user's identity bytes; matches the MLS leaf credential.
-    self_identity: Vec<u8>,
     /// Proposals that passed consensus, waiting for steward to commit.
     approved_proposals: HashMap<ProposalId, ConversationUpdateRequest>,
     /// Insertion order of `approved_proposals` (FIFO). Library proposal
@@ -135,10 +130,9 @@ pub struct Conversation {
 }
 
 impl Conversation {
-    fn new_base(conversation_name: &str, self_identity: Vec<u8>) -> Self {
+    fn new_base(conversation_name: &str) -> Self {
         Self {
             conversation_name: conversation_name.to_string(),
-            self_identity,
             approved_proposals: HashMap::new(),
             approved_order: Vec::new(),
             voting_proposals: HashMap::new(),
@@ -152,12 +146,6 @@ impl Conversation {
         }
     }
 
-    /// Local identity bytes for this conversation's member. Set at construction;
-    /// matches the value MLS surfaces on this conversation's leaf credential.
-    pub fn self_identity(&self) -> &[u8] {
-        &self.self_identity
-    }
-
     pub(crate) fn is_consensus_outcome_applied(&self, proposal_id: ProposalId) -> bool {
         self.resolved_proposals.contains(proposal_id)
     }
@@ -169,15 +157,15 @@ impl Conversation {
     /// Build a joiner-side handle for an existing conversation. The MLS service
     /// is held on `ConversationHandle`; the lifecycle layer attaches it via
     /// `entry.attach_mls(...)` once the welcome arrives.
-    pub fn prepare_to_join(conversation_name: &str, self_identity: Vec<u8>) -> Self {
-        Self::new_base(conversation_name, self_identity)
+    pub fn prepare_to_join(conversation_name: &str) -> Self {
+        Self::new_base(conversation_name)
     }
 
     /// Build a creator-side handle. The steward list and MLS service
     /// are owned by `ConversationHandle`; this constructor only initializes the
     /// proposal-queue and freeze-round state.
-    pub fn create(conversation_name: &str, creator_identity: Vec<u8>) -> Self {
-        Self::new_base(conversation_name, creator_identity)
+    pub fn create(conversation_name: &str) -> Self {
+        Self::new_base(conversation_name)
     }
 
     pub fn name(&self) -> &str {
@@ -692,14 +680,6 @@ mod tests {
         ids.iter().map(|&id| member(id)).collect()
     }
 
-    /// Test convenience: build a creator-side `Conversation`. Steward
-    /// list is owned by the per-conversation plug-in (covered separately in
-    /// `core::steward_list::tests`); these tests focus on
-    /// proposal-queue + dedup + freeze-round logic on `Conversation`.
-    fn creator_conversation(name: &str, identity: Vec<u8>) -> Conversation {
-        Conversation::create(name, identity)
-    }
-
     fn insert_self_leave(conversation: &mut Conversation, identity: &[u8]) {
         let remove = ConversationUpdateRequest {
             payload: Some(conversation_update_request::Payload::RemoveMember(
@@ -713,7 +693,7 @@ mod tests {
 
     #[test]
     fn test_reject_all_approved_preserves_self_leave_entry() {
-        let mut conversation = creator_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
 
         let leaver = member(2);
         insert_self_leave(&mut conversation, &leaver);
@@ -741,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_prune_clears_self_leave_entry_when_member_gone() {
-        let mut conversation = creator_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
 
         let leaver = member(2);
         insert_self_leave(&mut conversation, &leaver);
@@ -794,7 +774,7 @@ mod tests {
 
     #[test]
     fn mark_consensus_outcome_persists_in_resolved_cache() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
         assert!(!conversation.is_consensus_outcome_applied(42));
         conversation.mark_consensus_outcome_applied(42);
         assert!(conversation.is_consensus_outcome_applied(42));
@@ -819,7 +799,7 @@ mod tests {
     /// source; Add proposals are dropped.
     #[test]
     fn test_reject_all_approved_preserves_all_remove_member() {
-        let mut conversation = creator_conversation("test-conversation", member(1));
+        let mut conversation = Conversation::create("test-conversation");
 
         let ban_id: ProposalId = 0x1111_2222;
         let ecp_id: ProposalId = 0x3333_4444;
@@ -848,7 +828,7 @@ mod tests {
     /// `approved_order` is FIFO regardless of proposal-id ordering.
     #[test]
     fn test_approved_order_preserves_fifo_across_mutations() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
 
         insert_remove_member(&mut conversation, &member(2), 500);
         insert_remove_member(&mut conversation, &member(3), 100);
@@ -868,7 +848,7 @@ mod tests {
 
     #[test]
     fn test_urgent_commit_target_set_take_clears() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
         assert!(conversation.urgent_commit_target().is_none());
 
         let target = member(7);
@@ -882,7 +862,7 @@ mod tests {
 
     #[test]
     fn test_drop_approved_removals_for_target() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
         let victim = member(7);
         let bystander = member(9);
 
@@ -916,7 +896,7 @@ mod tests {
     /// `first_seen_epoch < cutoff` are dropped.
     #[test]
     fn test_expire_pending_updates_drops_entries_older_than_max_age() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
         let stale = member(7);
         let fresh = member(9);
 
@@ -936,7 +916,7 @@ mod tests {
     /// boundary case a tightened sync hits when shrinking the window.
     #[test]
     fn test_expire_pending_updates_max_age_zero_keeps_only_current_epoch() {
-        let mut conversation = creator_conversation("g", member(1));
+        let mut conversation = Conversation::create("g");
         let prior = member(7);
         let current = member(9);
 

--- a/src/core/conversation/handle.rs
+++ b/src/core/conversation/handle.rs
@@ -297,6 +297,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
         &mut self,
         allow_subset_candidates: bool,
         app_id: &[u8],
+        self_identity: &[u8],
     ) -> Result<FreezeFinalizeResult, CoreError> {
         let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
         let in_recovery = self.operating_mode == OperatingMode::Recovery;
@@ -307,6 +308,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
             in_recovery,
             allow_subset_candidates,
             app_id,
+            self_identity,
         )
     }
 
@@ -328,7 +330,7 @@ mod tests {
         steward: StubSteward,
     ) -> ConversationHandle<UnusedMls, StubScoring, StubSteward> {
         ConversationHandle::new(
-            Conversation::create("g", b"me".to_vec()),
+            Conversation::create("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_member(),
             ConversationConfig::default(),

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -156,6 +156,7 @@ pub fn finalize_freeze_round<M: MlsService>(
     in_recovery: bool,
     allow_subset_candidates: bool,
     app_id: &[u8],
+    self_identity: &[u8],
 ) -> Result<FreezeFinalizeResult, CoreError> {
     let current_epoch = mls.current_epoch()?;
     conversation.lock_freeze_round_selection(current_epoch);
@@ -172,7 +173,7 @@ pub fn finalize_freeze_round<M: MlsService>(
         return Ok(FreezeFinalizeResult::default());
     }
 
-    let ctx = RoundContext::snapshot(conversation, mls, steward, current_epoch)?;
+    let ctx = RoundContext::snapshot(conversation, mls, steward, current_epoch, self_identity)?;
     let sorted = rank_applicable_candidates(candidates, &ctx, allow_subset_candidates);
 
     if sorted.is_empty() {
@@ -220,9 +221,8 @@ impl RoundContext {
         mls: &M,
         steward: &dyn StewardListPlugin,
         current_epoch: u64,
+        self_identity: &[u8],
     ) -> Result<Self, CoreError> {
-        let self_identity = conversation.self_identity().to_vec();
-
         let mut mls_actions: Vec<MlsProposalOutput> = Vec::new();
         let mut self_remove_pending = false;
         for req in conversation.approved_proposals().values() {
@@ -250,7 +250,7 @@ impl RoundContext {
             self_remove_pending,
             current_epoch,
             live_epoch_steward_id,
-            self_identity,
+            self_identity: self_identity.to_vec(),
         })
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -373,6 +373,12 @@ impl StewardHandle {
     pub fn self_id(&self) -> &[u8] {
         &self.identity
     }
+
+    /// Test convenience: identity bytes stored on the handle; matches the
+    /// value the orchestrator caches at the User level.
+    pub fn self_identity(&self) -> &[u8] {
+        &self.identity
+    }
 }
 
 impl std::ops::Deref for StewardHandle {
@@ -405,7 +411,7 @@ pub fn setup_steward_with_config(
     )
     .unwrap();
     let identity_bytes = identity.identity_bytes().to_vec();
-    let group = Conversation::create(conversation_name, identity_bytes.clone());
+    let group = Conversation::create(conversation_name);
     let mut steward =
         DeterministicStewardList::empty(conversation_name.as_bytes().to_vec(), config);
     let _events = steward
@@ -440,6 +446,12 @@ pub struct JoinerHandle {
 }
 
 impl JoinerHandle {
+    /// Test convenience: identity bytes stored on the handle; matches the
+    /// value the orchestrator caches at the User level.
+    pub fn self_identity(&self) -> Vec<u8> {
+        self.identity.identity_bytes().to_vec()
+    }
+
     /// Try to accept a serialized welcome, materialising the joiner's
     /// MLS service if it addresses our key package. Returns `Ok(None)`
     /// when the welcome isn't for us.
@@ -482,8 +494,7 @@ pub fn setup_joiner_with_config(
     config: StewardListConfig,
 ) -> JoinerHandle {
     let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
-    let group =
-        Conversation::prepare_to_join(conversation_name, identity.identity_bytes().to_vec());
+    let group = Conversation::prepare_to_join(conversation_name);
     let steward = DeterministicStewardList::empty(conversation_name.as_bytes().to_vec(), config);
     let key_package =
         OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(&storage, &credentials)
@@ -562,6 +573,7 @@ pub fn steward_add_joiner(
         steward_handle.operating_mode == OperatingMode::Recovery,
         false,
         b"test-app-id",
+        &self_id,
     )
     .unwrap();
     let welcome_packet = match finalize.outcome {

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -14,7 +14,7 @@ use de_mls::core::{
     StewardListPlugin, build_key_package_message, finalize_freeze_round,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, WELCOME_SUBTOPIC};
-use de_mls::identity::{Identity, parse_wallet_address};
+use de_mls::identity::parse_wallet_address;
 use de_mls::mls_crypto::{MemoryDeMlsStorage, MlsService, OpenMlsService};
 use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationMessage, ConversationUpdateRequest, app_message,
@@ -44,10 +44,9 @@ fn test_process_inbound_invalid_subtopic() {
 #[test]
 fn test_process_inbound_app_msg_before_mls_init() {
     // Joiner-side handle with no MLS service attached yet.
-    let (identity, _credentials, _storage) =
+    let (_identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Conversation =
-        Conversation::prepare_to_join("test-group", identity.identity_bytes().to_vec());
+    let mut group: Conversation = Conversation::prepare_to_join("test-group");
 
     let result =
         process_inbound_compat(&mut group, None, b"some payload", APP_MSG_SUBTOPIC).unwrap();
@@ -139,10 +138,9 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
 
     // Joiner-side handle with no MLS yet — the key-package surfaces all the
     // same; promotion to a voting proposal is the app's decision.
-    let (identity, _credentials, _storage) =
+    let (_identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Conversation =
-        Conversation::prepare_to_join(conversation_name, identity.identity_bytes().to_vec());
+    let mut group: Conversation = Conversation::prepare_to_join(conversation_name);
 
     let other = setup_joiner(
         conversation_name,
@@ -291,6 +289,7 @@ fn test_process_inbound_leave_group() {
         remove_result
     );
 
+    let joiner_id = joiner.self_identity();
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
@@ -298,6 +297,7 @@ fn test_process_inbound_leave_group() {
         false,
         false,
         b"test-app-id",
+        &joiner_id,
     )
     .unwrap();
     let matched = matches!(
@@ -369,6 +369,7 @@ fn test_rejoin_after_eviction() {
         APP_MSG_SUBTOPIC,
     )
     .unwrap();
+    let joiner_id = joiner.self_identity();
     let finalize_joiner = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
@@ -376,6 +377,7 @@ fn test_rejoin_after_eviction() {
         false,
         false,
         b"test-app-id",
+        &joiner_id,
     )
     .unwrap();
     assert!(
@@ -385,6 +387,7 @@ fn test_rejoin_after_eviction() {
         ),
         "Expected LeaveConversation on joiner finalize, got {finalize_joiner:?}"
     );
+    let steward_id = steward_handle.self_identity().to_vec();
     let finalize_steward = finalize_freeze_round(
         &mut steward_handle.group,
         &steward_handle.mls,
@@ -392,6 +395,7 @@ fn test_rejoin_after_eviction() {
         false,
         false,
         b"test-app-id",
+        &steward_id,
     )
     .unwrap();
     assert!(matches!(

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -454,6 +454,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     );
 
     // Finalize: MLS commit staging authenticates the sender
+    let joiner_id = joiner.self_identity();
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
@@ -461,6 +462,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         false,
         false,
         b"test-app-id",
+        &joiner_id,
     )
     .unwrap();
     let matched = matches!(
@@ -479,7 +481,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
         .current_list()
         .expect("steward should have a list");
     assert!(
-        steward_list.contains(steward_handle.group.self_identity()),
+        steward_list.contains(steward_handle.self_identity()),
         "Steward should be on the steward list"
     );
 }
@@ -502,7 +504,7 @@ fn test_backup_commit_scores_absent_steward() {
     let mut alice_group = setup_steward(conversation_name, alice_hex);
     let mut bob = setup_joiner(conversation_name, bob_hex);
     let alice_id = alice_group.self_identity().to_vec();
-    let bob_id = bob.group.self_identity().to_vec();
+    let bob_id = bob.self_identity();
 
     let (welcome, _) = steward_add_joiner(&mut alice_group, &bob.kp_packet);
     bob.accept_welcome_packet(&welcome);
@@ -553,6 +555,7 @@ fn test_backup_commit_scores_absent_steward() {
             .to_vec()
     };
 
+    let bob_id = bob.self_identity();
     let result = finalize_freeze_round(
         &mut bob.group,
         bob.mls.as_ref().unwrap(),
@@ -560,6 +563,7 @@ fn test_backup_commit_scores_absent_steward() {
         false,
         false,
         b"test-app-id",
+        &bob_id,
     )
     .unwrap();
 
@@ -709,6 +713,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
         result
     );
 
+    let joiner_id = joiner.self_identity();
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
@@ -716,6 +721,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
         false,
         false,
         b"test-app-id",
+        &joiner_id,
     )
     .unwrap();
     assert!(
@@ -757,6 +763,7 @@ fn test_no_valid_candidate_triggers_no_candidate() {
     let epoch = group.mls.current_epoch().unwrap();
     group.start_freeze_round(epoch);
 
+    let group_id = group.self_identity().to_vec();
     let finalize = finalize_freeze_round(
         &mut group.group,
         &group.mls,
@@ -764,6 +771,7 @@ fn test_no_valid_candidate_triggers_no_candidate() {
         false,
         false,
         b"test-app-id",
+        &group_id,
     )
     .unwrap();
     assert!(


### PR DESCRIPTION
The local identity bytes now have a single owner. User caches them in an Arc at construction so every orchestrator method that needs them reads through one accessor instead of re-walking the Identity trait and allocating a fresh Vec at each call site.

Conversation no longer carries the field — finalize_freeze_round and RoundContext::snapshot take self_identity as a parameter from the caller, matching the surrounding plug-in API style. Conversation::create and prepare_to_join lose their identity argument. Test helpers expose a self_identity() accessor on the steward and joiner handles for parity.