### PR TITLE
refactor: fold mls locks, propagate cleanup errors, typed buffer outcome

### DIFF
--- a/src/app/orchestrator/freeze.rs
+++ b/src/app/orchestrator/freeze.rs
@@ -37,7 +37,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             info!(conversation = conversation_name, "pending join timed out");
             self.conversations.write().await.remove(conversation_name);
             self.cleanup_consensus_scope(conversation_name).await?;
-            let _ = self.handler.on_leave_conversation(conversation_name).await;
+            self.handler
+                .on_leave_conversation(conversation_name)
+                .await?;
             return Ok(false);
         }
 

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -262,7 +262,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self.conversations.write().await.remove(conversation_name);
         if let Some(entry) = entry {
             if let Some(mls) = entry.write().await.handle.take_mls() {
-                let _ = mls.delete();
+                mls.delete()?;
             }
         }
         self.cleanup_consensus_scope(conversation_name).await?;

--- a/src/app/orchestrator/messaging.rs
+++ b/src/app/orchestrator/messaging.rs
@@ -15,10 +15,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Broadcast our key-package on the welcome subtopic so the steward
     /// can invite us.
     pub async fn send_kp_message(&self, conversation_name: &str) -> Result<(), UserError> {
-        let _ = self
-            .lookup_entry(conversation_name)
+        if !self
+            .conversations
+            .read()
             .await
-            .ok_or(UserError::ConversationNotFound)?;
+            .contains_key(conversation_name)
+        {
+            return Err(UserError::ConversationNotFound);
+        }
         let key_package = self.generate_key_package()?;
         let packet = build_key_package_message(conversation_name, key_package, &self.app_id);
         self.handler.on_outbound(conversation_name, packet).await?;

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -91,6 +91,24 @@ pub(crate) struct FreezeRound {
     pub candidates: Vec<BufferedCommitCandidate>,
 }
 
+/// Result of [`Conversation::add_freeze_candidate`]. Each non-`Buffered`
+/// variant is a legitimate runtime state, not an error: the round may be
+/// past the buffer phase, the caller may be on a stale epoch, or the
+/// commit hash may already be buffered (peer race / retransmit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreezeBufferOutcome {
+    /// Candidate stored in the buffer for this epoch.
+    Buffered,
+    /// Selection has been finalized for this round; the buffer no longer
+    /// accepts candidates.
+    SelectionLocked,
+    /// The caller's `epoch` doesn't match the buffered round's epoch
+    /// (e.g. the local node hasn't merged the latest commit yet).
+    StaleEpoch,
+    /// A candidate with the same commit hash is already buffered.
+    DuplicateHash,
+}
+
 /// Per-conversation protocol state. Stewards batch commits; members vote.
 /// Construct with [`Conversation::new`].
 ///
@@ -392,17 +410,22 @@ impl Conversation {
         self.freeze_round = Some(self.build_freeze_round(epoch));
     }
 
