### PR TITLE
refactor: drop dead code, collapse forwarders, rename to steward-list

### DIFF
--- a/src/app/orchestrator/consensus.rs
+++ b/src/app/orchestrator/consensus.rs
@@ -409,7 +409,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 .steward_eligibility(&members_for_rotation);
             let is_es = entry
                 .handle
-                .steward
+                .steward_list
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == self_identity);
             let state = entry.handle.current_state();

--- a/src/app/orchestrator/consensus_events.rs
+++ b/src/app/orchestrator/consensus_events.rs
@@ -107,8 +107,14 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         }
 
         if consensus_apply.force_freezing {
-            self.force_freezing_for_urgent_commit(conversation_name)
-                .await;
+            // Bypass the inactivity timer so the urgent commit fires now.
+            let event = match self.lookup_entry(conversation_name).await {
+                Some(entry_arc) => entry_arc.write().await.force_freezing(),
+                None => None,
+            };
+            if let Some(event) = event {
+                self.handler.on_phase_change(conversation_name, event).await;
+            }
         }
 
         if let Some(target) = &consensus_apply.queued_remove_target {
@@ -137,23 +143,12 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         Ok(())
     }
 
-    /// Bypass the inactivity timer so the urgent commit fires now.
-    async fn force_freezing_for_urgent_commit(&self, conversation_name: &str) {
-        let event = match self.lookup_entry(conversation_name).await {
-            Some(entry_arc) => entry_arc.write().await.force_freezing(),
-            None => None,
-        };
-        if let Some(event) = event {
-            self.handler.on_phase_change(conversation_name, event).await;
-        }
-    }
-
     /// When the removal target is a current steward, fire a fresh election
     /// in parallel so the next epoch keeps a healthy ES + BS.
     async fn refresh_stewards_after_removal(&self, conversation_name: &str, target: &[u8]) {
         let target_was_steward = self
             .with_entry(conversation_name, |entry| {
-                entry.handle.steward.is_steward(target)
+                entry.handle.steward_list.is_steward(target)
             })
             .await
             .unwrap_or(false);
@@ -191,7 +186,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             // Election proposals carry the candidate pool implicitly:
             // `proposed_stewards` is the full set the proposer sorted, so
             // `candidate_pool == proposed_stewards` for validation.
-            entry.handle.steward.validate_proposed(
+            entry.handle.steward_list.validate_proposed(
                 &election.proposed_stewards,
                 election.election_epoch,
                 &election.proposed_stewards,
@@ -208,7 +203,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
 
         let resumed_from_reelection = {
             let mut entry = entry_arc.write().await;
-            let _events = entry.handle.steward.install_list(
+            let _events = entry.handle.steward_list.install_list(
                 election.election_epoch,
                 &election.proposed_stewards,
                 election.proposed_stewards.len(),
@@ -244,10 +239,10 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let (round, max) = match self.lookup_entry(conversation_name).await {
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
-                let _events = entry.handle.steward.bump_retry();
+                let _events = entry.handle.steward_list.bump_retry();
                 (
-                    entry.handle.steward.retry_round(),
-                    entry.handle.steward.max_retries(),
+                    entry.handle.steward_list.retry_round(),
+                    entry.handle.steward_list.max_retries(),
                 )
             }
             None => return,

--- a/src/app/orchestrator/freeze.rs
+++ b/src/app/orchestrator/freeze.rs
@@ -67,9 +67,13 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
 
             // Early selection: skip remaining freeze time if all expected
             // stewards have submitted candidates.
-            let all_candidates_in = entry.handle.steward.current_list().is_some_and(|list| {
-                entry.handle.conversation.freeze_candidate_count() >= list.len()
-            });
+            let all_candidates_in = entry
+                .handle
+                .steward_list
+                .current_list()
+                .is_some_and(|list| {
+                    entry.handle.conversation.freeze_candidate_count() >= list.len()
+                });
 
             if !all_candidates_in && !entry.is_freeze_timed_out() {
                 return Ok(FreezeTimeoutStatus::StillFreezing);
@@ -88,7 +92,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
 
         let (finalize_result, downward_cross) = {
             let mut entry = entry_arc.write().await;
-            let allow_subset = entry.handle.steward.config().allow_subset_candidates;
+            let allow_subset = entry.handle.steward_list.config().allow_subset_candidates;
             let result = if entry.handle.mls().is_some() {
                 match entry.handle.finalize_freeze_round(
                     allow_subset,
@@ -204,7 +208,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                                     entry.handle.conversation.steward_eligibility(&members);
                                 entry
                                     .handle
-                                    .steward
+                                    .steward_list
                                     .epoch_steward(violation_epoch, &eligible)
                                     .filter(|id| !id.is_empty() && *id != self_identity)
                                     .map(|id| id.to_vec())
@@ -278,7 +282,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         // Recovery uses the shorter retry inactivity window so we don't
         // burn another full epoch waiting for a steward to commit.
         let in_recovery =
-            entry.handle.is_in_recovery_mode() || entry.handle.steward.retry_round() > 0;
+            entry.handle.is_in_recovery_mode() || entry.handle.steward_list.retry_round() > 0;
         let inactivity = if in_recovery {
             entry.handle.config.recovery_inactivity_duration
         } else {
@@ -293,7 +297,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             // Candidate-build failure must not block the freeze transition —
             // peers' candidates still get processed.
             let self_identity = self.self_identity();
-            let outbound = if entry.handle.steward.is_steward(self_identity) {
+            let outbound = if entry.handle.steward_list.is_steward(self_identity) {
                 match entry
                     .handle
                     .create_commit_candidate(self_identity, &self.app_id)

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -212,7 +212,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let working_event = match self.lookup_entry(conversation_name).await {
             Some(entry_arc) => {
                 let mut entry = entry_arc.write().await;
-                entry.handle.steward.reset_retry();
+                entry.handle.steward_list.reset_retry();
                 let state = entry.handle.current_state();
                 if matches!(
                     state,
@@ -295,7 +295,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             entry.handle.conversation.ensure_freeze_round(epoch);
 
             let self_identity = self.self_identity().to_vec();
-            let outbound = if entry.handle.steward.is_steward(&self_identity) {
+            let outbound = if entry.handle.steward_list.is_steward(&self_identity) {
                 match entry
                     .handle
                     .create_commit_candidate(&self_identity, &self.app_id)
@@ -338,7 +338,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 None => return Ok(()),
             };
             let entry = entry_arc.read().await;
-            if entry.handle.steward.current_list().is_some() {
+            if entry.handle.steward_list.current_list().is_some() {
                 return Ok(());
             }
             let mls = entry.handle.expect_mls()?;
@@ -385,8 +385,8 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         };
         let mut entry = entry_arc.write().await;
         let sn = sync.steward_members.len();
-        entry.handle.steward.set_config(protocol_config);
-        let _events = entry.handle.steward.install_list(
+        entry.handle.steward_list.set_config(protocol_config);
+        let _events = entry.handle.steward_list.install_list(
             sync.election_epoch,
             &sync.steward_members,
             sn,
@@ -394,7 +394,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         )?;
         entry
             .handle
-            .steward
+            .steward_list
             .set_max_retries(sync.max_reelection_attempts);
         entry
             .handle
@@ -528,7 +528,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 let self_id = self.self_identity();
                 let already_in = {
                     let entry = entry_arc.read().await;
-                    entry.handle.steward.is_steward(self_id) || entry.handle.mls().is_some()
+                    entry.handle.steward_list.is_steward(self_id) || entry.handle.mls().is_some()
                 };
                 if already_in {
                     return Ok(());

--- a/src/app/orchestrator/lifecycle.rs
+++ b/src/app/orchestrator/lifecycle.rs
@@ -51,11 +51,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let self_identity_bytes = self.self_identity().to_vec();
         let (conversation, mls_opt, state_machine, phase_timer) = if is_creation {
             let mls = self.plugins.create_mls(conversation_name.to_string())?;
-            let conversation = Conversation::create(conversation_name);
+            let conversation = Conversation::new(conversation_name);
             let state_machine = ConversationStateMachine::new_as_member();
             (conversation, Some(mls), state_machine, PhaseTimer::new())
         } else {
-            let conversation = Conversation::prepare_to_join(conversation_name);
+            let conversation = Conversation::new(conversation_name);
             let state_machine = ConversationStateMachine::new_as_pending_join();
             // Anchor the timer at "now" so `is_pending_join_expired` can
             // detect the 3× commit-inactivity timeout.
@@ -64,16 +64,19 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             (conversation, None, state_machine, phase_timer)
         };
 
-        let mut steward = self.make_steward_plugin(conversation_name);
-        steward.set_max_retries(config.max_reelection_attempts);
+        let mut steward_list = self.plugins.make_steward_list(
+            conversation_name.as_bytes(),
+            self.default_steward_list_config.clone(),
+        );
+        steward_list.set_max_retries(config.max_reelection_attempts);
         // Creator path: bootstrap the list with self as sole steward at
         // epoch 0. Joiner path leaves the plug-in empty until `ConversationSync`.
         if is_creation {
             let _events =
-                steward.install_list(0, std::slice::from_ref(&self_identity_bytes), 1, 0)?;
+                steward_list.install_list(0, std::slice::from_ref(&self_identity_bytes), 1, 0)?;
         }
 
-        let mut scoring = self.make_scoring_service();
+        let mut scoring = self.plugins.make_scoring(&self.default_scoring_config);
         // Joiners get tracked at `JoinedConversation` time, once members are known.
         if is_creation {
             // Creator is self at `default_score`; under standard config
@@ -99,7 +102,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 phase_timer,
                 config,
                 scoring,
-                steward,
+                steward_list,
             ))),
         );
         drop(conversations);

--- a/src/app/orchestrator/mod.rs
+++ b/src/app/orchestrator/mod.rs
@@ -75,7 +75,7 @@ pub struct User<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventH
     /// on conversation A doesn't block reads on conversation B. Per-conversation
     /// peer scoring lives inside the runner, so scoring access is guarded
     /// by the same `RwLock` — no separate scoring lock.
-    conversations: ConversationRegistry<GP::Mls, GP::Scoring, GP::Steward>,
+    conversations: ConversationRegistry<GP::Mls, GP::Scoring, GP::StewardList>,
     consensus_service: Arc<ProviderConsensus<P>>,
     eth_signer: PrivateKeySigner,
     handler: Arc<H>,
@@ -87,7 +87,7 @@ pub struct User<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventH
     default_scoring_config: ScoringConfig,
     /// Seed config for the per-conversation steward-list plug-in. Same
     /// ownership story as `default_scoring_config`.
-    default_steward_config: StewardListConfig,
+    default_steward_list_config: StewardListConfig,
     /// Per-instance UUID embedded in every outbound packet. Inbound packets
     /// carrying our `app_id` are self-echoes and silently dropped.
     app_id: Vec<u8>,
@@ -107,7 +107,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler> Clo
             handler: Arc::clone(&self.handler),
             default_conversation_config: self.default_conversation_config.clone(),
             default_scoring_config: self.default_scoring_config.clone(),
-            default_steward_config: self.default_steward_config.clone(),
+            default_steward_list_config: self.default_steward_list_config.clone(),
             app_id: self.app_id.clone(),
         }
     }
@@ -135,7 +135,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             handler,
             default_conversation_config,
             default_scoring_config: ScoringConfig::default(),
-            default_steward_config: StewardListConfig::default(),
+            default_steward_list_config: StewardListConfig::default(),
             app_id: uuid::Uuid::new_v4().as_bytes().to_vec(),
         }
     }
@@ -150,25 +150,8 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
     /// Override the seed [`StewardListConfig`] used for newly-created
     /// per-conversation steward-list plug-ins. Same lifecycle as
     /// [`Self::set_default_scoring_config`].
-    pub fn set_default_steward_config(&mut self, config: StewardListConfig) {
-        self.default_steward_config = config;
-    }
-
-    /// Build a fresh per-conversation scoring plug-in from the user's default
-    /// scoring config. Used by runner construction in lifecycle / welcome
-    /// paths.
-    pub(crate) fn make_scoring_service(&self) -> GP::Scoring {
-        self.plugins.make_scoring(&self.default_scoring_config)
-    }
-
-    /// Build a fresh per-conversation steward-list plug-in. Returns an empty
-    /// plug-in; the lifecycle creator path bootstraps it via `install_list`,
-    /// the joiner path leaves it empty until `ConversationSync` arrives.
-    pub(crate) fn make_steward_plugin(&self, conversation_name: &str) -> GP::Steward {
-        self.plugins.make_steward(
-            conversation_name.as_bytes(),
-            self.default_steward_config.clone(),
-        )
+    pub fn set_default_steward_list_config(&mut self, config: StewardListConfig) {
+        self.default_steward_list_config = config;
     }
 
     /// Look up a conversation runner. Returns `None` when no runner is
@@ -178,7 +161,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
     pub(crate) async fn lookup_entry(
         &self,
         conversation_name: &str,
-    ) -> Option<Arc<RwLock<SessionRunner<GP::Mls, GP::Scoring, GP::Steward>>>> {
+    ) -> Option<Arc<RwLock<SessionRunner<GP::Mls, GP::Scoring, GP::StewardList>>>> {
         self.conversations
             .read()
             .await
@@ -191,7 +174,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
     pub(crate) async fn with_entry<R>(
         &self,
         conversation_name: &str,
-        f: impl FnOnce(&SessionRunner<GP::Mls, GP::Scoring, GP::Steward>) -> R,
+        f: impl FnOnce(&SessionRunner<GP::Mls, GP::Scoring, GP::StewardList>) -> R,
     ) -> Option<R> {
         let entry_arc = self.lookup_entry(conversation_name).await?;
         let entry = entry_arc.read().await;

--- a/src/app/orchestrator/plugins.rs
+++ b/src/app/orchestrator/plugins.rs
@@ -18,13 +18,14 @@ use crate::{
 };
 
 /// Per-conversation plug-in bundle. One trait carries the three plug-in
-/// types (`Mls`, `Scoring`, `Steward`) plus the construction methods for
-/// each. Identity is intentionally **not** part of this bundle — it lives
-/// parallel to the conversation registry as `Arc<dyn Identity>` on `User`.
+/// types (`Mls`, `Scoring`, `StewardList`) plus the construction methods
+/// for each. Identity is intentionally **not** part of this bundle — it
+/// lives parallel to the conversation registry as `Arc<dyn Identity>` on
+/// `User`.
 pub trait ConversationPlugins: Send + Sync + 'static {
     type Mls: MlsService;
     type Scoring: PeerScoringPlugin;
-    type Steward: StewardListPlugin;
+    type StewardList: StewardListPlugin;
 
     /// Build an MLS service for a brand-new conversation as its sole creator.
     fn create_mls(&self, conversation_id: String) -> Result<Self::Mls, MlsError>;
@@ -44,7 +45,11 @@ pub trait ConversationPlugins: Send + Sync + 'static {
     /// Build a fresh steward-list plug-in for a new conversation runner.
     /// Returns an empty plug-in; the lifecycle creator path bootstraps it
     /// via [`StewardListPlugin::install_list`].
-    fn make_steward(&self, conversation_id: &[u8], config: StewardListConfig) -> Self::Steward;
+    fn make_steward_list(
+        &self,
+        conversation_id: &[u8],
+        config: StewardListConfig,
+    ) -> Self::StewardList;
 }
 
 /// MLS service type for the default `DefaultProvider`-backed `User`. Uses
@@ -73,7 +78,7 @@ pub struct DefaultConversationPlugins {
 impl ConversationPlugins for DefaultConversationPlugins {
     type Mls = DefaultMlsService;
     type Scoring = DefaultPeerScoring;
-    type Steward = DefaultStewardList;
+    type StewardList = DefaultStewardList;
 
     fn create_mls(&self, conversation_id: String) -> Result<Self::Mls, MlsError> {
         OpenMlsService::new_as_creator(
@@ -106,7 +111,11 @@ impl ConversationPlugins for DefaultConversationPlugins {
         )
     }
 
-    fn make_steward(&self, conversation_id: &[u8], config: StewardListConfig) -> Self::Steward {
+    fn make_steward_list(
+        &self,
+        conversation_id: &[u8],
+        config: StewardListConfig,
+    ) -> Self::StewardList {
         DeterministicStewardList::empty(conversation_id.to_vec(), config)
     }
 }

--- a/src/app/orchestrator/query.rs
+++ b/src/app/orchestrator/query.rs
@@ -37,7 +37,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             Some(mls) => mls.current_epoch()?,
             None => 0,
         };
-        Ok((epoch, entry.handle.steward.retry_round()))
+        Ok((epoch, entry.handle.steward_list.retry_round()))
     }
 
     pub async fn list_conversations(&self) -> Vec<String> {
@@ -68,7 +68,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let received = e.handle.conversation.freeze_candidate_count();
             let expected = e
                 .handle
-                .steward
+                .steward_list
                 .current_list()
                 .map(|l| l.len())
                 .unwrap_or(0);
@@ -83,9 +83,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         conversation_name: &str,
     ) -> Result<bool, UserError> {
         let self_id = self.self_identity().to_vec();
-        self.with_entry(conversation_name, |e| e.handle.steward.is_steward(&self_id))
-            .await
-            .ok_or(UserError::ConversationNotFound)
+        self.with_entry(conversation_name, |e| {
+            e.handle.steward_list.is_steward(&self_id)
+        })
+        .await
+        .ok_or(UserError::ConversationNotFound)
     }
 
     pub async fn get_conversation_members(
@@ -160,11 +162,12 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let members = entry.handle.conversation_members()?;
 
         let eligible = entry.handle.conversation.steward_eligibility(&members);
-        let (live_epoch, live_backup) = entry.handle.steward.epoch_and_backup(epoch, &eligible);
+        let (live_epoch, live_backup) =
+            entry.handle.steward_list.epoch_and_backup(epoch, &eligible);
         let live_epoch = live_epoch.map(|s| s.to_vec());
         let live_backup = live_backup.map(|s| s.to_vec());
-        let exhausted = entry.handle.steward.is_exhausted(epoch);
-        let has_list = entry.handle.steward.current_list().is_some();
+        let exhausted = entry.handle.steward_list.is_exhausted(epoch);
+        let has_list = entry.handle.steward_list.current_list().is_some();
         let roles = members
             .iter()
             .cloned()
@@ -174,12 +177,12 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                         MemberRole::EpochSteward
                     } else if live_backup.as_deref().is_some_and(|bs| bs == id) {
                         MemberRole::BackupSteward
-                    } else if entry.handle.steward.is_steward(&id) {
+                    } else if entry.handle.steward_list.is_steward(&id) {
                         MemberRole::Steward
                     } else {
                         MemberRole::Member
                     }
-                } else if has_list && entry.handle.steward.is_steward(&id) {
+                } else if has_list && entry.handle.steward_list.is_steward(&id) {
                     MemberRole::Steward
                 } else {
                     MemberRole::Member

--- a/src/app/orchestrator/steward.rs
+++ b/src/app/orchestrator/steward.rs
@@ -62,7 +62,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let mls = entry.handle.expect_mls()?;
         let epoch = mls.current_epoch()?;
         let members = entry.handle.conversation_members()?;
-        let _events = entry.handle.steward.maybe_auto_fill(epoch, &members)?;
+        let _events = entry.handle.steward_list.maybe_auto_fill(epoch, &members)?;
         Ok(())
     }
 
@@ -115,7 +115,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 candidate_pool.iter().map(Vec::as_slice).collect();
             let eligible = |c: &[u8]| pool_set.contains(c);
 
-            match entry.handle.steward.propose_election(
+            match entry.handle.steward_list.propose_election(
                 epoch,
                 &candidate_pool,
                 self_identity,
@@ -190,7 +190,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let conversation_ref = &entry.handle.conversation;
             let authorized = entry
                 .handle
-                .steward
+                .steward_list
                 .election_proposer(&|c: &[u8]| {
                     mls_set.contains(c) && !conversation_ref.is_pending_removal(c)
                 })
@@ -256,13 +256,13 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let mut entry = entry_arc.write().await;
         let sn = entry
             .handle
-            .steward
+            .steward_list
             .config()
             .compute_list_size(members.len());
         // Test/admin regenerate — no election, no retry seed.
         let _events = entry
             .handle
-            .steward
+            .steward_list
             .install_list(current_epoch, &members, sn, 0)?;
         Ok(())
     }
@@ -332,7 +332,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let eligible = entry.handle.conversation.steward_eligibility(&members);
             let is_live = entry
                 .handle
-                .steward
+                .steward_list
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == self_identity);
             if !is_live {
@@ -419,7 +419,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 })
                 .collect();
 
-            let list = match entry.handle.steward.current_list() {
+            let list = match entry.handle.steward_list.current_list() {
                 Some(l) => l,
                 None => return Ok(()),
             };
@@ -446,7 +446,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
             let mls = entry.handle.expect_mls()?;
             let mls_members = entry.handle.conversation_members()?;
             let eligible = entry.handle.conversation.steward_eligibility(&mls_members);
-            let steward_members = entry.handle.steward.steward_members(&eligible);
+            let steward_members = entry.handle.steward_list.steward_members(&eligible);
 
             // `retry_round` is the seed that produced the *stored* list —
             // a frozen tag on `StewardList`, not the plug-in's dynamic
@@ -457,11 +457,11 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
                 election_epoch: list.election_epoch(),
                 sn_min: list.config().sn_min as u32,
                 sn_max: list.config().sn_max as u32,
-                allow_subset_candidates: entry.handle.steward.config().allow_subset_candidates,
+                allow_subset_candidates: entry.handle.steward_list.config().allow_subset_candidates,
                 peer_scores: scores,
                 timing: Some(timing),
                 retry_round: list.retry_round(),
-                max_reelection_attempts: entry.handle.steward.max_retries(),
+                max_reelection_attempts: entry.handle.steward_list.max_retries(),
                 liveness_criteria_yes: entry.handle.config.liveness_criteria_yes,
                 threshold_peer_score: entry.handle.scoring.threshold(),
                 pending_update_max_epochs: entry.handle.config.pending_update_max_epochs,
@@ -496,7 +496,7 @@ impl<P: DeMlsProvider, GP: ConversationPlugins, H: ConversationEventHandler + 's
         let (is_steward, epoch, to_remove): (bool, u64, Vec<(Vec<u8>, i64)>) = {
             let mut entry = entry_arc.write().await;
             let mls = entry.handle.expect_mls()?;
-            let is_steward = entry.handle.steward.is_steward(self_id);
+            let is_steward = entry.handle.steward_list.is_steward(self_id);
             let epoch = mls.current_epoch()?;
             if !is_steward {
                 return Ok(());

--- a/src/app/session_runner.rs
+++ b/src/app/session_runner.rs
@@ -48,7 +48,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> SessionRunner<
         phase_timer: PhaseTimer,
         config: ConversationConfig,
         scoring: Sc,
-        steward: St,
+        steward_list: St,
     ) -> Self {
         Self {
             handle: ConversationHandle::new(
@@ -57,7 +57,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> SessionRunner<
                 state_machine,
                 config,
                 scoring,
-                steward,
+                steward_list,
             ),
             phase_timer,
             auto_vote_timers: Arc::new(Mutex::new(HashMap::new())),
@@ -188,38 +188,38 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> SessionRunner<
 mod tests {
     use super::*;
     use crate::core::Conversation;
-    use crate::test_fixtures::{StubScoring, StubSteward, UnusedMls};
+    use crate::test_fixtures::{StubScoring, StubStewardList, UnusedMls};
     use std::time::Instant;
 
     fn make_runner_pending_join(
         commit_inactivity: Duration,
-    ) -> SessionRunner<UnusedMls, StubScoring, StubSteward> {
+    ) -> SessionRunner<UnusedMls, StubScoring, StubStewardList> {
         let config = ConversationConfig {
             commit_inactivity_duration: commit_inactivity,
             ..ConversationConfig::default()
         };
         let mut runner = SessionRunner::new(
-            Conversation::prepare_to_join("g"),
+            Conversation::new("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_pending_join(),
             PhaseTimer::new(),
             config,
             StubScoring,
-            StubSteward::member(),
+            StubStewardList::member(),
         );
         runner.phase_timer.start();
         runner
     }
 
-    fn make_runner_working() -> SessionRunner<UnusedMls, StubScoring, StubSteward> {
+    fn make_runner_working() -> SessionRunner<UnusedMls, StubScoring, StubStewardList> {
         SessionRunner::new(
-            Conversation::create("g"),
+            Conversation::new("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_member(),
             PhaseTimer::new(),
             ConversationConfig::default(),
             StubScoring,
-            StubSteward::member(),
+            StubStewardList::member(),
         )
     }
 

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn election_yes_owner_returns_outcome_and_clears_queue() {
         let config = StewardListConfig::new(2, 5).unwrap();
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
         let mems = members(&[1, 2, 3, 4, 5]);
         let sn = mems.len().min(config.sn_max);
         let list = StewardList::generate(10, b"test-conversation", &mems, sn, config, 0).unwrap();
@@ -330,7 +330,7 @@ mod tests {
     /// NO on an election returns no outcome and leaves the approved queue empty.
     #[test]
     fn election_no_returns_empty() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
         let request = election_request(vec![member(1), member(2)], 10);
 
         let proposal_id = 43;
@@ -352,7 +352,7 @@ mod tests {
     /// (non-owner path), and doesn't touch any proposal queues.
     #[test]
     fn election_yes_nonowner_returns_outcome_without_queue_side_effects() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
         let request = election_request(vec![member(1), member(2), member(3)], 5);
 
         let proposal_id = 44;
@@ -382,7 +382,7 @@ mod tests {
     /// when an entry for the same target is already in `approved_proposals`.
     #[test]
     fn removal_deduped_when_target_already_pending() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
         let target = member(7);
 
         // First removal — non-owner path inserts straight into approved.
@@ -413,7 +413,7 @@ mod tests {
     /// queue does not retain an outcome we deliberately discarded.
     #[test]
     fn removal_dedup_clears_owner_voting_entry() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
         let target = member(7);
 
         // Pre-existing approved removal from an unrelated path.
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_yes_marks_urgent_and_force_freezes() {
-        let mut conversation = Conversation::create("urgent-yes");
+        let mut conversation = Conversation::new("urgent-yes");
         let target = member(7);
 
         let request = score_below_threshold_request(target.clone(), member(1));
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn ecp_score_below_threshold_no_does_not_mark_urgent() {
-        let mut conversation = Conversation::create("urgent-no");
+        let mut conversation = Conversation::new("urgent-no");
         let request = score_below_threshold_request(member(7), member(1));
         let payload = request.encode_to_vec();
 
@@ -499,7 +499,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_yes_signals_recovery_mode_and_force_freezes() {
-        let mut conversation = Conversation::create("deadlock-yes");
+        let mut conversation = Conversation::new("deadlock-yes");
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     fn ecp_deadlock_no_does_not_signal_recovery_mode() {
-        let mut conversation = Conversation::create("deadlock-no");
+        let mut conversation = Conversation::new("deadlock-no");
 
         let request = deadlock_request(member(1));
         let payload = request.encode_to_vec();

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -92,7 +92,7 @@ pub(crate) struct FreezeRound {
 }
 
 /// Per-conversation protocol state. Stewards batch commits; members vote.
-/// Construct with [`Conversation::create`] or [`Conversation::prepare_to_join`].
+/// Construct with [`Conversation::new`].
 ///
 /// Proposal-queue and freeze-round bookkeeping.
 pub struct Conversation {
@@ -130,7 +130,7 @@ pub struct Conversation {
 }
 
 impl Conversation {
-    fn new_base(conversation_name: &str) -> Self {
+    pub fn new(conversation_name: &str) -> Self {
         Self {
             conversation_name: conversation_name.to_string(),
             approved_proposals: HashMap::new(),
@@ -152,20 +152,6 @@ impl Conversation {
 
     pub(crate) fn mark_consensus_outcome_applied(&mut self, proposal_id: ProposalId) {
         self.resolved_proposals.record(proposal_id);
-    }
-
-    /// Build a joiner-side handle for an existing conversation. The MLS service
-    /// is held on `ConversationHandle`; the lifecycle layer attaches it via
-    /// `entry.attach_mls(...)` once the welcome arrives.
-    pub fn prepare_to_join(conversation_name: &str) -> Self {
-        Self::new_base(conversation_name)
-    }
-
-    /// Build a creator-side handle. The steward list and MLS service
-    /// are owned by `ConversationHandle`; this constructor only initializes the
-    /// proposal-queue and freeze-round state.
-    pub fn create(conversation_name: &str) -> Self {
-        Self::new_base(conversation_name)
     }
 
     pub fn name(&self) -> &str {
@@ -693,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_reject_all_approved_preserves_self_leave_entry() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
 
         let leaver = member(2);
         insert_self_leave(&mut conversation, &leaver);
@@ -721,7 +707,7 @@ mod tests {
 
     #[test]
     fn test_prune_clears_self_leave_entry_when_member_gone() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
 
         let leaver = member(2);
         insert_self_leave(&mut conversation, &leaver);
@@ -774,7 +760,7 @@ mod tests {
 
     #[test]
     fn mark_consensus_outcome_persists_in_resolved_cache() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
         assert!(!conversation.is_consensus_outcome_applied(42));
         conversation.mark_consensus_outcome_applied(42);
         assert!(conversation.is_consensus_outcome_applied(42));
@@ -799,7 +785,7 @@ mod tests {
     /// source; Add proposals are dropped.
     #[test]
     fn test_reject_all_approved_preserves_all_remove_member() {
-        let mut conversation = Conversation::create("test-conversation");
+        let mut conversation = Conversation::new("test-conversation");
 
         let ban_id: ProposalId = 0x1111_2222;
         let ecp_id: ProposalId = 0x3333_4444;
@@ -828,7 +814,7 @@ mod tests {
     /// `approved_order` is FIFO regardless of proposal-id ordering.
     #[test]
     fn test_approved_order_preserves_fifo_across_mutations() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
 
         insert_remove_member(&mut conversation, &member(2), 500);
         insert_remove_member(&mut conversation, &member(3), 100);
@@ -848,7 +834,7 @@ mod tests {
 
     #[test]
     fn test_urgent_commit_target_set_take_clears() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
         assert!(conversation.urgent_commit_target().is_none());
 
         let target = member(7);
@@ -862,7 +848,7 @@ mod tests {
 
     #[test]
     fn test_drop_approved_removals_for_target() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
         let victim = member(7);
         let bystander = member(9);
 
@@ -896,7 +882,7 @@ mod tests {
     /// `first_seen_epoch < cutoff` are dropped.
     #[test]
     fn test_expire_pending_updates_drops_entries_older_than_max_age() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
         let stale = member(7);
         let fresh = member(9);
 
@@ -916,7 +902,7 @@ mod tests {
     /// boundary case a tightened sync hits when shrinking the window.
     #[test]
     fn test_expire_pending_updates_max_age_zero_keeps_only_current_epoch() {
-        let mut conversation = Conversation::create("g");
+        let mut conversation = Conversation::new("g");
         let prior = member(7);
         let current = member(9);
 

--- a/src/core/conversation/handle.rs
+++ b/src/core/conversation/handle.rs
@@ -43,11 +43,11 @@ pub struct ConversationHandle<M: MlsService, Sc: PeerScoringPlugin, St: StewardL
     /// Per-conversation peer-score plug-in. Read by protocol decisions under
     /// the orchestrator's per-handle lock; no separate `Mutex` needed.
     pub(crate) scoring: Sc,
-    /// Per-conversation steward list plug-in. Holds the active list, retry
+    /// Per-conversation steward-list plug-in. Holds the active list, retry
     /// counter, and election retry policy. Orchestrator composes
     /// eligibility from MLS members + `Conversation::is_pending_removal` and
     /// passes it on every position query.
-    pub(crate) steward: St,
+    pub(crate) steward_list: St,
     /// Authorization mode (RFC §Layer 3 Anti-Deadlock ECP). `Recovery` is
     /// set when an accepted Deadlock ECP relaxes the steward gate so any
     /// member may produce the next commit; cleared on accepted election.
@@ -65,7 +65,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
         state_machine: ConversationStateMachine,
         config: ConversationConfig,
         scoring: Sc,
-        steward: St,
+        steward_list: St,
     ) -> Self {
         Self {
             conversation,
@@ -73,7 +73,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
             state_machine,
             config,
             scoring,
-            steward,
+            steward_list,
             operating_mode: OperatingMode::Normal,
         }
     }
@@ -151,7 +151,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
         app_id: &[u8],
     ) -> Result<Option<OutboundPacket>, CoreError> {
         let mls = self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)?;
-        if !self.steward.is_steward(self_identity) && !self.is_in_recovery_mode() {
+        if !self.steward_list.is_steward(self_identity) && !self.is_in_recovery_mode() {
             return Err(CoreError::NotASteward);
         }
 
@@ -162,14 +162,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
         // MLS forbids committing one's own removal. If the approved batch contains
         // RemoveMember(self), skip local candidate creation — another steward will
         // commit the batch (including this node's removal) once they enter freeze.
-        let self_removal_pending = self.conversation.approved_proposals().values().any(|req| {
-            matches!(
-                req.payload.as_ref(),
-                Some(Payload::RemoveMember(r))
-                    if r.identity == self_identity
-            )
-        });
-        if self_removal_pending {
+        if self.conversation.is_pending_removal(self_identity) {
             info!(
                 conversation = self.conversation.name(),
                 "commit candidate skipped: approved batch contains self-remove"
@@ -304,7 +297,7 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
         finalize_freeze_round(
             &mut self.conversation,
             mls,
-            &self.steward,
+            &self.steward_list,
             in_recovery,
             allow_subset_candidates,
             app_id,
@@ -324,24 +317,24 @@ impl<M: MlsService, Sc: PeerScoringPlugin, St: StewardListPlugin> ConversationHa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::{StubScoring, StubSteward, UnusedMls};
+    use crate::test_fixtures::{StubScoring, StubStewardList, UnusedMls};
 
     fn make_handle(
-        steward: StubSteward,
-    ) -> ConversationHandle<UnusedMls, StubScoring, StubSteward> {
+        steward_list: StubStewardList,
+    ) -> ConversationHandle<UnusedMls, StubScoring, StubStewardList> {
         ConversationHandle::new(
-            Conversation::create("g"),
+            Conversation::new("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_member(),
             ConversationConfig::default(),
             StubScoring,
-            steward,
+            steward_list,
         )
     }
 
     #[test]
     fn create_commit_candidate_errors_for_non_steward_outside_recovery() {
-        let mut handle = make_handle(StubSteward::member());
+        let mut handle = make_handle(StubStewardList::member());
         let err = handle
             .create_commit_candidate(b"me", b"app")
             .expect_err("non-steward should be rejected");
@@ -350,7 +343,7 @@ mod tests {
 
     #[test]
     fn create_commit_candidate_errors_when_no_approved_proposals() {
-        let mut handle = make_handle(StubSteward::steward());
+        let mut handle = make_handle(StubStewardList::steward());
         let err = handle
             .create_commit_candidate(b"me", b"app")
             .expect_err("empty approved queue should be rejected");

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -223,20 +223,13 @@ impl RoundContext {
         current_epoch: u64,
         self_identity: &[u8],
     ) -> Result<Self, CoreError> {
-        let mut mls_actions: Vec<MlsProposalOutput> = Vec::new();
-        let mut self_remove_pending = false;
-        for req in conversation.approved_proposals().values() {
-            if let Some(action) = expected_action_for_request(req) {
-                mls_actions.push(action);
-            }
-            if matches!(
-                &req.payload,
-                Some(Payload::RemoveMember(rm)) if rm.identity == self_identity
-            ) {
-                self_remove_pending = true;
-            }
-        }
+        let mls_actions: Vec<MlsProposalOutput> = conversation
+            .approved_proposals()
+            .values()
+            .filter_map(expected_action_for_request)
+            .collect();
         let mls_count = mls_actions.len();
+        let self_remove_pending = conversation.is_pending_removal(self_identity);
 
         let members = mls.members()?;
         let eligible = conversation.steward_eligibility(&members);

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -223,7 +223,6 @@ pub trait PeerScoringPlugin: Send + Sync + 'static {
     /// Emits [`PeerScoringEvent::ThresholdCrossedDown`] iff the default
     /// score lands at-or-below threshold (unusual config); otherwise no
     /// event.
-    #[must_use]
     fn add_member(&mut self, member_id: &[u8]) -> Vec<PeerScoringEvent>;
 
     /// Stop tracking a member. Emits no events — removal is a membership
@@ -236,27 +235,24 @@ pub trait PeerScoringPlugin: Send + Sync + 'static {
     /// before applying ops). Returns events only when the op causes a
     /// threshold cross; repeated ops on a member already at-or-below
     /// threshold do not re-emit.
-    #[must_use]
     fn apply_op(&mut self, op: &ScoreOp) -> Vec<PeerScoringEvent>;
 
     /// Apply a batch of [`ScoreOp`]s. Returns the concatenated events
     /// for every op in input order. A member crossing threshold twice
     /// in one batch (down then up, say) yields two events in that order.
-    #[must_use]
-    fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent>;
+    /// Default impl chains [`Self::apply_op`]; override for batched-write
+    /// storage where the round-trip cost dominates.
+    fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent> {
+        ops.iter().flat_map(|op| self.apply_op(op)).collect()
+    }
 
-    /// Apply a [`ScoreSnapshot`] (ConversationSync receive). Each entry is an
-    /// absolute-score replacement that auto-tracks members not already
-    /// known to the plug-in (treating "untracked → tracked" as crossing
-    /// from above for cross-detection — see [`PeerScoringEvent`]). This
-    /// is the one mutator that diverges from [`Self::apply_op`]'s
-    /// no-track-on-unknown behaviour: snapshots are bootstrap payloads
-    /// and arrive before membership sync in some edge cases.
+    /// Apply a snapshot of absolute scores (ConversationSync bootstrap).
+    /// Unknown members are auto-tracked at the snapshot value — unlike
+    /// [`Self::apply_op`], which ignores them — because a snapshot may
+    /// arrive before the MLS membership view catches up.
     ///
-    /// Events fire only when the entry's prior state was on the
-    /// opposite side of threshold from the new score; re-applying an
-    /// unchanged snapshot emits nothing.
-    #[must_use]
+    /// Emits a [`PeerScoringEvent`] per entry that crosses threshold;
+    /// re-applying an unchanged snapshot emits nothing.
     fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent>;
 
     /// Sparse snapshot of non-default scores for ConversationSync send.
@@ -379,14 +375,6 @@ impl<S: PeerScoreStorage + Send + Sync + 'static, P: ScoringProvider + Send + Sy
         )
         .into_iter()
         .collect()
-    }
-
-    fn apply_ops(&mut self, ops: &[ScoreOp]) -> Vec<PeerScoringEvent> {
-        let mut events = Vec::new();
-        for op in ops {
-            events.extend(self.apply_op(op));
-        }
-        events
     }
 
     fn apply_snapshot(&mut self, snapshot: &ScoreSnapshot) -> Vec<PeerScoringEvent> {

--- a/src/core/proposal_framing.rs
+++ b/src/core/proposal_framing.rs
@@ -1,7 +1,6 @@
 //! Wire framing helpers: welcome-subtopic packets and consensus
 //! `CreateProposalRequest` construction. Conversation construction lives on
-//! [`Conversation::create`](crate::core::Conversation::create) and
-//! [`Conversation::prepare_to_join`](crate::core::Conversation::prepare_to_join);
+//! [`Conversation::new`](crate::core::Conversation::new);
 //! application-message framing lives on
 //! [`MlsService::build_message`](crate::mls_crypto::MlsService::build_message).
 

--- a/src/core/steward_list/deterministic.rs
+++ b/src/core/steward_list/deterministic.rs
@@ -96,15 +96,6 @@ impl StewardListPlugin for DeterministicStewardList {
             .and_then(|l| l.live_steward_from(epoch, 0, eligible))
     }
 
-    fn backup_steward(&self, epoch: u64, eligible: &dyn Fn(&[u8]) -> bool) -> Option<&[u8]> {
-        // Resolve as a pair so the backup walk excludes the live epoch
-        // steward — the standalone offset-1 lookup could collapse onto
-        // the same identity once ineligibility shifts the rotation.
-        self.list
-            .as_ref()
-            .and_then(|l| l.live_epoch_and_backup(epoch, eligible).1)
-    }
-
     fn epoch_and_backup(
         &self,
         epoch: u64,

--- a/src/core/steward_list/list.rs
+++ b/src/core/steward_list/list.rs
@@ -27,7 +27,7 @@ pub struct StewardListConfig {
 
 impl Default for StewardListConfig {
     /// Tiny-conversation defaults — `sn ∈ [1, 2]`, subset candidates disallowed.
-    /// Adjust at `User` init via [`crate::app::User::set_default_steward_config`].
+    /// Adjust at `User` init via [`crate::app::User::set_default_steward_list_config`].
     fn default() -> Self {
         Self::new(1, 2).expect("1..=2 is always a valid StewardListConfig range")
     }

--- a/src/core/steward_list/plugin.rs
+++ b/src/core/steward_list/plugin.rs
@@ -92,12 +92,6 @@ pub trait StewardListPlugin: Send + Sync + 'static {
     /// for the nominal position.
     fn epoch_steward(&self, epoch: u64, eligible: &dyn Fn(&[u8]) -> bool) -> Option<&[u8]>;
 
-    /// Backup steward for `epoch` — distinct from the live epoch
-    /// steward (resolving them together avoids the rotation collapsing
-    /// both roles onto the same identity when an ineligible nominal
-    /// shifts the walk).
-    fn backup_steward(&self, epoch: u64, eligible: &dyn Fn(&[u8]) -> bool) -> Option<&[u8]>;
-
     /// Live epoch steward + backup, guaranteed distinct when ≥2 are
     /// eligible. Backup is `None` when fewer than two stewards are
     /// eligible.
@@ -172,7 +166,6 @@ pub trait StewardListPlugin: Send + Sync + 'static {
 
     /// Increment the retry round. Emits [`StewardListEvent::RetryExhausted`]
     /// once the new round exceeds `max_retries`.
-    #[must_use]
     fn bump_retry(&mut self) -> Vec<StewardListEvent>;
 
     /// Reset the retry round to 0 (called on accepted election or

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -80,12 +80,12 @@ impl MlsService for UnusedMls {
 }
 
 /// Steward plug-in with controllable `is_steward`. Other methods panic.
-pub(crate) struct StubSteward {
+pub(crate) struct StubStewardList {
     is_steward: bool,
     config: StewardListConfig,
 }
 
-impl StubSteward {
+impl StubStewardList {
     pub(crate) fn member() -> Self {
         Self {
             is_steward: false,
@@ -100,7 +100,7 @@ impl StubSteward {
     }
 }
 
-impl StewardListPlugin for StubSteward {
+impl StewardListPlugin for StubStewardList {
     fn config(&self) -> &StewardListConfig {
         &self.config
     }
@@ -127,9 +127,6 @@ impl StewardListPlugin for StubSteward {
         unreachable!()
     }
     fn epoch_steward(&self, _: u64, _: &dyn Fn(&[u8]) -> bool) -> Option<&[u8]> {
-        unreachable!()
-    }
-    fn backup_steward(&self, _: u64, _: &dyn Fn(&[u8]) -> bool) -> Option<&[u8]> {
         unreachable!()
     }
     fn epoch_and_backup(
@@ -200,9 +197,6 @@ impl PeerScoringPlugin for StubScoring {
         unreachable!()
     }
     fn apply_op(&mut self, _: &ScoreOp) -> Vec<PeerScoringEvent> {
-        unreachable!()
-    }
-    fn apply_ops(&mut self, _: &[ScoreOp]) -> Vec<PeerScoringEvent> {
         unreachable!()
     }
     fn apply_snapshot(&mut self, _: &ScoreSnapshot) -> Vec<PeerScoringEvent> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -143,12 +143,12 @@ impl ConversationEventHandler for MockHandler {
 pub fn build_commit_candidate(
     group: &mut Conversation,
     mls: &TestMls,
-    steward: &DeterministicStewardList,
+    steward_list: &DeterministicStewardList,
     in_recovery: bool,
     self_identity: &[u8],
     app_id: &[u8],
 ) -> Result<Option<OutboundPacket>, CoreError> {
-    if !steward.is_steward(self_identity) && !in_recovery {
+    if !steward_list.is_steward(self_identity) && !in_recovery {
         return Err(CoreError::NotASteward);
     }
     if group.approved_proposals().is_empty() {
@@ -260,7 +260,7 @@ pub fn build_commit_candidate(
 
 // ─────────────────────────── MLS + group setup ───────────────────────────
 
-pub fn default_steward_config() -> StewardListConfig {
+pub fn default_steward_list_config() -> StewardListConfig {
     StewardListConfig::new(1, 5).unwrap()
 }
 
@@ -361,7 +361,7 @@ pub fn process_inbound_compat(
 pub struct StewardHandle {
     pub group: Conversation,
     pub mls: TestMls,
-    pub steward: DeterministicStewardList,
+    pub steward_list: DeterministicStewardList,
     pub identity: Vec<u8>,
     pub liveness_criteria_yes: bool,
     pub pending_update_max_epochs: u32,
@@ -395,7 +395,7 @@ impl std::ops::DerefMut for StewardHandle {
 }
 
 pub fn setup_steward(conversation_name: &str, wallet_hex: &str) -> StewardHandle {
-    setup_steward_with_config(conversation_name, wallet_hex, default_steward_config())
+    setup_steward_with_config(conversation_name, wallet_hex, default_steward_list_config())
 }
 
 pub fn setup_steward_with_config(
@@ -411,16 +411,16 @@ pub fn setup_steward_with_config(
     )
     .unwrap();
     let identity_bytes = identity.identity_bytes().to_vec();
-    let group = Conversation::create(conversation_name);
-    let mut steward =
+    let group = Conversation::new(conversation_name);
+    let mut steward_list =
         DeterministicStewardList::empty(conversation_name.as_bytes().to_vec(), config);
-    let _events = steward
+    let _events = steward_list
         .install_list(0, std::slice::from_ref(&identity_bytes), 1, 0)
         .expect("bootstrap list install");
     StewardHandle {
         group,
         mls,
-        steward,
+        steward_list,
         identity: identity_bytes,
         liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
         pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
@@ -438,7 +438,7 @@ pub struct JoinerHandle {
     pub storage: Arc<MemoryDeMlsStorage>,
     pub group: Conversation,
     pub mls: Option<TestMls>,
-    pub steward: DeterministicStewardList,
+    pub steward_list: DeterministicStewardList,
     pub kp_packet: OutboundPacket,
     pub liveness_criteria_yes: bool,
     pub pending_update_max_epochs: u32,
@@ -485,7 +485,7 @@ impl JoinerHandle {
 }
 
 pub fn setup_joiner(conversation_name: &str, wallet_hex: &str) -> JoinerHandle {
-    setup_joiner_with_config(conversation_name, wallet_hex, default_steward_config())
+    setup_joiner_with_config(conversation_name, wallet_hex, default_steward_list_config())
 }
 
 pub fn setup_joiner_with_config(
@@ -494,8 +494,9 @@ pub fn setup_joiner_with_config(
     config: StewardListConfig,
 ) -> JoinerHandle {
     let (identity, credentials, storage) = setup_identity_storage(wallet_hex);
-    let group = Conversation::prepare_to_join(conversation_name);
-    let steward = DeterministicStewardList::empty(conversation_name.as_bytes().to_vec(), config);
+    let group = Conversation::new(conversation_name);
+    let steward_list =
+        DeterministicStewardList::empty(conversation_name.as_bytes().to_vec(), config);
     let key_package =
         OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(&storage, &credentials)
             .unwrap();
@@ -506,7 +507,7 @@ pub fn setup_joiner_with_config(
         storage,
         group,
         mls: None,
-        steward,
+        steward_list,
         kp_packet,
         liveness_criteria_yes: de_mls::core::DEFAULT_LIVENESS_CRITERIA_YES,
         pending_update_max_epochs: de_mls::core::DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
@@ -559,7 +560,7 @@ pub fn steward_add_joiner(
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         steward_handle.operating_mode == OperatingMode::Recovery,
         &self_id,
         b"test-app-id",
@@ -569,7 +570,7 @@ pub fn steward_add_joiner(
     let finalize = finalize_freeze_round(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         steward_handle.operating_mode == OperatingMode::Recovery,
         false,
         b"test-app-id",

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -22,9 +22,9 @@ use de_mls::protos::de_mls::messages::v1::{
 
 mod common;
 use common::{
-    build_commit_candidate, default_steward_config, process_inbound_compat, setup_identity_storage,
-    setup_joiner, setup_joiner_with_config, setup_steward, setup_steward_with_config,
-    steward_add_joiner,
+    build_commit_candidate, default_steward_list_config, process_inbound_compat,
+    setup_identity_storage, setup_joiner, setup_joiner_with_config, setup_steward,
+    setup_steward_with_config, steward_add_joiner,
 };
 
 // ─────────────────────────── process_inbound tests ───────────────────────────
@@ -46,7 +46,7 @@ fn test_process_inbound_app_msg_before_mls_init() {
     // Joiner-side handle with no MLS service attached yet.
     let (_identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Conversation = Conversation::prepare_to_join("test-group");
+    let mut group: Conversation = Conversation::new("test-group");
 
     let result =
         process_inbound_compat(&mut group, None, b"some payload", APP_MSG_SUBTOPIC).unwrap();
@@ -140,7 +140,7 @@ fn test_process_inbound_welcome_non_steward_buffers_key_package() {
     // same; promotion to a voting proposal is the app's decision.
     let (_identity, _credentials, _storage) =
         setup_identity_storage("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-    let mut group: Conversation = Conversation::prepare_to_join(conversation_name);
+    let mut group: Conversation = Conversation::new(conversation_name);
 
     let other = setup_joiner(
         conversation_name,
@@ -259,7 +259,7 @@ fn test_process_inbound_leave_group() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -293,7 +293,7 @@ fn test_process_inbound_leave_group() {
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
-        &joiner.steward,
+        &joiner.steward_list,
         false,
         false,
         b"test-app-id",
@@ -348,7 +348,7 @@ fn test_rejoin_after_eviction() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -373,7 +373,7 @@ fn test_rejoin_after_eviction() {
     let finalize_joiner = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
-        &joiner.steward,
+        &joiner.steward_list,
         false,
         false,
         b"test-app-id",
@@ -391,7 +391,7 @@ fn test_rejoin_after_eviction() {
     let finalize_steward = finalize_freeze_round(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         false,
         b"test-app-id",
@@ -417,7 +417,7 @@ fn test_rejoin_after_eviction() {
     // storage); the steward re-adds them. With MLS now on the entry/handle
     // rather than `Conversation`, no separate joiner-side `Conversation` allocation is
     // needed for the rejoin — the test only needs the resulting MLS service.
-    let _ = default_steward_config();
+    let _ = default_steward_list_config();
     let key_package = OpenMlsService::<Arc<MemoryDeMlsStorage>>::generate_key_package(
         &joiner.storage,
         &joiner.credentials,
@@ -486,7 +486,7 @@ fn test_process_inbound_raw_commit_payload_is_ignored() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -545,13 +545,13 @@ fn test_auto_fill_steward_list_triggers_below_sn_min() {
     let sn = members_2.len().min(config.sn_max);
     assert!(
         steward_handle
-            .steward
+            .steward_list
             .install_list(epoch, &members_2, sn, 0)
             .is_ok()
     );
 
     let list = steward_handle
-        .steward
+        .steward_list
         .current_list()
         .expect("steward list should exist after auto-fill");
     assert_eq!(list.len(), 2);
@@ -585,7 +585,7 @@ fn test_auto_fill_never_triggers_with_default_config() {
     let members = steward_handle.mls.members().unwrap();
     assert_eq!(members.len(), 1);
     assert!(
-        members.len() >= steward_handle.steward.config().sn_min,
+        members.len() >= steward_handle.steward_list.config().sn_min,
         "default config (sn_min=1) should never trigger auto-fill"
     );
 }
@@ -607,12 +607,12 @@ fn test_group_sync_roundtrip() {
     joiner.accept_welcome_packet(&welcome_packet);
 
     assert!(
-        joiner.steward.current_list().is_none(),
+        joiner.steward_list.current_list().is_none(),
         "Joiner should not have a steward list before sync"
     );
 
     let steward_list = steward_handle
-        .steward
+        .steward_list
         .current_list()
         .expect("steward should have a list");
     let sync = ConversationSync {
@@ -682,7 +682,7 @@ fn test_group_sync_roundtrip() {
         let sn = sync.steward_members.len();
         assert!(
             joiner
-                .steward
+                .steward_list
                 .install_list(
                     sync.election_epoch,
                     &sync.steward_members,
@@ -694,11 +694,11 @@ fn test_group_sync_roundtrip() {
     }
 
     let joiner_list = joiner
-        .steward
+        .steward_list
         .current_list()
         .expect("Joiner should have a steward list after sync");
     let steward_list = steward_handle
-        .steward
+        .steward_list
         .current_list()
         .expect("steward should have a list");
     assert_eq!(joiner_list.members(), steward_list.members());
@@ -726,28 +726,28 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut steward_handle =
         setup_steward_with_config(conversation_name, steward_hex, steward_protocol);
     let mut joiner =
-        setup_joiner_with_config(conversation_name, joiner_hex, default_steward_config());
+        setup_joiner_with_config(conversation_name, joiner_hex, default_steward_list_config());
 
     steward_handle.liveness_criteria_yes = STEWARD_LIVENESS_YES;
     steward_handle.pending_update_max_epochs = STEWARD_PENDING_MAX_EPOCHS;
 
     assert_ne!(joiner.liveness_criteria_yes, STEWARD_LIVENESS_YES);
     assert_ne!(joiner.pending_update_max_epochs, STEWARD_PENDING_MAX_EPOCHS);
-    assert_ne!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
-    assert_ne!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
+    assert_ne!(joiner.steward_list.config().sn_min, STEWARD_SN_MIN);
+    assert_ne!(joiner.steward_list.config().sn_max, STEWARD_SN_MAX);
 
     let (welcome_packet, _) = steward_add_joiner(&mut steward_handle, &joiner.kp_packet);
     joiner.accept_welcome_packet(&welcome_packet);
 
     let alice = b"alice".to_vec();
     let bob = b"bob".to_vec();
-    let steward_list = steward_handle.steward.current_list().unwrap();
+    let steward_list = steward_handle.steward_list.current_list().unwrap();
     let sync = ConversationSync {
         steward_members: steward_list.members().to_vec(),
         election_epoch: steward_list.election_epoch(),
         sn_min: steward_list.config().sn_min as u32,
         sn_max: steward_list.config().sn_max as u32,
-        allow_subset_candidates: steward_handle.steward.config().allow_subset_candidates,
+        allow_subset_candidates: steward_handle.steward_list.config().allow_subset_candidates,
         peer_scores: vec![
             PeerScore {
                 member_id: alice.clone(),
@@ -760,7 +760,7 @@ fn test_group_sync_propagates_divergent_per_group_config() {
         ],
         timing: None,
         retry_round: steward_list.retry_round(),
-        max_reelection_attempts: steward_handle.steward.max_retries(),
+        max_reelection_attempts: steward_handle.steward_list.max_retries(),
         liveness_criteria_yes: steward_handle.liveness_criteria_yes,
         threshold_peer_score: STEWARD_THRESHOLD,
         pending_update_max_epochs: steward_handle.pending_update_max_epochs,
@@ -795,14 +795,14 @@ fn test_group_sync_propagates_divergent_per_group_config() {
     let mut applied_protocol =
         StewardListConfig::new(received.sn_min as usize, received.sn_max as usize).unwrap();
     applied_protocol.allow_subset_candidates = received.allow_subset_candidates;
-    joiner.steward.set_config(applied_protocol);
+    joiner.steward_list.set_config(applied_protocol);
     joiner.liveness_criteria_yes = received.liveness_criteria_yes;
     joiner.pending_update_max_epochs = received.pending_update_max_epochs;
 
     assert_eq!(joiner.liveness_criteria_yes, STEWARD_LIVENESS_YES);
     assert_eq!(joiner.pending_update_max_epochs, STEWARD_PENDING_MAX_EPOCHS);
-    assert_eq!(joiner.steward.config().sn_min, STEWARD_SN_MIN);
-    assert_eq!(joiner.steward.config().sn_max, STEWARD_SN_MAX);
+    assert_eq!(joiner.steward_list.config().sn_min, STEWARD_SN_MIN);
+    assert_eq!(joiner.steward_list.config().sn_max, STEWARD_SN_MAX);
 
     let mut scoring = PeerScoringService::new(
         InMemoryPeerScoreStorage::new(),
@@ -853,10 +853,10 @@ fn test_group_sync_idempotent_for_existing_members() {
 
     // Manually give the joiner a steward list (simulating a previous sync)
     let members = joiner.mls.as_ref().unwrap().members().unwrap();
-    assert!(joiner.steward.install_list(0, &members, 1, 0).is_ok());
-    assert!(joiner.steward.current_list().is_some());
+    assert!(joiner.steward_list.install_list(0, &members, 1, 0).is_ok());
+    assert!(joiner.steward_list.current_list().is_some());
 
-    let steward_list = steward_handle.steward.current_list().unwrap();
+    let steward_list = steward_handle.steward_list.current_list().unwrap();
     let sync = ConversationSync {
         steward_members: steward_list.members().to_vec(),
         election_epoch: steward_list.election_epoch(),
@@ -893,7 +893,7 @@ fn test_group_sync_idempotent_for_existing_members() {
     // App layer would skip applying because the list is already set; verify
     // the existing list wasn't overwritten.
     assert_eq!(
-        joiner.steward.current_list().unwrap().len(),
+        joiner.steward_list.current_list().unwrap().len(),
         1,
         "Existing list should be preserved (1 member), not overwritten by sync"
     );
@@ -921,18 +921,18 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
     let epoch = steward_handle.mls.current_epoch().unwrap();
     let accepted_round: u32 = 2;
     steward_handle
-        .steward
+        .steward_list
         .install_list(epoch, &members, 4, accepted_round)
         .unwrap();
-    steward_handle.steward.reset_retry();
+    steward_handle.steward_list.reset_retry();
 
     let list = steward_handle
-        .steward
+        .steward_list
         .current_list()
         .expect("list set above");
     assert_eq!(list.retry_round(), accepted_round, "list keeps its seed");
     assert_eq!(
-        steward_handle.steward.retry_round(),
+        steward_handle.steward_list.retry_round(),
         0,
         "counter was reset on accept — distinct from the list tag"
     );
@@ -962,7 +962,7 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
         peer_scores: vec![],
         timing: None,
         retry_round: list.retry_round(),
-        max_reelection_attempts: steward_handle.steward.max_retries(),
+        max_reelection_attempts: steward_handle.steward_list.max_retries(),
         liveness_criteria_yes: true,
         threshold_peer_score: 0,
         pending_update_max_epochs: 3,
@@ -988,7 +988,7 @@ fn test_group_sync_carries_list_retry_round_not_group_counter() {
             conversation_name.as_bytes(),
             &sync.steward_members,
             &config,
-            steward_handle.steward.retry_round(),
+            steward_handle.steward_list.retry_round(),
         )
         .unwrap(),
         "the post-accept counter value (0) regenerates a different ordering"

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -59,7 +59,7 @@ fn test_emergency_in_approved_queue_returns_error() {
     let result = build_commit_candidate(
         &mut group.group,
         &group.mls,
-        &group.steward,
+        &group.steward_list,
         false,
         &group.identity,
         b"test-app-id",
@@ -191,7 +191,7 @@ fn test_emergency_mixed_with_regular_returns_error() {
     let result = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -247,7 +247,7 @@ fn test_duplicate_batch_returns_noop() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -356,7 +356,7 @@ fn test_candidate_ignored_without_freeze_round() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -424,7 +424,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -458,7 +458,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
-        &joiner.steward,
+        &joiner.steward_list,
         false,
         false,
         b"test-app-id",
@@ -477,7 +477,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     // After finalization, verify the steward list on the creator group
     // still contains the steward (the list is the source of truth).
     let steward_list = steward_handle
-        .steward
+        .steward_list
         .current_list()
         .expect("steward should have a list");
     assert!(
@@ -486,13 +486,13 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     );
 }
 
-/// Test: when a backup steward commits in place of the live epoch steward,
+/// Test: when a backup steward commits in place of the live epoch steward_list,
 /// finalize emits `CensorshipInactivity` against the absent steward.
 ///
 /// Build a two-steward list over Alice + Bob. If hash rotation places the
 /// OTHER steward at `epoch_steward(epoch)`, Bob's successful commit from
 /// his own node pins the absent steward with `CensorshipInactivity`. If
-/// rotation makes Bob himself the live epoch steward, the self-accusation
+/// rotation makes Bob himself the live epoch steward_list, the self-accusation
 /// skip keeps the score-op list free of `CensorshipInactivity`.
 #[test]
 fn test_backup_commit_scores_absent_steward() {
@@ -514,10 +514,12 @@ fn test_backup_commit_scores_absent_steward() {
     let epoch = alice_group.mls.current_epoch().unwrap();
     let members = vec![alice_id.clone(), bob_id.clone()];
     alice_group
-        .steward
+        .steward_list
         .install_list(epoch, &members, 2, 0)
         .unwrap();
-    bob.steward.install_list(epoch, &members, 2, 0).unwrap();
+    bob.steward_list
+        .install_list(epoch, &members, 2, 0)
+        .unwrap();
 
     // Produce an approved proposal (invite Charlie) on both sides.
     let charlie = setup_joiner(conversation_name, charlie_hex);
@@ -541,7 +543,7 @@ fn test_backup_commit_scores_absent_steward() {
     let _ = build_commit_candidate(
         &mut bob.group,
         bob.mls.as_ref().unwrap(),
-        &bob.steward,
+        &bob.steward_list,
         false,
         bob.identity.identity_bytes(),
         b"test-app-id",
@@ -549,7 +551,7 @@ fn test_backup_commit_scores_absent_steward() {
     .unwrap();
     let live_epoch_steward = {
         let eligible = bob.group.steward_eligibility(&members);
-        bob.steward
+        bob.steward_list
             .epoch_steward(epoch, &eligible)
             .expect("both stewards are eligible")
             .to_vec()
@@ -559,7 +561,7 @@ fn test_backup_commit_scores_absent_steward() {
     let result = finalize_freeze_round(
         &mut bob.group,
         bob.mls.as_ref().unwrap(),
-        &bob.steward,
+        &bob.steward_list,
         false,
         false,
         b"test-app-id",
@@ -605,7 +607,7 @@ fn test_backup_commit_scores_absent_steward() {
             !events
                 .iter()
                 .any(|(_, e)| *e == ScoreEvent::CensorshipInactivity),
-            "No CensorshipInactivity expected when self is the live epoch steward, got {events:?}",
+            "No CensorshipInactivity expected when self is the live epoch steward_list, got {events:?}",
         );
     }
 }
@@ -670,7 +672,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
     let packets = build_commit_candidate(
         &mut steward_handle.group,
         &steward_handle.mls,
-        &steward_handle.steward,
+        &steward_handle.steward_list,
         false,
         &steward_handle.identity,
         b"test-app-id",
@@ -682,7 +684,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
         .expect("Expected batch proposals packet");
 
     // Forge `steward_identity` to impersonate a different identity. The
-    // MLS commit message is still signed by the real steward, so staging
+    // MLS commit message is still signed by the real steward_list, so staging
     // succeeds and the cross-check fires.
     let mut app_msg = AppMessage::decode(batch_packet.payload.as_slice()).unwrap();
     let real_steward_id = steward_handle.self_identity().to_vec();
@@ -717,7 +719,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
     let finalize = finalize_freeze_round(
         &mut joiner.group,
         joiner.mls.as_ref().unwrap(),
-        &joiner.steward,
+        &joiner.steward_list,
         false,
         false,
         b"test-app-id",
@@ -767,7 +769,7 @@ fn test_no_valid_candidate_triggers_no_candidate() {
     let finalize = finalize_freeze_round(
         &mut group.group,
         &group.mls,
-        &group.steward,
+        &group.steward_list,
         false,
         false,
         b"test-app-id",

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -65,7 +65,7 @@ fn make(
 ) -> (TU, H) {
     let h = H::new();
     let mut u = User::with_private_key_and_config(key, cs, Arc::new(h.clone()), cfg).unwrap();
-    u.set_default_steward_config(steward_cfg);
+    u.set_default_steward_list_config(steward_cfg);
     (u, h)
 }
 


### PR DESCRIPTION
Two themes in one cleanup pass.

Mechanical cleanup: dropped the unused `backup_steward` trait method (no production callers), inlined three single-caller forwarders, collapsed `Conversation::create` / `prepare_to_join` into a single `Conversation::new`, deduplicated the self-removal-pending scan through the existing `is_pending_removal` helper, and gave `PeerScoringPlugin::apply_ops` a default impl that chains `apply_op`.

Naming follow-up: the per-conversation plug-in is a steward-list service — what it owns — even though it exposes queries like "who is the epoch steward". Renamed `ConversationPlugins::Steward` to `StewardList` and the factory `make_steward` to `make_steward_list`, the per-conversation field from `steward` to `steward_list` everywhere it is accessed, and the seed-config setter to match. The trait methods that ask about a steward (`is_steward`, `epoch_steward`, `epoch_and_backup`) are left alone — they describe queries, not what the plug-in is.

Also simplified the `apply_snapshot` doc comment, which had grown into a hard-to-skim block about the snapshot-vs-op divergence.
