### PR TITLE
docs: fix drift after plug-in extraction

### DIFF
--- a/src/app/phase_timer.rs
+++ b/src/app/phase_timer.rs
@@ -5,7 +5,7 @@
 //! [`crate::app::SessionRunner`] reads durations off the handle's config
 //! and passes them to this timer's elapsed-checks.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// What a freeze-timeout poll returned.
 #[derive(Debug, PartialEq)]
@@ -59,10 +59,9 @@ impl PhaseTimer {
         self.started_at
     }
 
-    /// `true` once `duration` has elapsed since the anchor was set;
-    /// `false` if no anchor is set. Caller is responsible for state
+    /// `false` when no anchor is set. Caller is responsible for state
     /// guarding and for choosing the right duration for the current phase.
-    pub fn elapsed_since_anchor(&self, duration: std::time::Duration) -> bool {
+    pub fn elapsed_since_anchor(&self, duration: Duration) -> bool {
         match self.started_at {
             Some(t) => Instant::now() >= t + duration,
             None => false,

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -31,8 +31,8 @@ pub struct ConsensusApplyResult {
     pub force_freezing: bool,
     pub queued_remove_target: Option<Vec<u8>>,
     /// `true` when an accepted Layer-3 Deadlock ECP signals "open recovery
-    /// mode." Caller flips the recovery-mode flag on; cleared on the next
-    /// accepted election.
+    /// mode." Caller switches the handle's [`crate::core::OperatingMode`]
+    /// to `Recovery`; cleared on the next accepted election.
     pub enter_recovery_mode: bool,
 }
 

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -1,6 +1,6 @@
 //! Per-conversation protocol-queue state: approved/voting proposal queues,
 //! freeze-round candidate buffer, pending-update buffer, urgent-commit
-//! target, recovery-mode flag, ECP dedup. MLS crypto state and the
+//! target, ECP dedup. MLS crypto state, the operating mode, and the
 //! steward-list plug-in live alongside on `ConversationHandle`.
 
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -378,10 +378,8 @@ impl Conversation {
         }
     }
 
-    /// Ensure a freeze round exists for the given MLS epoch.
-    ///
-    /// If absent or stale, initializes one with the current approved proposal IDs.
-    /// The `epoch` parameter should be the current MLS epoch from `OpenMlsService::current_epoch()`.
+    /// Initialise a freeze round for `epoch` if none exists or the buffered
+    /// one is for a stale epoch.
     pub(crate) fn ensure_freeze_round(&mut self, epoch: u64) {
         if matches!(self.freeze_round, Some(ref round) if round.epoch == epoch) {
             return;
@@ -389,17 +387,14 @@ impl Conversation {
         self.freeze_round = Some(self.build_freeze_round(epoch));
     }
 
-    /// Start a new freeze round for the given MLS epoch.
-    ///
-    /// Existing round state is replaced.
+    /// Replace the active freeze round with a fresh one for `epoch`.
     pub fn start_freeze_round(&mut self, epoch: u64) {
         self.freeze_round = Some(self.build_freeze_round(epoch));
     }
 
-    /// Add a validated candidate to the active freeze round.
-    ///
-    /// Returns `true` if buffered, `false` if ignored (locked round or duplicate).
-    /// The `epoch` parameter should be the current MLS epoch from `OpenMlsService::current_epoch()`.
+    /// Buffer a validated candidate for the active freeze round. Returns
+    /// `true` when accepted, `false` when ignored (locked round, stale
+    /// epoch, or duplicate commit hash).
     pub fn add_freeze_candidate(&mut self, candidate: BufferedCommitCandidate, epoch: u64) -> bool {
         self.ensure_freeze_round(epoch);
         let Some(round) = self.freeze_round.as_mut() else {
@@ -423,7 +418,6 @@ impl Conversation {
     }
 
     /// Mark the active freeze round as selection-locked.
-    /// The `epoch` parameter should be the current MLS epoch from `OpenMlsService::current_epoch()`.
     pub(crate) fn lock_freeze_round_selection(&mut self, epoch: u64) {
         if let Some(round) = self.freeze_round.as_mut() {
             if round.epoch == epoch {

--- a/src/core/conversation/handle.rs
+++ b/src/core/conversation/handle.rs
@@ -1,7 +1,6 @@
 //! Per-conversation aggregate owned by the orchestrator: protocol state, MLS
 //! service, plug-ins, state machine, durable config, and operating mode.
-//! Pure data + protocol-function wrappers — no timers, no spawned tasks,
-//! no I/O. App-side wiring (phase timer, auto-vote handles) lives on
+//! App-side wiring (phase timer, auto-vote handles) lives on
 //! [`crate::app::SessionRunner`], which owns one `ConversationHandle` by value.
 
 use prost::Message;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,7 +9,7 @@
 //! [`crate::core::DefaultProvider`] bundles in-memory backends for tests
 //! and simple deployments.
 //!
-//! Submodules: `conversation` (per-group state, handle, state machine,
+//! Submodules: `conversation` (per-conversation state, handle, state machine,
 //! config), `consensus` (pure consensus result application), `events`
 //! ([`crate::core::ConversationEventHandler`]), `freeze` (round selection
 //! + apply), `inbound` (app-subtopic packet routing), `peer_scoring`

--- a/src/core/peer_scoring.rs
+++ b/src/core/peer_scoring.rs
@@ -142,7 +142,7 @@ pub struct ScoringMemberDiff {
     pub to_remove: Vec<Vec<u8>>,
 }
 
-/// Pure diff between a scoring table snapshot and an MLS member roster.
+/// Diff between a scoring table snapshot and an MLS member roster.
 /// Caller applies the diff to its own [`PeerScoringPlugin`].
 pub fn scoring_member_diff(scored: &[Vec<u8>], mls_members: &[Vec<u8>]) -> ScoringMemberDiff {
     let scored_set: HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();
@@ -210,8 +210,7 @@ fn creator_penalty(ev: &ViolationEvidence) -> ScoreOp {
 /// Per-conversation peer-scoring plug-in. Mutating methods return any
 /// [`PeerScoringEvent`]s the call produced; the coordinator drains them
 /// at safe points and turns threshold crossings into protocol actions.
-/// The plug-in itself owns no I/O — storage backends and event
-/// publishing are caller concerns.
+/// Storage backends and event publishing are caller concerns.
 pub trait PeerScoringPlugin: Send + Sync + 'static {
     /// Start tracking a member at the plug-in's default score.
     ///

--- a/src/core/proposal_framing.rs
+++ b/src/core/proposal_framing.rs
@@ -23,7 +23,6 @@ use crate::{
 /// The key package is supplied by the caller (typically via
 /// `OpenMlsService::generate_key_package`) so a joiner can publish a key
 /// package before any MLS service for the target conversation exists.
-/// package before any MLS service for the target conversation exists.
 pub fn build_key_package_message(
     conversation_name: &str,
     key_package: KeyPackageBytes,
@@ -63,9 +62,8 @@ pub(crate) fn build_invitation_packet(
 // ─────────────────────────── Consensus Proposal Building ───────────────────────────
 
 /// Build the consensus-library `CreateProposalRequest` for a
-/// `ConversationUpdateRequest`. Pure — no async, no I/O. The caller (app
-/// layer) submits the resulting request via
-/// `ProviderConsensus::create_proposal_with_config`.
+/// `ConversationUpdateRequest`. The caller (app layer) submits the
+/// resulting request via `ProviderConsensus::create_proposal_with_config`.
 pub fn build_create_proposal_request(
     request: &ConversationUpdateRequest,
     creator_id: &[u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! // Build a user from an Ethereum private key. The convenience
 //! // constructor pins every `User` generic to the default provider
 //! // and plug-in bundle, so type inference works without annotation.
-//! let user = User::with_private_key(
+//! let mut user = User::with_private_key(
 //!     "0xac0974...",   // Private key
 //!     consensus,       // Consensus service
 //!     event_handler,   // Your ConversationEventHandler implementation

--- a/src/mls_crypto/service/mod.rs
+++ b/src/mls_crypto/service/mod.rs
@@ -20,13 +20,13 @@ mod backend;
 pub use api::{CIPHERSUITE, DEFAULT_COMMIT_BATCH_MAX, MlsService};
 use backend::MlsProvider;
 
-/// OpenMLS-backed MLS service, scoped to a single group.
+/// OpenMLS-backed MLS service, scoped to a single conversation.
 ///
 /// The service owns one `MlsGroup` plus an optional staged-commit slot
 /// for the inbound stage→merge/discard pipeline. MLS credentials and
 /// storage are supplied at construction. Credentials are
-/// `Arc<MlsCredentials>` so one user's credentials back every per-group
-/// service without copying the signing key.
+/// `Arc<MlsCredentials>` so one user's credentials back every
+/// per-conversation service without copying the signing key.
 pub struct OpenMlsService<S: DeMlsStorage> {
     pub(super) storage: S,
     pub(super) crypto: RustCrypto,


### PR DESCRIPTION
Doc-only pass after the plug-in extraction series. Some comments still described the pre-PR-#82 world.

Actively wrong: `ConsensusApplyResult::enter_recovery_mode` said "flips the recovery-mode flag" — the flag became `OperatingMode::{Normal, Recovery}` on `ConversationHandle`. The `Conversation` module doc still listed "recovery-mode flag" among its fields. "per-group" references in `core` and `mls_crypto` module docs are now "per-conversation". `build_key_package_message` had a duplicate sentence. The `lib.rs` quick-start example needed `let mut user` to call `&mut self` methods.

Style violations of the project's current-state-only and no-redundant-WHAT conventions: dropped "Pure data / no I/O" framing from `ConversationHandle`, the `PeerScoringPlugin` trait doc, and the `scoring_member_diff` helper; trimmed `phase_timer::elapsed_since_anchor` to keep just the no-anchor edge case; collapsed three near-identical "the epoch parameter should be `OpenMlsService::current_epoch`" notes on freeze-round methods.
