### PR TITLE
refactor: trim hot-path clones in freeze and commit-apply

### DIFF
--- a/src/app/orchestrator/freeze.rs
+++ b/src/app/orchestrator/freeze.rs
@@ -90,7 +90,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .on_phase_change(conversation_name, selection_event)
             .await;
 
-        let (finalize_result, downward_cross) = {
+        let (mut finalize_result, downward_cross) = {
             let mut entry = entry_arc.write().await;
             let allow_subset = entry.handle.steward_list.config().allow_subset_candidates;
             let result = if entry.handle.mls().is_some() {
@@ -122,14 +122,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             (result, cross)
         };
 
-        // Notify the integrator of the just-committed batch (UI history,
-        // audit logs, etc.). Fired outside the runner lock so the handler
-        // can take its own locks without deadlock risk.
         if !finalize_result.committed_batch.is_empty() {
-            let batch: Vec<_> = finalize_result.committed_batch.values().cloned().collect();
             if let Err(e) = self
                 .handler
-                .on_commit_applied(conversation_name, batch)
+                .on_commit_applied(
+                    conversation_name,
+                    std::mem::take(&mut finalize_result.committed_batch),
+                )
                 .await
             {
                 error!(conversation = conversation_name, error = %e, "on_commit_applied callback failed");

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -411,15 +411,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         entry.handle.config.liveness_criteria_yes = sync.liveness_criteria_yes;
         entry.handle.config.pending_update_max_epochs = sync.pending_update_max_epochs;
         if let Some(timing) = &sync.timing {
-            let cfg = &mut entry.handle.config;
-            cfg.commit_inactivity_duration =
-                std::time::Duration::from_millis(timing.commit_inactivity_duration_ms);
-            cfg.freeze_duration = std::time::Duration::from_millis(timing.freeze_duration_ms);
-            cfg.recovery_inactivity_duration =
-                std::time::Duration::from_millis(timing.recovery_inactivity_duration_ms);
-            cfg.proposal_expiration =
-                std::time::Duration::from_millis(timing.proposal_expiration_ms);
-            cfg.consensus_timeout = std::time::Duration::from_millis(timing.consensus_timeout_ms);
+            entry.handle.config.apply_timing(timing);
         }
         Ok(())
     }

--- a/src/app/orchestrator/steward.rs
+++ b/src/app/orchestrator/steward.rs
@@ -422,21 +422,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 None => return Ok(()),
             };
 
-            let timing = TimingConfig {
-                commit_inactivity_duration_ms: entry
-                    .handle
-                    .config
-                    .commit_inactivity_duration
-                    .as_millis() as u64,
-                freeze_duration_ms: entry.handle.config.freeze_duration.as_millis() as u64,
-                proposal_expiration_ms: entry.handle.config.proposal_expiration.as_millis() as u64,
-                consensus_timeout_ms: entry.handle.config.consensus_timeout.as_millis() as u64,
-                recovery_inactivity_duration_ms: entry
-                    .handle
-                    .config
-                    .recovery_inactivity_duration
-                    .as_millis() as u64,
-            };
+            let timing = TimingConfig::from(&entry.handle.config);
 
             // Filter ghosts and queued-removal targets so joiners don't
             // inherit stewards they would have to walk past on the very

--- a/src/core/conversation/config.rs
+++ b/src/core/conversation/config.rs
@@ -151,9 +151,15 @@ mod tests {
         let timing = TimingConfig::from(&original);
         let mut applied = ConversationConfig::default();
         applied.apply_timing(&timing);
-        assert_eq!(applied.commit_inactivity_duration, Duration::from_millis(100));
+        assert_eq!(
+            applied.commit_inactivity_duration,
+            Duration::from_millis(100)
+        );
         assert_eq!(applied.freeze_duration, Duration::from_millis(200));
-        assert_eq!(applied.recovery_inactivity_duration, Duration::from_millis(300));
+        assert_eq!(
+            applied.recovery_inactivity_duration,
+            Duration::from_millis(300)
+        );
         assert_eq!(applied.proposal_expiration, Duration::from_millis(400));
         assert_eq!(applied.consensus_timeout, Duration::from_millis(500));
     }

--- a/src/core/conversation/config.rs
+++ b/src/core/conversation/config.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use crate::core::ProposalKind;
+use crate::protos::de_mls::messages::v1::TimingConfig;
 
 /// Wall-clock window the steward waits before batching approved proposals
 /// into a commit (RFC §Inactivity Timer #1, "Commit inactivity").
@@ -98,6 +99,34 @@ impl ConversationConfig {
             self.election_voting_delay
         } else {
             self.voting_delay
+        }
+    }
+
+    /// Overwrite the duration fields from a wire [`TimingConfig`]. Used on
+    /// the joiner side when applying `ConversationSync`. Non-timing fields
+    /// (`liveness_criteria_yes`, `pending_update_max_epochs`) are not in
+    /// `TimingConfig` and stay untouched.
+    pub fn apply_timing(&mut self, timing: &TimingConfig) {
+        self.commit_inactivity_duration =
+            Duration::from_millis(timing.commit_inactivity_duration_ms);
+        self.freeze_duration = Duration::from_millis(timing.freeze_duration_ms);
+        self.recovery_inactivity_duration =
+            Duration::from_millis(timing.recovery_inactivity_duration_ms);
+        self.proposal_expiration = Duration::from_millis(timing.proposal_expiration_ms);
+        self.consensus_timeout = Duration::from_millis(timing.consensus_timeout_ms);
+    }
+}
+
+/// Build the wire [`TimingConfig`] from a [`ConversationConfig`]. Used on
+/// the steward side when sending `ConversationSync` to joiners.
+impl From<&ConversationConfig> for TimingConfig {
+    fn from(config: &ConversationConfig) -> Self {
+        Self {
+            commit_inactivity_duration_ms: config.commit_inactivity_duration.as_millis() as u64,
+            freeze_duration_ms: config.freeze_duration.as_millis() as u64,
+            recovery_inactivity_duration_ms: config.recovery_inactivity_duration.as_millis() as u64,
+            proposal_expiration_ms: config.proposal_expiration.as_millis() as u64,
+            consensus_timeout_ms: config.consensus_timeout.as_millis() as u64,
         }
     }
 }