-    /// Buffer a validated candidate for the active freeze round. Returns
-    /// `true` when accepted, `false` when ignored (locked round, stale
-    /// epoch, or duplicate commit hash).
-    pub fn add_freeze_candidate(&mut self, candidate: BufferedCommitCandidate, epoch: u64) -> bool {
+    /// Buffer a validated candidate for the active freeze round.
+    pub fn add_freeze_candidate(
+        &mut self,
+        candidate: BufferedCommitCandidate,
+        epoch: u64,
+    ) -> FreezeBufferOutcome {
         self.ensure_freeze_round(epoch);
         let Some(round) = self.freeze_round.as_mut() else {
-            return false;
+            return FreezeBufferOutcome::StaleEpoch;
         };
 
-        if round.epoch != epoch || round.selection_locked {
-            return false;
+        if round.epoch != epoch {
+            return FreezeBufferOutcome::StaleEpoch;
+        }
+        if round.selection_locked {
+            return FreezeBufferOutcome::SelectionLocked;
         }
 
         if round
@@ -410,11 +433,11 @@ impl Conversation {
             .iter()
             .any(|c| c.commit_hash == candidate.commit_hash)
         {
-            return false;
+            return FreezeBufferOutcome::DuplicateHash;
         }
 
         round.candidates.push(candidate);
-        true
+        FreezeBufferOutcome::Buffered
     }
 
     /// Mark the active freeze round as selection-locked.

--- a/src/core/conversation/handle.rs
+++ b/src/core/conversation/handle.rs
@@ -9,9 +9,9 @@ use tracing::info;
 use crate::{
     core::{
         BufferedCommitCandidate, Conversation, ConversationConfig, ConversationPluginsFactory,
-        ConversationState, ConversationStateMachine, CoreError, FreezeFinalizeResult,
-        OperatingMode, ProcessResult, ProposalKind, StewardListPlugin, compute_commit_hash,
-        finalize_freeze_round, member_set, process_inbound,
+        ConversationState, ConversationStateMachine, CoreError, FreezeBufferOutcome,
+        FreezeFinalizeResult, OperatingMode, ProcessResult, ProposalKind, StewardListPlugin,
+        compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     mls_crypto::{
@@ -258,7 +258,7 @@ impl<CP: ConversationPluginsFactory> ConversationHandle<CP> {
         // commit merges, so joiners can't advance epoch ahead of the steward.
         let commit_hash = compute_commit_hash(&candidate.commit_message);
         let epoch = mls.current_epoch()?;
-        let _ = self.conversation.add_freeze_candidate(
+        let outcome = self.conversation.add_freeze_candidate(
             BufferedCommitCandidate {
                 candidate_msg: candidate.clone(),
                 commit_hash,
@@ -267,6 +267,19 @@ impl<CP: ConversationPluginsFactory> ConversationHandle<CP> {
             },
             epoch,
         );
+        // We still return the outbound packet so the steward broadcasts;
+        // finalize will ignore the unbuffered local candidate. The
+        // non-Buffered outcomes are legitimate runtime states (see
+        // `FreezeBufferOutcome` doc), not errors — log at debug so they
+        // surface for operators without alerting.
+        if !matches!(outcome, FreezeBufferOutcome::Buffered) {
+            tracing::debug!(
+                conversation = self.conversation.name(),
+                epoch,
+                ?outcome,
+                "local commit candidate not buffered",
+            );
+        }
 
         info!(
             conversation = self.conversation.name(),

--- a/src/core/conversation/mod.rs
+++ b/src/core/conversation/mod.rs
@@ -22,8 +22,8 @@ pub use config::{
     DEFAULT_RECOVERY_INACTIVITY_DURATION, DEFAULT_VOTING_DELAY,
 };
 pub use conversation::{
-    BufferedCommitCandidate, Conversation, PendingUpdate, ProposalId, member_set,
-    self_leave_proposal_id, target_identity_of,
+    BufferedCommitCandidate, Conversation, FreezeBufferOutcome, PendingUpdate, ProposalId,
+    member_set, self_leave_proposal_id, target_identity_of,
 };
 pub use handle::ConversationHandle;
 pub use state_machine::{ConversationState, ConversationStateMachine, OperatingMode};

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -141,7 +141,7 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
     // merged or discarded along an incoming-wins path — leaving it
     // behind would break the next MLS encrypt.
     if !own_commit_discarded {
-        let _ = mls.discard_own_commit();
+        mls.discard_own_commit()?;
     }
     conversation.clear_freeze_round();
     Ok(FreezeFinalizeResult {

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -10,8 +10,8 @@ use tracing::info;
 use super::apply::apply_in_priority_order;
 use crate::{
     core::{
-        Conversation, CoreError, ProcessResult, ProposalId, ScoreOp, StewardListPlugin,
-        conversation::BufferedCommitCandidate,
+        Conversation, CoreError, FreezeBufferOutcome, ProcessResult, ProposalId, ScoreOp,
+        StewardListPlugin, conversation::BufferedCommitCandidate,
     },
     mls_crypto::{MlsMessageKind, MlsProposalOutput, MlsService},
     protos::de_mls::messages::v1::{
@@ -119,7 +119,7 @@ pub fn process_commit_candidate<M: MlsService>(
     }
 
     let epoch = mls.current_epoch()?;
-    let buffered = conversation.add_freeze_candidate(
+    let outcome = conversation.add_freeze_candidate(
         BufferedCommitCandidate {
             candidate_msg,
             commit_hash,
@@ -128,17 +128,23 @@ pub fn process_commit_candidate<M: MlsService>(
         },
         epoch,
     );
-    if !buffered {
-        return Ok(ProcessResult::Noop);
+    match outcome {
+        FreezeBufferOutcome::Buffered => {
+            info!(
+                conversation = %conversation_name,
+                epoch,
+                total_candidates = conversation.freeze_candidate_count(),
+                "remote candidate buffered"
+            );
+            Ok(ProcessResult::CommitCandidateReceived)
+        }
+        // All other outcomes are legitimate runtime states, not errors.
+        // Drop the candidate quietly; the round proceeds with whatever
+        // is already buffered.
+        FreezeBufferOutcome::SelectionLocked
+        | FreezeBufferOutcome::StaleEpoch
+        | FreezeBufferOutcome::DuplicateHash => Ok(ProcessResult::Noop),
     }
-
-    info!(
-        conversation = %conversation_name,
-        epoch,
-        total_candidates = conversation.freeze_candidate_count(),
-        "remote candidate buffered"
-    );
-    Ok(ProcessResult::CommitCandidateReceived)
 }
 
 /// Pick and apply a buffered candidate for the active freeze round.
@@ -164,12 +170,12 @@ pub fn finalize_freeze_round<M: MlsService>(
     let Some(candidates) = conversation.take_round_candidates(current_epoch) else {
         // Drop any local pending commit so the next MLS encrypt
         // doesn't trip on "pending proposal exists".
-        let _ = mls.discard_own_commit();
+        mls.discard_own_commit()?;
         return Ok(FreezeFinalizeResult::default());
     };
 
     if candidates.is_empty() {
-        let _ = mls.discard_own_commit();
+        mls.discard_own_commit()?;
         return Ok(FreezeFinalizeResult::default());
     }
 
@@ -177,7 +183,7 @@ pub fn finalize_freeze_round<M: MlsService>(
     let sorted = rank_applicable_candidates(candidates, &ctx, allow_subset_candidates);
 
     if sorted.is_empty() {
-        let _ = mls.discard_own_commit();
+        mls.discard_own_commit()?;
         return Ok(FreezeFinalizeResult::default());
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,8 +47,8 @@ pub use conversation::{
     ConversationState, ConversationStateMachine, DEFAULT_COMMIT_INACTIVITY_DURATION,
     DEFAULT_CONSENSUS_TIMEOUT, DEFAULT_ELECTION_VOTING_DELAY, DEFAULT_LIVENESS_CRITERIA_YES,
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_PROPOSAL_EXPIRATION,
-    DEFAULT_RECOVERY_INACTIVITY_DURATION, DEFAULT_VOTING_DELAY, OperatingMode, PendingUpdate,
-    ProposalId, member_set, self_leave_proposal_id, target_identity_of,
+    DEFAULT_RECOVERY_INACTIVITY_DURATION, DEFAULT_VOTING_DELAY, FreezeBufferOutcome, OperatingMode,
+    PendingUpdate, ProposalId, member_set, self_leave_proposal_id, target_identity_of,
 };
 
 // ── Consensus result application (pure, synchronous) ──

--- a/src/mls_crypto/service/backend.rs
+++ b/src/mls_crypto/service/backend.rs
@@ -59,7 +59,7 @@ impl<S> OpenMlsService<S>
 where
     S: DeMlsStorage,
 {
-    fn make_provider(&self) -> MlsProvider<'_, S::MlsStorage> {
+    fn provider(&self) -> MlsProvider<'_, S::MlsStorage> {
         MlsProvider {
             crypto: &self.crypto,
             storage: self.storage.mls_storage(),
@@ -106,12 +106,12 @@ where
     // ══════════════════════════════════════════════════════════
 
     fn delete(&self) -> Result<(), MlsError> {
-        let provider = self.make_provider();
-        let mut group = self.mls_group.write()?;
-        group
+        let provider = self.provider();
+        self.state
+            .write()?
+            .group
             .delete(provider.storage())
-            .map_err(MlsError::storage)?;
-        Ok(())
+            .map_err(MlsError::storage)
     }
 
     // ══════════════════════════════════════════════════════════
@@ -119,8 +119,10 @@ where
     // ══════════════════════════════════════════════════════════
 
     fn members(&self) -> Result<Vec<Vec<u8>>, MlsError> {
-        let group = self.mls_group.read()?;
-        Ok(group
+        Ok(self
+            .state
+            .read()?
+            .group
             .members()
             .map(|m| m.credential.serialized_content().to_vec())
             .collect())
@@ -133,8 +135,7 @@ where
     }
 
     fn current_epoch(&self) -> Result<u64, MlsError> {
-        let group = self.mls_group.read()?;
-        Ok(group.epoch().as_u64())
+        Ok(self.state.read()?.group.epoch().as_u64())
     }
 
     // ══════════════════════════════════════════════════════════
@@ -145,10 +146,11 @@ where
         &self,
         updates: &[MlsCommitInput],
     ) -> Result<CommitCandidate, MlsError> {
-        let provider = self.make_provider();
+        let provider = self.provider();
         let signer = self.credentials.signer();
 
-        let mut group = self.mls_group.write()?;
+        let mut state = self.state.write()?;
+        let group = &mut state.group;
         let mut mls_proposals = Vec::new();
 
         for update in updates {
@@ -194,17 +196,22 @@ where
     }
 
     fn merge_own_commit(&self) -> Result<(), MlsError> {
-        let provider = self.make_provider();
-        let mut group = self.mls_group.write()?;
-        group.merge_pending_commit(&provider)?;
+        let provider = self.provider();
+        self.state.write()?.group.merge_pending_commit(&provider)?;
         Ok(())
     }
 
     fn discard_own_commit(&self) -> Result<(), MlsError> {
-        let provider = self.make_provider();
-        let mut group = self.mls_group.write()?;
-        let _ = group.clear_pending_commit(provider.storage());
-        let _ = group.clear_pending_proposals(provider.storage());
+        let provider = self.provider();
+        let mut state = self.state.write()?;
+        state
+            .group
+            .clear_pending_commit(provider.storage())
+            .map_err(MlsError::storage)?;
+        state
+            .group
+            .clear_pending_proposals(provider.storage())
+            .map_err(MlsError::storage)?;
         Ok(())
     }
 
@@ -217,13 +224,16 @@ where
         proposals: &[Vec<u8>],
         commit_bytes: &[u8],
     ) -> Result<StagedCandidateResult, MlsError> {
-        let provider = self.make_provider();
+        let provider = self.provider();
 
-        // Hold the group lock for the whole atomic stage. Anything we put
+        // Hold the state lock for the whole atomic stage. Anything we put
         // into MLS pending state stays there for the caller to roll back
-        // via `discard_staged_commit` on Aborted.
+        // via `discard_staged_commit` on Aborted; the pending-staged-commit
+        // slot is written before the lock drops so observers never see the
+        // group at the post-stage epoch with `pending_staged_commit = None`.
+        let mut state = self.state.write()?;
         let outcome = {
-            let mut group = self.mls_group.write()?;
+            let group = &mut state.group;
 
             // ── Stage every proposal, collecting senders ──
             let mut proposal_senders: Vec<Vec<u8>> = Vec::with_capacity(proposals.len());
@@ -315,7 +325,7 @@ where
 
         match outcome {
             Some((commit_sender, proposal_senders, self_removed, actions, staged)) => {
-                *self.pending_staged_commit.write()? = Some(staged);
+                state.pending_staged_commit = Some(staged);
                 Ok(StagedCandidateResult::Staged {
                     commit_sender,
                     proposal_senders,
@@ -328,25 +338,24 @@ where
     }
 
     fn merge_staged_commit(&self) -> Result<(), MlsError> {
-        let provider = self.make_provider();
-
-        let staged = self
+        let provider = self.provider();
+        let mut state = self.state.write()?;
+        let staged = state
             .pending_staged_commit
-            .write()?
             .take()
             .ok_or_else(|| MlsError::NoPendingStagedCommit(self.conversation_id.clone()))?;
-
-        let mut group = self.mls_group.write()?;
-        group.merge_staged_commit(&provider, staged)?;
+        state.group.merge_staged_commit(&provider, staged)?;
         Ok(())
     }
 
     fn discard_staged_commit(&self) -> Result<(), MlsError> {
-        *self.pending_staged_commit.write()? = None;
-
-        let provider = self.make_provider();
-        let mut group = self.mls_group.write()?;
-        let _ = group.clear_pending_proposals(provider.storage());
+        let provider = self.provider();
+        let mut state = self.state.write()?;
+        state.pending_staged_commit = None;
+        state
+            .group
+            .clear_pending_proposals(provider.storage())
+            .map_err(MlsError::storage)?;
         Ok(())
     }
 
@@ -355,11 +364,13 @@ where
     // ══════════════════════════════════════════════════════════
 
     fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, MlsError> {
-        let provider = self.make_provider();
+        let provider = self.provider();
         let signer = self.credentials.signer();
-
-        let mut group = self.mls_group.write()?;
-        let message = group.create_message(&provider, signer, plaintext)?;
+        let message = self
+            .state
+            .write()?
+            .group
+            .create_message(&provider, signer, plaintext)?;
         Ok(message.to_bytes()?)
     }
 
@@ -378,9 +389,10 @@ where
     }
 
     fn decrypt_application_only(&self, ciphertext: &[u8]) -> Result<DecryptResult, MlsError> {
-        let provider = self.make_provider();
+        let provider = self.provider();
 
-        let mut group = self.mls_group.write()?;
+        let mut state = self.state.write()?;
+        let group = &mut state.group;
 
         let (mls_message, _) = MlsMessageIn::tls_deserialize_bytes(ciphertext)?;
         let protocol_message: ProtocolMessage = mls_message.try_into_protocol_message()?;
@@ -417,9 +429,10 @@ where
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Result<DecryptResult, MlsError> {
-        let provider = self.make_provider();
+        let provider = self.provider();
 
-        let mut group = self.mls_group.write()?;
+        let mut state = self.state.write()?;
+        let group = &mut state.group;
 
         let (mls_message, _) = MlsMessageIn::tls_deserialize_bytes(ciphertext)?;
         let protocol_message: ProtocolMessage = mls_message.try_into_protocol_message()?;
@@ -457,7 +470,7 @@ where
             )),
             ProcessedMessageContent::ProposalMessage(proposal) => {
                 let action =
-                    OpenMlsService::<S>::extract_proposal_action(&group, proposal.proposal())?;
+                    OpenMlsService::<S>::extract_proposal_action(group, proposal.proposal())?;
 
                 group
                     .store_pending_proposal(provider.storage(), proposal.as_ref().clone())

--- a/src/mls_crypto/service/mod.rs
+++ b/src/mls_crypto/service/mod.rs
@@ -23,17 +23,26 @@ use backend::MlsProvider;
 /// OpenMLS-backed MLS service, scoped to a single conversation.
 ///
 /// The service owns one `MlsGroup` plus an optional staged-commit slot
-/// for the inbound stage→merge/discard pipeline. MLS credentials and
-/// storage are supplied at construction. Credentials are
-/// `Arc<MlsCredentials>` so one user's credentials back every
-/// per-conversation service without copying the signing key.
+/// for the inbound stage→merge/discard pipeline; both live behind a
+/// single [`RwLock<MlsGroupState>`] so a staged commit can never be
+/// observed against a divergent group state. MLS credentials and storage
+/// are supplied at construction. Credentials are `Arc<MlsCredentials>`
+/// so one user's credentials back every per-conversation service without
+/// copying the signing key.
 pub struct OpenMlsService<S: DeMlsStorage> {
     pub(super) storage: S,
     pub(super) crypto: RustCrypto,
     pub(super) credentials: Arc<MlsCredentials>,
     pub(super) conversation_id: String,
-    pub(super) mls_group: RwLock<MlsGroup>,
-    pub(super) pending_staged_commit: RwLock<Option<StagedCommit>>,
+    pub(super) state: RwLock<MlsGroupState>,
+}
+
+/// The two-field state guarded by `OpenMlsService::state`. The fields
+/// move together through stage → merge / discard, so giving them one
+/// `RwLock` removes the ordering hazard of locking them independently.
+pub(super) struct MlsGroupState {
+    pub(super) group: MlsGroup,
+    pub(super) pending_staged_commit: Option<StagedCommit>,
 }
 
 impl<S: DeMlsStorage> OpenMlsService<S> {
@@ -63,8 +72,10 @@ impl<S: DeMlsStorage> OpenMlsService<S> {
             crypto,
             credentials,
             conversation_id,
-            mls_group: RwLock::new(group),
-            pending_staged_commit: RwLock::new(None),
+            state: RwLock::new(MlsGroupState {
+                group,
+                pending_staged_commit: None,
+            }),
         })
     }
 
@@ -97,7 +108,7 @@ impl<S: DeMlsStorage> OpenMlsService<S> {
         }
 
         for secret in welcome.secrets() {
-            let _ = storage.remove_key_package_ref(secret.new_member().as_slice());
+            storage.remove_key_package_ref(secret.new_member().as_slice())?;
         }
 
         let group = {
@@ -115,8 +126,10 @@ impl<S: DeMlsStorage> OpenMlsService<S> {
             crypto,
             credentials,
             conversation_id,
-            mls_group: RwLock::new(group),
-            pending_staged_commit: RwLock::new(None),
+            state: RwLock::new(MlsGroupState {
+                group,
+                pending_staged_commit: None,
+            }),
         }))
     }
 


### PR DESCRIPTION
The MLS service had two independent `std::sync::RwLock`s — one for the MLS group, one for the optional staged-commit slot — which moved together through stage → merge / discard. Folding them into a single `RwLock<MlsGroupState>` removes the ordering window where a staged commit and the group state could be observed independently. `make_provider` is renamed `provider` (accessor, not a "make"); single-use callsites drop the mechanical `let group = &mut state.group;` reborrow in favor of `state.group.X` directly.

Cleanup paths that previously discarded `Result` via `let _ = ...` now propagate via `?`: `discard_own_commit`, `discard_staged_commit`, the welcome-path `remove_key_package_ref` loop, freeze-round early-exit cleanups, the `on_leave_conversation` callback during pending-join timeout, and `mls.delete()` on conversation leave.

`Conversation::add_freeze_candidate` returns a typed `FreezeBufferOutcome` enum (Buffered / SelectionLocked / StaleEpoch / DuplicateHash) instead of bool. The three non-Buffered variants are legitimate runtime states, not errors — both callers still collapse them to "skip", but logs and any future consumer can distinguish reasons. `send_kp_message` drops a confused lookup-and-discard pattern in favor of a direct `contains_key` existence check.