--- a/src/core/conversation/config.rs
+++ b/src/core/conversation/config.rs
@@ -135,6 +135,29 @@ impl From<&ConversationConfig> for TimingConfig {
 mod tests {
     use super::*;
 
+    /// `TimingConfig` ↔ `ConversationConfig` round-trip preserves all
+    /// five duration fields. Distinct values per field catch accidental
+    /// swaps in either direction.
+    #[test]
+    fn timing_config_round_trip() {
+        let original = ConversationConfig {
+            commit_inactivity_duration: Duration::from_millis(100),
+            freeze_duration: Duration::from_millis(200),
+            recovery_inactivity_duration: Duration::from_millis(300),
+            proposal_expiration: Duration::from_millis(400),
+            consensus_timeout: Duration::from_millis(500),
+            ..ConversationConfig::default()
+        };
+        let timing = TimingConfig::from(&original);
+        let mut applied = ConversationConfig::default();
+        applied.apply_timing(&timing);
+        assert_eq!(applied.commit_inactivity_duration, Duration::from_millis(100));
+        assert_eq!(applied.freeze_duration, Duration::from_millis(200));
+        assert_eq!(applied.recovery_inactivity_duration, Duration::from_millis(300));
+        assert_eq!(applied.proposal_expiration, Duration::from_millis(400));
+        assert_eq!(applied.consensus_timeout, Duration::from_millis(500));
+    }
+
     /// Steward-election proposals get the shorter `election_voting_delay`;
     /// other kinds get `voting_delay`.
     #[test]

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -18,11 +18,9 @@ use crate::{
 pub type ProposalId = u32;
 
 /// Deterministic proposal ID for a self-leave, derived from the leaver's
-/// identity. Pinning the ID is what makes a leaver's crash-retry dedupe
-/// against an in-flight session (`ProposalAlreadyExist`) instead of opening
-/// a second session that would land a duplicate `RemoveMember` in the next
-/// commit batch. It also doubles as the self-leave signature used by
-/// `is_auto_approved_entry` and `reject_all_approved_proposals`.
+/// identity. Pinning the ID dedupes a crash-retry against any in-flight
+/// session via `ProposalAlreadyExist` and lets every node key the approved
+/// entry under the same id.
 pub fn self_leave_proposal_id(identity: &[u8]) -> u32 {
     let hash = Sha256::digest(identity);
     u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])
@@ -66,7 +64,6 @@ pub fn target_identity_of(request: &ConversationUpdateRequest) -> Option<&[u8]> 
 /// `max_age_epochs` epochs have elapsed since the entry was first seen.
 #[derive(Clone, Debug)]
 pub struct PendingUpdate {
-    /// The `ConversationUpdateRequest` carrying either `InviteMember` or `RemoveMember`.
     pub request: ConversationUpdateRequest,
     /// MLS epoch at which this update was first observed locally.
     pub first_seen_epoch: u64,
@@ -111,10 +108,7 @@ pub enum FreezeBufferOutcome {
 
 /// Per-conversation protocol state. Stewards batch commits; members vote.
 /// Construct with [`Conversation::new`].
-///
-/// Proposal-queue and freeze-round bookkeeping.
 pub struct Conversation {
-    /// The name of the conversation.
     conversation_name: String,
     /// Proposals that passed consensus, waiting for steward to commit.
     approved_proposals: HashMap<ProposalId, ConversationUpdateRequest>,
@@ -193,13 +187,10 @@ impl Conversation {
         move |candidate: &[u8]| !self.is_pending_removal(candidate) && mls_set.contains(candidate)
     }
 
-    /// True iff `approved_proposals` carries any `RemoveMember(identity)` —
-    /// regardless of source (self-leave, ban, ECP-derived). Used by the
-    /// steward-eligibility predicate to skip a member whose removal is queued
-    /// for the next commit: MLS forbids them from committing it themselves,
-    /// so the rotation walk would have to fall back anyway. Broader than
-    /// [`Self::is_pending_self_leave`] (which only matches the deterministic
-    /// self-leave id).
+    /// True iff `approved_proposals` carries any `RemoveMember(identity)`,
+    /// regardless of source. Used by `steward_eligibility` to skip a member
+    /// whose removal is queued — MLS forbids them from committing it
+    /// themselves. Broader than [`Self::is_pending_self_leave`].
     pub fn is_pending_removal(&self, identity: &[u8]) -> bool {
         self.approved_proposals.values().any(|req| {
             matches!(
@@ -277,16 +268,14 @@ impl Conversation {
         }
     }
 
-    /// Clear the approved-proposal queue and return the cleared batch so
-    /// callers can archive it for UI / diagnostic history. Returns an
-    /// empty `HashMap` when the queue was already empty.
-    ///
-    /// MLS advances the epoch itself on commit merge, so no counter bump
-    /// here. Per-node epoch history is an app-layer concern; this method
-    /// surfaces the snapshot but does not retain it.
-    pub fn clear_approved_proposals(&mut self) -> HashMap<ProposalId, ConversationUpdateRequest> {
-        self.approved_order.clear();
-        std::mem::take(&mut self.approved_proposals)
+    /// Clear the approved-proposal queue and return the cleared batch in
+    /// FIFO insertion order so callers can archive it for UI / diagnostic
+    /// history. Returns an empty `Vec` when the queue was already empty.
+    pub fn clear_approved_proposals(&mut self) -> Vec<ConversationUpdateRequest> {
+        self.approved_order
+            .drain(..)
+            .filter_map(|pid| self.approved_proposals.remove(&pid))
+            .collect()
     }
 
     /// Discard the approved queue on freeze failure. `RemoveMember`

--- a/src/core/conversation/handle.rs
+++ b/src/core/conversation/handle.rs
@@ -22,12 +22,9 @@ use crate::{
     },
 };
 
-/// Per-conversation aggregate. Generic over a single [`ConversationPluginsFactory`]
-/// bundle so callsites name one type parameter instead of three. Fields
-/// with simple direct semantics (`conversation`, `state_machine`, `config`,
-/// `scoring`, `steward_list`) are exposed as fields; fields with
-/// attach/detach lifecycle (`mls`) or RFC-defined invariants
-/// (`operating_mode`) go through controlled accessors.
+/// Per-conversation aggregate owned by the orchestrator. Bundles protocol
+/// state, the MLS service, plug-ins, state machine, durable config, and
+/// operating mode behind one type parameter.
 pub struct ConversationHandle<CP: ConversationPluginsFactory> {
     pub(crate) conversation: Conversation,
     /// Per-conversation MLS service. `None` for joiners in `PendingJoin` who
@@ -41,19 +38,15 @@ pub struct ConversationHandle<CP: ConversationPluginsFactory> {
     /// `liveness_criteria_yes`, `pending_update_max_epochs`. Read by
     /// orchestrators; joiner-sync writes through this directly.
     pub(crate) config: ConversationConfig,
-    /// Per-conversation peer-score plug-in. Read by protocol decisions under
-    /// the orchestrator's per-handle lock; no separate `Mutex` needed.
+    /// Per-conversation peer-score plug-in.
     pub(crate) scoring: CP::Scoring,
     /// Per-conversation steward-list plug-in. Holds the active list, retry
     /// counter, and election retry policy. Orchestrator composes
-    /// eligibility from MLS members + `Conversation::is_pending_removal` and
-    /// passes it on every position query.
+    /// eligibility from MLS members + `Conversation::is_pending_removal`.
     pub(crate) steward_list: CP::StewardList,
     /// Authorization mode (RFC §Layer 3 Anti-Deadlock ECP). `Recovery` is
     /// set when an accepted Deadlock ECP relaxes the steward gate so any
     /// member may produce the next commit; cleared on accepted election.
-    /// Read by the freeze coordinator, the create-commit path, and
-    /// `core::finalize_freeze_round` (via `in_recovery` parameter).
     operating_mode: OperatingMode,
 }
 
@@ -108,9 +101,7 @@ impl<CP: ConversationPluginsFactory> ConversationHandle<CP> {
     }
 
     /// Borrow the MLS service, erroring with
-    /// [`CoreError::MlsGroupNotInitialized`] when not attached. Use this
-    /// in code paths where the service must be present so the `?` chain
-    /// stays linear.
+    /// [`CoreError::MlsGroupNotInitialized`] when not attached.
     pub(crate) fn expect_mls(&self) -> Result<&CP::Mls, CoreError> {
         self.mls.as_ref().ok_or(CoreError::MlsGroupNotInitialized)
     }
@@ -267,11 +258,8 @@ impl<CP: ConversationPluginsFactory> ConversationHandle<CP> {
             },
             epoch,
         );
-        // We still return the outbound packet so the steward broadcasts;
-        // finalize will ignore the unbuffered local candidate. The
-        // non-Buffered outcomes are legitimate runtime states (see
-        // `FreezeBufferOutcome` doc), not errors — log at debug so they
-        // surface for operators without alerting.
+        // Non-Buffered outcomes are legitimate runtime states (see
+        // `FreezeBufferOutcome`), not errors — log at debug.
         if !matches!(outcome, FreezeBufferOutcome::Buffered) {
             tracing::debug!(
                 conversation = self.conversation.name(),
@@ -297,9 +285,7 @@ impl<CP: ConversationPluginsFactory> ConversationHandle<CP> {
         )))
     }
 
-    /// Finalize the active freeze round. Errors with
-    /// [`CoreError::MlsGroupNotInitialized`] when no MLS service is
-    /// attached.
+    /// Finalize the active freeze round.
     pub(crate) fn finalize_freeze_round(
         &mut self,
         allow_subset_candidates: bool,

--- a/src/core/conversation/state_machine.rs
+++ b/src/core/conversation/state_machine.rs
@@ -52,8 +52,6 @@ impl Display for ConversationState {
     }
 }
 
-/// State enum + named transitions. The app layer wraps this with
-/// timer-driven behaviour through [`crate::app::PhaseTimer`].
 #[derive(Debug, Clone)]
 pub struct ConversationStateMachine {
     state: ConversationState,

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -2,12 +2,10 @@
 //! Per-candidate apply paths (local merge / remote stage-validate-merge),
 //! MLS staging, validation, and post-commit bookkeeping live here.
 
-use std::collections::HashMap;
-
 use super::round::{FreezeFinalizeResult, FreezeOutcome, RoundContext};
 use crate::{
     core::{
-        Conversation, CoreError, ProcessResult, ProposalId, ScoreEvent, ScoreOp, StewardListPlugin,
+        Conversation, CoreError, ProcessResult, ScoreEvent, ScoreOp, StewardListPlugin,
         conversation::BufferedCommitCandidate, proposal_framing::build_invitation_packet,
     },
     mls_crypto::{MlsProposalOutput, MlsService, StagedCandidateResult},
@@ -24,7 +22,7 @@ enum CandidateOutcome {
     Terminal {
         outcome: FreezeOutcome,
         committer: Vec<u8>,
-        committed_batch: HashMap<ProposalId, ConversationUpdateRequest>,
+        committed_batch: Vec<ConversationUpdateRequest>,
     },
     Drop(ScoreOp),
 }
@@ -147,7 +145,7 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
     Ok(FreezeFinalizeResult {
         outcome: FreezeOutcome::NoCandidate,
         score_ops,
-        committed_batch: HashMap::new(),
+        committed_batch: Vec::new(),
     })
 }
 
@@ -306,8 +304,8 @@ enum StagingOutcome {
 
 /// Stage proposals and commit, cross-checking sender consistency along the way.
 ///
-/// Leaves MLS in the staged state on `Staged`; the caller must clean up via
-/// `discard_and_*` for `Abort` / `Violation`.
+/// Leaves MLS in the staged state on `Staged`; the caller must clean up
+/// via `discard_staged_commit` for `Abort` / `Violation`.
 fn stage_candidate<M>(
     mls: &M,
     conversation_name: &str,
@@ -450,12 +448,12 @@ fn check_commit_sender_authorized(
 fn record_applied_commit(
     conversation: &mut Conversation,
     commit_hash: Vec<u8>,
-) -> HashMap<ProposalId, ConversationUpdateRequest> {
+) -> Vec<ConversationUpdateRequest> {
     conversation.record_committed_batch(commit_hash);
     let snapshot = if let Some(target) = conversation.take_urgent_commit_target() {
         // Urgent commit: leave the rest of the queue for the next cycle.
         conversation.drop_approved_removals_for(&target);
-        HashMap::new()
+        Vec::new()
     } else {
         conversation.clear_approved_proposals()
     };

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -9,7 +9,10 @@ use crate::{
         conversation::BufferedCommitCandidate, proposal_framing::build_invitation_packet,
     },
     mls_crypto::{MlsProposalOutput, MlsService, StagedCandidateResult},
-    protos::de_mls::messages::v1::{CommitCandidate, ConversationUpdateRequest, ViolationEvidence},
+    protos::de_mls::messages::v1::{
+        CommitCandidate, ConversationUpdateRequest, ViolationEvidence,
+        conversation_update_request::Payload,
+    },
 };
 
 /// Result of trying to apply one candidate. `Terminal` ends the round;
@@ -39,9 +42,9 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
     conversation: &mut Conversation,
     mls: &M,
     steward: &dyn StewardListPlugin,
-    in_recovery: bool,
     sorted: Vec<BufferedCommitCandidate>,
     ctx: &RoundContext,
+    self_identity: &[u8],
     app_id: &[u8],
 ) -> Result<FreezeFinalizeResult, CoreError> {
     let mut score_ops: Vec<ScoreOp> = Vec::new();
@@ -58,24 +61,16 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
                 );
                 continue;
             }
-            apply_local_candidate(conversation, mls, chosen, ctx.self_remove_pending, app_id)?
+            apply_local_candidate(conversation, mls, chosen, ctx, app_id)?
         } else {
-            if !own_commit_discarded && steward.is_steward(&ctx.self_identity) {
+            if !own_commit_discarded && steward.is_steward(self_identity) {
                 // A failure here leaves an old pending commit in MLS and
                 // would sabotage every subsequent staging attempt — bubble
                 // the error out of the round instead of pressing on.
                 mls.discard_own_commit()?;
                 own_commit_discarded = true;
             }
-            apply_incoming_candidate(
-                conversation,
-                mls,
-                steward,
-                in_recovery,
-                chosen,
-                &ctx.mls_actions,
-                ctx.current_epoch,
-            )?
+            apply_incoming_candidate(conversation, mls, steward, chosen, ctx)?
         };
 
         match apply_result {
@@ -84,47 +79,15 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
                 committer,
                 committed_batch,
             } => {
-                score_ops.push(ScoreOp {
-                    member_id: committer.clone(),
-                    event: ScoreEvent::SuccessfulCommit,
-                });
-                // If a backup committed in place of the epoch steward,
-                // penalise the absent steward (RFC §Steward violation
-                // list: censorship/inactivity). Skip self-accusation —
-                // we know our own liveness directly. The walk in
-                // `live_epoch_steward_id` already filters out
-                // queued-removal targets, so a draining named steward
-                // never appears here as `expected`.
-                if let Some(expected) = ctx.live_epoch_steward_id.as_deref() {
-                    if expected != committer.as_slice() && expected != ctx.self_identity.as_slice()
-                    {
-                        score_ops.push(ScoreOp {
-                            member_id: expected.to_vec(),
-                            event: ScoreEvent::CensorshipInactivity,
-                        });
-                    }
-                }
-                // Unpicked candidates that passed the count filter are
-                // honest competitors under Δ-synchrony (same approved set,
-                // different MLS entropy). RFC §Commit Validation: "MUST
-                // NOT be classified as misbehaviour." Score only when the
-                // wire-claimed identity sits on the steward list — a forged
-                // claim from a non-steward earns no credit.
-                for loser in remaining {
-                    let claimed = loser.candidate_msg.steward_identity;
-                    let on_list = steward.is_steward(&claimed);
-                    if on_list {
-                        score_ops.push(ScoreOp {
-                            member_id: claimed,
-                            event: ScoreEvent::HonestCommitAttempt,
-                        });
-                    } else {
-                        tracing::debug!(
-                            conversation = %conversation_name,
-                            "dropping HonestCommitAttempt: claimed identity not on steward list"
-                        );
-                    }
-                }
+                record_winner_scores(
+                    &mut score_ops,
+                    &committer,
+                    self_identity,
+                    ctx,
+                    remaining,
+                    steward,
+                    &conversation_name,
+                );
                 return Ok(FreezeFinalizeResult {
                     outcome,
                     score_ops,
@@ -149,6 +112,59 @@ pub(super) fn apply_in_priority_order<M: MlsService>(
     })
 }
 
+/// Append the scoring side-effects of a winning commit:
+/// `SuccessfulCommit` on the committer, `CensorshipInactivity` on the
+/// absent named steward (if a backup won and we aren't that steward),
+/// and `HonestCommitAttempt` on each unpicked competitor whose
+/// wire-claimed identity sits on the steward list.
+///
+/// RFC §Commit Validation: unpicked competitors are honest under
+/// Δ-synchrony (same approved set, different MLS entropy) and MUST NOT
+/// be classified as misbehaviour. The steward-list check rejects forged
+/// credit claims from non-stewards.
+fn record_winner_scores(
+    score_ops: &mut Vec<ScoreOp>,
+    committer: &[u8],
+    self_identity: &[u8],
+    ctx: &RoundContext,
+    losers: impl Iterator<Item = BufferedCommitCandidate>,
+    steward: &dyn StewardListPlugin,
+    conversation_name: &str,
+) {
+    score_ops.push(ScoreOp {
+        member_id: committer.to_vec(),
+        event: ScoreEvent::SuccessfulCommit,
+    });
+
+    // The walk in `live_epoch_steward_id` already filters out
+    // queued-removal targets, so a draining named steward never appears
+    // here as `expected`.
+    if let Some(expected) = ctx.live_epoch_steward_id.as_deref()
+        && expected != committer
+        && expected != self_identity
+    {
+        score_ops.push(ScoreOp {
+            member_id: expected.to_vec(),
+            event: ScoreEvent::CensorshipInactivity,
+        });
+    }
+
+    for loser in losers {
+        let claimed = loser.candidate_msg.steward_identity;
+        if steward.is_steward(&claimed) {
+            score_ops.push(ScoreOp {
+                member_id: claimed,
+                event: ScoreEvent::HonestCommitAttempt,
+            });
+        } else {
+            tracing::debug!(
+                conversation = %conversation_name,
+                "dropping HonestCommitAttempt: claimed identity not on steward list"
+            );
+        }
+    }
+}
+
 // ─────────────────────────── Application Paths ───────────────────────────
 
 /// Merge our own commit and send the deferred welcomes we held back.
@@ -158,7 +174,7 @@ fn apply_local_candidate<M: MlsService>(
     conversation: &mut Conversation,
     mls: &M,
     chosen: BufferedCommitCandidate,
-    self_removed: bool,
+    ctx: &RoundContext,
     app_id: &[u8],
 ) -> Result<CandidateOutcome, CoreError> {
     // Local candidate: we wrote the message, so the wire-claimed identity
@@ -174,7 +190,7 @@ fn apply_local_candidate<M: MlsService>(
 
     let committed_batch = record_applied_commit(conversation, chosen.commit_hash);
 
-    let result = if self_removed {
+    let result = if ctx.self_remove_pending {
         ProcessResult::LeaveConversation
     } else {
         ProcessResult::ConversationUpdated
@@ -200,10 +216,8 @@ fn apply_incoming_candidate<M: MlsService>(
     conversation: &mut Conversation,
     mls: &M,
     steward: &dyn StewardListPlugin,
-    in_recovery: bool,
     chosen: BufferedCommitCandidate,
-    expected_actions: &[MlsProposalOutput],
-    current_epoch: u64,
+    ctx: &RoundContext,
 ) -> Result<CandidateOutcome, CoreError> {
     let conversation_name = conversation.name().to_owned();
 
@@ -211,7 +225,7 @@ fn apply_incoming_candidate<M: MlsService>(
         mls,
         &conversation_name,
         &chosen.candidate_msg,
-        current_epoch,
+        ctx,
     )? {
         StagingOutcome::Staged {
             commit_sender,
@@ -240,9 +254,8 @@ fn apply_incoming_candidate<M: MlsService>(
     if let Some(violation) = check_commit_sender_authorized(
         conversation,
         steward,
-        in_recovery,
         &commit_sender,
-        current_epoch,
+        ctx,
     ) {
         mls.discard_staged_commit()?;
         return Ok(CandidateOutcome::Drop(
@@ -255,10 +268,9 @@ fn apply_incoming_candidate<M: MlsService>(
     // MLS actions must match the set we voted to approve.
     if let Some(violation) = validate_commit_candidate(
         conversation,
-        expected_actions,
         &commit_sender,
         &commit_actions,
-        current_epoch,
+        ctx,
     )? {
         mls.discard_staged_commit()?;
         return Ok(CandidateOutcome::Drop(
@@ -310,7 +322,7 @@ fn stage_candidate<M>(
     mls: &M,
     conversation_name: &str,
     candidate: &CommitCandidate,
-    current_epoch: u64,
+    ctx: &RoundContext,
 ) -> Result<StagingOutcome, CoreError>
 where
     M: MlsService,
@@ -339,7 +351,7 @@ where
         );
         return Ok(StagingOutcome::Violation(ViolationEvidence::broken_commit(
             commit_sender,
-            current_epoch,
+            ctx.current_epoch,
             "commit candidate's steward_identity doesn't match MLS commit sender",
         )));
     }
@@ -356,7 +368,7 @@ where
         );
         return Ok(StagingOutcome::Violation(ViolationEvidence::broken_commit(
             commit_sender,
-            current_epoch,
+            ctx.current_epoch,
             "commit bundles proposals not signed by the committer",
         )));
     }
@@ -372,36 +384,62 @@ where
 
 /// Check that a commit's MLS actions match the voted-approved set.
 /// `Some(evidence)` on mismatch.
+///
+/// Compares both sides as sorted `(kind_tag, &identity)` projections —
+/// no `MlsProposalOutput` allocation, no per-element clone.
 fn validate_commit_candidate(
     conversation: &Conversation,
-    expected_actions: &[MlsProposalOutput],
     sender_id: &[u8],
     mls_actions: &[MlsProposalOutput],
-    epoch: u64,
+    ctx: &RoundContext,
 ) -> Result<Option<ViolationEvidence>, CoreError> {
-    let conversation_name = conversation.name();
+    let mut expected: Vec<(u8, &[u8])> = conversation
+        .approved_proposals()
+        .values()
+        .filter_map(action_projection_from_request)
+        .collect();
+    let mut actual: Vec<(u8, &[u8])> =
+        mls_actions.iter().map(action_projection_from_mls).collect();
+    expected.sort();
+    actual.sort();
 
-    let mut expected_actions = expected_actions.to_vec();
-    let mut actual_actions = mls_actions.to_vec();
-
-    expected_actions.sort();
-    actual_actions.sort();
-
-    if actual_actions != expected_actions {
-        tracing::warn!(
-            conversation = conversation_name,
-            actual = ?actual_actions,
-            expected = ?expected_actions,
-            "violation: MLS actions don't match voted proposals"
-        );
-        return Ok(Some(ViolationEvidence::broken_mls_proposal(
-            sender_id.to_vec(),
-            epoch,
-            format!("MLS actions {actual_actions:?} != voted {expected_actions:?}"),
-        )));
+    if expected == actual {
+        return Ok(None);
     }
 
-    Ok(None)
+    tracing::warn!(
+        conversation = conversation.name(),
+        actual = ?mls_actions,
+        expected = ?expected,
+        "violation: MLS actions don't match voted proposals"
+    );
+    Ok(Some(ViolationEvidence::broken_mls_proposal(
+        sender_id.to_vec(),
+        ctx.current_epoch,
+        format!("MLS actions {mls_actions:?} != voted {expected:?}"),
+    )))
+}
+
+/// `(kind_tag, identity)` projection of an approved voting request.
+/// Returns `None` for non-MLS payloads (emergency/election).
+fn action_projection_from_request(
+    req: &ConversationUpdateRequest,
+) -> Option<(u8, &[u8])> {
+    match req.payload.as_ref()? {
+        Payload::InviteMember(im) => Some((0, &im.identity)),
+        Payload::RemoveMember(rm) => Some((1, &rm.identity)),
+        _ => None,
+    }
+}
+
+/// `(kind_tag, identity)` projection of an MLS-staged action. `Other`
+/// gets a distinct tag so it never matches voted Add/Remove.
+fn action_projection_from_mls(action: &MlsProposalOutput) -> (u8, &[u8]) {
+    match action {
+        MlsProposalOutput::Add(id) => (0, id),
+        MlsProposalOutput::Remove(id) => (1, id),
+        MlsProposalOutput::Other(_) => (2, b""),
+    }
 }
 
 /// RFC §"de-MLS Objects": any steward-list member may commit to preserve
@@ -414,15 +452,14 @@ fn validate_commit_candidate(
 fn check_commit_sender_authorized(
     conversation: &Conversation,
     steward: &dyn StewardListPlugin,
-    in_recovery: bool,
     commit_sender: &[u8],
-    epoch: u64,
+    ctx: &RoundContext,
 ) -> Option<ViolationEvidence> {
-    if in_recovery {
+    if ctx.in_recovery {
         return None;
     }
     steward.current_list()?;
-    if steward.is_exhausted(epoch) {
+    if steward.is_exhausted(ctx.current_epoch) {
         return None;
     }
     if steward.is_steward(commit_sender) {
@@ -434,7 +471,7 @@ fn check_commit_sender_authorized(
     );
     Some(ViolationEvidence::broken_commit(
         commit_sender.to_vec(),
-        epoch,
+        ctx.current_epoch,
         "commit from unauthorized sender (not on the steward list)",
     ))
 }

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -221,42 +221,35 @@ fn apply_incoming_candidate<M: MlsService>(
 ) -> Result<CandidateOutcome, CoreError> {
     let conversation_name = conversation.name().to_owned();
 
-    let (commit_sender, self_removed, commit_actions) = match stage_candidate(
-        mls,
-        &conversation_name,
-        &chosen.candidate_msg,
-        ctx,
-    )? {
-        StagingOutcome::Staged {
-            commit_sender,
-            self_removed,
-            commit_actions,
-        } => (commit_sender, self_removed, commit_actions),
-        StagingOutcome::Abort => {
-            // Wire-valid but MLS-invalid — penalize the author; the
-            // loop will try the next candidate.
-            mls.discard_staged_commit()?;
-            return Ok(CandidateOutcome::Drop(ScoreOp {
-                member_id: chosen.candidate_msg.steward_identity,
-                event: ScoreEvent::MisbehavingCommit,
-            }));
-        }
-        StagingOutcome::Violation(v) => {
-            mls.discard_staged_commit()?;
-            return Ok(CandidateOutcome::Drop(
-                v.target_score_op()
-                    .expect("staged-violation always has a target-side score"),
-            ));
-        }
-    };
+    let (commit_sender, self_removed, commit_actions) =
+        match stage_candidate(mls, &conversation_name, &chosen.candidate_msg, ctx)? {
+            StagingOutcome::Staged {
+                commit_sender,
+                self_removed,
+                commit_actions,
+            } => (commit_sender, self_removed, commit_actions),
+            StagingOutcome::Abort => {
+                // Wire-valid but MLS-invalid — penalize the author; the
+                // loop will try the next candidate.
+                mls.discard_staged_commit()?;
+                return Ok(CandidateOutcome::Drop(ScoreOp {
+                    member_id: chosen.candidate_msg.steward_identity,
+                    event: ScoreEvent::MisbehavingCommit,
+                }));
+            }
+            StagingOutcome::Violation(v) => {
+                mls.discard_staged_commit()?;
+                return Ok(CandidateOutcome::Drop(
+                    v.target_score_op()
+                        .expect("staged-violation always has a target-side score"),
+                ));
+            }
+        };
 
     // Commit sender must be on the steward list (RFC §"Commit validation service").
-    if let Some(violation) = check_commit_sender_authorized(
-        conversation,
-        steward,
-        &commit_sender,
-        ctx,
-    ) {
+    if let Some(violation) =
+        check_commit_sender_authorized(conversation, steward, &commit_sender, ctx)
+    {
         mls.discard_staged_commit()?;
         return Ok(CandidateOutcome::Drop(
             violation
@@ -266,12 +259,9 @@ fn apply_incoming_candidate<M: MlsService>(
     }
 
     // MLS actions must match the set we voted to approve.
-    if let Some(violation) = validate_commit_candidate(
-        conversation,
-        &commit_sender,
-        &commit_actions,
-        ctx,
-    )? {
+    if let Some(violation) =
+        validate_commit_candidate(conversation, &commit_sender, &commit_actions, ctx)?
+    {
         mls.discard_staged_commit()?;
         return Ok(CandidateOutcome::Drop(
             violation
@@ -398,8 +388,7 @@ fn validate_commit_candidate(
         .values()
         .filter_map(action_projection_from_request)
         .collect();
-    let mut actual: Vec<(u8, &[u8])> =
-        mls_actions.iter().map(action_projection_from_mls).collect();
+    let mut actual: Vec<(u8, &[u8])> = mls_actions.iter().map(action_projection_from_mls).collect();
     expected.sort();
     actual.sort();
 
@@ -422,9 +411,7 @@ fn validate_commit_candidate(
 
 /// `(kind_tag, identity)` projection of an approved voting request.
 /// Returns `None` for non-MLS payloads (emergency/election).
-fn action_projection_from_request(
-    req: &ConversationUpdateRequest,
-) -> Option<(u8, &[u8])> {
+fn action_projection_from_request(req: &ConversationUpdateRequest) -> Option<(u8, &[u8])> {
     match req.payload.as_ref()? {
         Payload::InviteMember(im) => Some((0, &im.identity)),
         Payload::RemoveMember(rm) => Some((1, &rm.identity)),

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -2,16 +2,14 @@
 //!
 //! Per-candidate apply lives in the sibling [`super::apply`] module.
 
-use std::collections::HashMap;
-
 use sha2::{Digest, Sha256};
 use tracing::info;
 
 use super::apply::apply_in_priority_order;
 use crate::{
     core::{
-        Conversation, CoreError, FreezeBufferOutcome, ProcessResult, ProposalId, ScoreOp,
-        StewardListPlugin, conversation::BufferedCommitCandidate,
+        Conversation, CoreError, FreezeBufferOutcome, ProcessResult, ScoreOp, StewardListPlugin,
+        conversation::BufferedCommitCandidate,
     },
     mls_crypto::{MlsMessageKind, MlsProposalOutput, MlsService},
     protos::de_mls::messages::v1::{
@@ -24,35 +22,22 @@ use crate::{
 // ═════════════════════════════════════════════════════════════════════════════
 
 /// What [`finalize_freeze_round`] hands back to the caller.
-///
-/// `score_ops` accumulates during the phase-3 loop — each time a candidate
-/// is dropped for MLS-staging failure the caller records a
-/// [`crate::core::ScoreEvent::MisbehavingCommit`] against its author. The
-/// app layer feeds these directly into the peer-scoring service without
-/// an ECP round-trip (RFC §Peer Scoring: locally-observed violations may
-/// be scored immediately).
 #[derive(Debug, Clone, Default)]
 pub struct FreezeFinalizeResult {
     pub outcome: FreezeOutcome,
     pub score_ops: Vec<ScoreOp>,
-    /// The approved-proposal batch that was just committed and cleared
-    /// from `Conversation::approved_proposals`. Empty when no commit applied or
-    /// when an urgent-target commit drops only the targeted entry. App
-    /// layer typically archives this for UI history.
-    pub committed_batch: HashMap<ProposalId, ConversationUpdateRequest>,
+    /// Just-committed approvals in FIFO order. Empty on no-op or when
+    /// an urgent-target commit drops only its entry.
+    pub committed_batch: Vec<ConversationUpdateRequest>,
 }
 
-/// Terminal outcome of a freeze round: either a dispatchable result or no
-/// candidate was applyable.
-///
 /// `result` is boxed because [`ProcessResult`] is a large enum (~240 bytes)
 /// and `NoCandidate` is the common case.
 #[derive(Debug, Clone, Default)]
 pub enum FreezeOutcome {
-    /// A dispatchable result — successful apply or self-leave.
-    /// `outbound` carries deferred welcomes when our own candidate won.
     Applied {
         result: Box<ProcessResult>,
+        /// Deferred welcomes when our own candidate won.
         outbound: Option<crate::ds::OutboundPacket>,
     },
     #[default]
@@ -66,11 +51,9 @@ pub fn compute_commit_hash(commit_message: &[u8]) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
-/// Buffer a remote commit candidate for the active freeze round.
-///
-/// Enforces the invariants [`finalize_freeze_round`] assumes: non-empty
-/// proposals/commit, valid MLS wire kinds, non-empty `steward_identity`,
-/// not already committed. No MLS state is mutated here.
+/// Buffer a remote commit candidate. Enforces non-empty proposals/commit,
+/// valid MLS wire kinds, non-empty `steward_identity`, and non-duplicate
+/// hash. No MLS state is mutated.
 pub fn process_commit_candidate<M: MlsService>(
     conversation: &mut Conversation,
     mls: &M,
@@ -138,9 +121,7 @@ pub fn process_commit_candidate<M: MlsService>(
             );
             Ok(ProcessResult::CommitCandidateReceived)
         }
-        // All other outcomes are legitimate runtime states, not errors.
-        // Drop the candidate quietly; the round proceeds with whatever
-        // is already buffered.
+        // Legitimate runtime states, not errors — drop quietly.
         FreezeBufferOutcome::SelectionLocked
         | FreezeBufferOutcome::StaleEpoch
         | FreezeBufferOutcome::DuplicateHash => Ok(ProcessResult::Noop),
@@ -202,21 +183,18 @@ pub fn finalize_freeze_round<M: MlsService>(
 // ROUND SETUP
 // ═════════════════════════════════════════════════════════════════════════════
 
-/// Precomputed round-level data: the approved-queue snapshot every
-/// candidate must match, the epoch the round targets, and the identities
-/// used for self-accusation skips and committer-vs-expected checks.
-///
-/// `mls_actions` is the expected MLS action set (non-MLS payloads
-/// filtered out). `self_remove_pending` flips the local apply's terminal
-/// result to `LeaveConversation` when our removal is in the batch.
-/// `live_epoch_steward_id` is the pre-merge eligibility-filtered steward
-/// expected to have committed at `current_epoch`; used to penalise an
-/// absent steward when a backup commits in their place.
+/// Precomputed round-level data used during candidate apply.
 pub(super) struct RoundContext {
+    /// Expected MLS action set; non-MLS payloads filtered out.
     pub(super) mls_actions: Vec<MlsProposalOutput>,
     pub(super) mls_count: usize,
+    /// Flips the local apply's terminal result to `LeaveConversation`
+    /// when our removal is in the batch.
     pub(super) self_remove_pending: bool,
     pub(super) current_epoch: u64,
+    /// Pre-merge eligibility-filtered steward expected at
+    /// `current_epoch`. Used to penalise an absent steward when a
+    /// backup commits in their place.
     pub(super) live_epoch_steward_id: Option<Vec<u8>>,
     pub(super) self_identity: Vec<u8>,
 }
@@ -345,8 +323,6 @@ fn compare_candidate_priority(
 mod tests {
     use super::*;
 
-    /// Test-only: sort candidates by the RFC priority comparator so tests can
-    /// assert the full ranked order. Production uses `min_by` instead.
     fn sort_by_priority(
         candidates: &mut [BufferedCommitCandidate],
         epoch_steward_id: Option<&[u8]>,

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -131,8 +131,8 @@ pub fn process_commit_candidate<M: MlsService>(
 /// Pick and apply a buffered candidate for the active freeze round.
 ///
 /// Three phases:
-/// 1. Snapshot the round context — approved-queue actions, current
-///    epoch, and the pre-merge live epoch steward.
+/// 1. Snapshot the pre-merge round state (counts, epoch, recovery flag,
+///    live epoch steward).
 /// 2. Filter candidates by action count and rank them by RFC priority.
 /// 3. Apply in priority order, falling back on the next candidate when
 ///    MLS staging rejects the current one.

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -11,7 +11,7 @@ use crate::{
         Conversation, CoreError, FreezeBufferOutcome, ProcessResult, ScoreOp, StewardListPlugin,
         conversation::BufferedCommitCandidate,
     },
-    mls_crypto::{MlsMessageKind, MlsProposalOutput, MlsService},
+    mls_crypto::{MlsMessageKind, MlsService},
     protos::de_mls::messages::v1::{
         CommitCandidate, ConversationUpdateRequest, conversation_update_request::Payload,
     },
@@ -160,7 +160,14 @@ pub fn finalize_freeze_round<M: MlsService>(
         return Ok(FreezeFinalizeResult::default());
     }
 
-    let ctx = RoundContext::snapshot(conversation, mls, steward, current_epoch, self_identity)?;
+    let ctx = RoundContext::snapshot(
+        conversation,
+        mls,
+        steward,
+        current_epoch,
+        in_recovery,
+        self_identity,
+    )?;
     let sorted = rank_applicable_candidates(candidates, &ctx, allow_subset_candidates);
 
     if sorted.is_empty() {
@@ -172,9 +179,9 @@ pub fn finalize_freeze_round<M: MlsService>(
         conversation,
         mls,
         steward,
-        in_recovery,
         sorted,
         &ctx,
+        self_identity,
         app_id,
     )
 }
@@ -183,20 +190,22 @@ pub fn finalize_freeze_round<M: MlsService>(
 // ROUND SETUP
 // ═════════════════════════════════════════════════════════════════════════════
 
-/// Precomputed round-level data used during candidate apply.
+/// Pre-merge round state used during candidate apply.
 pub(super) struct RoundContext {
-    /// Expected MLS action set; non-MLS payloads filtered out.
-    pub(super) mls_actions: Vec<MlsProposalOutput>,
+    /// Number of MLS-producing approvals (Add/Remove). Used to filter
+    /// candidates whose proposal count doesn't match the voted set.
     pub(super) mls_count: usize,
     /// Flips the local apply's terminal result to `LeaveConversation`
     /// when our removal is in the batch.
     pub(super) self_remove_pending: bool,
     pub(super) current_epoch: u64,
+    /// RFC §Layer 3 Anti-Deadlock: any member MAY commit when set;
+    /// otherwise the commit sender must be on the steward list.
+    pub(super) in_recovery: bool,
     /// Pre-merge eligibility-filtered steward expected at
     /// `current_epoch`. Used to penalise an absent steward when a
     /// backup commits in their place.
     pub(super) live_epoch_steward_id: Option<Vec<u8>>,
-    pub(super) self_identity: Vec<u8>,
 }
 
 impl RoundContext {
@@ -205,14 +214,14 @@ impl RoundContext {
         mls: &M,
         steward: &dyn StewardListPlugin,
         current_epoch: u64,
+        in_recovery: bool,
         self_identity: &[u8],
     ) -> Result<Self, CoreError> {
-        let mls_actions: Vec<MlsProposalOutput> = conversation
+        let mls_count = conversation
             .approved_proposals()
             .values()
-            .filter_map(expected_action_for_request)
-            .collect();
-        let mls_count = mls_actions.len();
+            .filter(|req| produces_mls_action(req))
+            .count();
         let self_remove_pending = conversation.is_pending_removal(self_identity);
 
         let members = mls.members()?;
@@ -222,24 +231,23 @@ impl RoundContext {
             .map(|s| s.to_vec());
 
         Ok(Self {
-            mls_actions,
             mls_count,
             self_remove_pending,
             current_epoch,
+            in_recovery,
             live_epoch_steward_id,
-            self_identity: self_identity.to_vec(),
         })
     }
 }
 
-/// The MLS action a voted request should map to, or `None` for non-MLS
-/// payloads (emergency/election) — doubles as the "MLS-producing" filter.
-fn expected_action_for_request(req: &ConversationUpdateRequest) -> Option<MlsProposalOutput> {
-    match &req.payload {
-        Some(Payload::InviteMember(im)) => Some(MlsProposalOutput::Add(im.identity.clone())),
-        Some(Payload::RemoveMember(rm)) => Some(MlsProposalOutput::Remove(rm.identity.clone())),
-        Some(Payload::EmergencyCriteria(_)) | Some(Payload::StewardElection(_)) | None => None,
-    }
+/// True iff `req` is a membership change that produces an MLS proposal
+/// (vs governance kinds like emergency criteria or steward election,
+/// which are consensus-only).
+pub(super) fn produces_mls_action(req: &ConversationUpdateRequest) -> bool {
+    matches!(
+        req.payload.as_ref(),
+        Some(Payload::InviteMember(_) | Payload::RemoveMember(_))
+    )
 }
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Three small refactors in the same hot path, all touching how freeze and commit-apply move data around.

`clear_approved_proposals` returns `Vec<ConversationUpdateRequest>` in FIFO order; the app callback consumes via `mem::take` instead of `HashMap.values().cloned().collect()`.

`RoundContext` drops the cached `mls_actions` field. `validate_commit_candidate` iterates `conversation.approved_proposals()` directly and compares `(kind_tag, &identity)` projections — no `MlsProposalOutput` allocation, no `.to_vec()` reallocations. The 40-line scoring block is extracted into `record_winner_scores`, and `&RoundContext` is threaded uniformly through every helper (`in_recovery` and `current_epoch` no longer travel as separate parameters).

`TimingConfig ↔ ConversationConfig` wire conversion lives on `ConversationConfig` (`apply_timing` method + `impl From`); the two inline blocks at the orchestrator collapse to single calls.