### PR TITLE
refactor(error): typed noop reasons, boxed variants, identity split

### DIFF
--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -1,5 +1,7 @@
 use de_mls::{
-    app::FreezeTimeoutStatus, ds::WakuDeliveryService, protos::de_mls::messages::v1::BanRequest,
+    app::{FreezeTimeoutStatus, UserError},
+    ds::WakuDeliveryService,
+    protos::de_mls::messages::v1::BanRequest,
 };
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo};
 
@@ -7,6 +9,28 @@ use crate::{
     Gateway, UserRef,
     forwarder::{display_batch, load_member_info},
 };
+
+/// True when a [`UserError`] surfaced during the polling loop should end
+/// the loop. Exhaustive match per variant so a newly-added [`UserError`]
+/// variant forces an explicit decision at compile time. Fatal variants
+/// mean "the conversation is gone, stop polling"; non-fatal variants are
+/// transient and the loop continues.
+fn is_polling_fatal(err: &UserError) -> bool {
+    match err {
+        UserError::ConversationNotFound | UserError::AlreadyLeaving => true,
+        UserError::ConversationAlreadyExists
+        | UserError::ConversationBlocked(_)
+        | UserError::PartialFreeze
+        | UserError::Callback(_)
+        | UserError::Core(_)
+        | UserError::Consensus(_)
+        | UserError::Message(_)
+        | UserError::SystemTime(_)
+        | UserError::Signer(_)
+        | UserError::Mls(_)
+        | UserError::Identity(_) => false,
+    }
+}
 
 impl Gateway<WakuDeliveryService> {
     pub async fn create_conversation(&self, conversation_name: String) -> anyhow::Result<()> {
@@ -117,7 +141,7 @@ impl Gateway<WakuDeliveryService> {
             {
                 Ok(status) => status,
                 Err(e) => {
-                    if e.is_fatal() {
+                    if is_polling_fatal(&e) {
                         tracing::warn!(group = %conversation_name, error = %e, "polling loop exiting");
                         break;
                     }
@@ -135,7 +159,7 @@ impl Gateway<WakuDeliveryService> {
                         Ok(true) => { /* entered Freezing (+ created candidate if steward) */ }
                         Ok(false) => {}
                         Err(e) => {
-                            if e.is_fatal() {
+                            if is_polling_fatal(&e) {
                                 tracing::warn!(group = %conversation_name, error = %e, "polling loop exiting");
                                 break;
                             }

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -55,11 +55,3 @@ pub enum UserError {
     Identity(#[from] IdentityError),
 }
 
-impl UserError {
-    pub fn is_fatal(&self) -> bool {
-        matches!(
-            self,
-            UserError::ConversationNotFound | UserError::AlreadyLeaving
-        )
-    }
-}

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -5,6 +5,7 @@ use hashgraph_like_consensus::error::ConsensusError;
 
 use crate::{
     core::{CallbackError, CoreError},
+    identity::IdentityError,
     mls_crypto::MlsError,
 };
 
@@ -49,6 +50,9 @@ pub enum UserError {
 
     #[error("MLS error: {0}")]
     Mls(#[from] MlsError),
+
+    #[error("Identity error: {0}")]
+    Identity(#[from] IdentityError),
 }
 
 impl UserError {

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -54,4 +54,3 @@ pub enum UserError {
     #[error("Identity error: {0}")]
     Identity(#[from] IdentityError),
 }
-

--- a/src/app/orchestrator/freeze.rs
+++ b/src/app/orchestrator/freeze.rs
@@ -171,7 +171,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 }
 
                 if let Err(e) = self
-                    .dispatch_inbound_result(conversation_name, *result)
+                    .dispatch_inbound_result(conversation_name, result)
                     .await
                 {
                     error!(conversation = conversation_name, error = %e, "finalize result dispatch failed");

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -57,13 +57,21 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 self.on_conversation_updated(conversation_name).await
             }
             ProcessResult::LeaveConversation => self.on_leave_conversation(conversation_name).await,
-            ProcessResult::CommitCandidateReceived => {
-                self.on_commit_candidate_received(conversation_name).await
+            ProcessResult::CommitCandidateReceived { steward } => {
+                self.on_commit_candidate_received(conversation_name, &steward)
+                    .await
             }
             ProcessResult::ConversationSyncReceived(sync) => {
                 self.on_conversation_sync(conversation_name, sync).await
             }
-            ProcessResult::Noop => Ok(()),
+            ProcessResult::Noop(reason) => {
+                tracing::debug!(
+                    conversation = conversation_name,
+                    ?reason,
+                    "inbound dispatched as noop"
+                );
+                Ok(())
+            }
         }
     }
 
@@ -274,7 +282,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
     /// Peer broadcast a commit candidate. If we were in Working, enter
     /// Freezing and — if we're a steward — build our own candidate too.
-    async fn on_commit_candidate_received(&self, conversation_name: &str) -> Result<(), UserError> {
+    async fn on_commit_candidate_received(
+        &self,
+        conversation_name: &str,
+        steward: &[u8],
+    ) -> Result<(), UserError> {
+        tracing::debug!(
+            conversation = conversation_name,
+            steward = %ShortId::new(steward),
+            "candidate received from peer steward"
+        );
         let entry_arc = match self.lookup_entry(conversation_name).await {
             Some(e) => e,
             None => return Ok(()),

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -28,11 +28,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     ) -> Result<(), UserError> {
         match result {
             ProcessResult::AppMessage(msg) => {
-                self.handler.on_app_message(conversation_name, msg).await?;
+                self.handler.on_app_message(conversation_name, *msg).await?;
                 Ok(())
             }
             ProcessResult::Proposal(proposal) => {
-                self.on_incoming_proposal(conversation_name, proposal).await
+                self.on_incoming_proposal(conversation_name, *proposal).await
             }
             ProcessResult::Vote(vote) => {
                 let entry_arc = self
@@ -42,14 +42,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 let entry = entry_arc.read().await;
                 forward_incoming_vote::<P>(
                     &entry.handle.conversation,
-                    vote,
+                    *vote,
                     &*self.consensus_service,
                 )
                 .await?;
                 Ok(())
             }
             ProcessResult::MembershipChangeReceived(request) => {
-                self.handle_incoming_update_request(conversation_name, request)
+                self.handle_incoming_update_request(conversation_name, *request)
                     .await
             }
             ProcessResult::JoinedConversation(name) => self.on_joined_conversation(&name).await,
@@ -62,7 +62,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                     .await
             }
             ProcessResult::ConversationSyncReceived(sync) => {
-                self.on_conversation_sync(conversation_name, sync).await
+                self.on_conversation_sync(conversation_name, *sync).await
             }
             ProcessResult::Noop(reason) => {
                 tracing::debug!(

--- a/src/app/orchestrator/inbound.rs
+++ b/src/app/orchestrator/inbound.rs
@@ -32,7 +32,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 Ok(())
             }
             ProcessResult::Proposal(proposal) => {
-                self.on_incoming_proposal(conversation_name, *proposal).await
+                self.on_incoming_proposal(conversation_name, *proposal)
+                    .await
             }
             ProcessResult::Vote(vote) => {
                 let entry_arc = self

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,12 +1,16 @@
 //! Core library errors.
 
-use crate::mls_crypto;
+use crate::{identity::IdentityError, mls_crypto};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CoreError {
-    /// MLS error (covers identity, service, and storage variants).
+    /// MLS error (covers service, wire-format, and storage variants).
     #[error("MLS error: {0}")]
     Mls(#[from] mls_crypto::MlsError),
+
+    /// Identity-domain error (wallet-address parsing, etc.).
+    #[error("Identity error: {0}")]
+    Identity(#[from] IdentityError),
 
     #[error("Consensus error: {0}")]
     ConsensusError(#[from] hashgraph_like_consensus::error::ConsensusError),

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -22,10 +22,6 @@ pub enum CoreError {
     #[error("Message error: {0}")]
     MessageError(#[from] prost::DecodeError),
 
-    /// JSON error.
-    #[error("JSON error: {0}")]
-    JsonError(#[from] serde_json::Error),
-
     /// MLS group is not initialized for this conversation.
     #[error("MLS group not initialized")]
     MlsGroupNotInitialized,

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -196,10 +196,7 @@ fn apply_local_candidate<M: MlsService>(
         ProcessResult::ConversationUpdated
     };
     Ok(CandidateOutcome::Terminal {
-        outcome: FreezeOutcome::Applied {
-            result: Box::new(result),
-            outbound,
-        },
+        outcome: FreezeOutcome::Applied { result, outbound },
         committer,
         committed_batch,
     })
@@ -281,7 +278,7 @@ fn apply_incoming_candidate<M: MlsService>(
     };
     Ok(CandidateOutcome::Terminal {
         outcome: FreezeOutcome::Applied {
-            result: Box::new(result),
+            result,
             outbound: None,
         },
         committer: commit_sender,

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -8,8 +8,8 @@ use tracing::info;
 use super::apply::apply_in_priority_order;
 use crate::{
     core::{
-        Conversation, CoreError, FreezeBufferOutcome, ProcessResult, ScoreOp, StewardListPlugin,
-        conversation::BufferedCommitCandidate,
+        Conversation, CoreError, FreezeBufferOutcome, NoopReason, ProcessResult, ScoreOp,
+        StewardListPlugin, conversation::BufferedCommitCandidate,
     },
     mls_crypto::{MlsMessageKind, MlsService},
     protos::de_mls::messages::v1::{
@@ -66,7 +66,7 @@ pub fn process_commit_candidate<M: MlsService>(
     if conversation.freeze_round().is_none() {
         if conversation.approved_proposals_count() == 0 {
             tracing::debug!(conversation = %conversation_name, "candidate ignored: no approved proposals");
-            return Ok(ProcessResult::Noop);
+            return Ok(ProcessResult::Noop(NoopReason::NoApprovedProposals));
         }
         let epoch = mls.current_epoch()?;
         conversation.ensure_freeze_round(epoch);
@@ -75,17 +75,17 @@ pub fn process_commit_candidate<M: MlsService>(
     let commit_hash = compute_commit_hash(&candidate_msg.commit_message);
     if conversation.is_duplicate_commit_candidate(&commit_hash) {
         tracing::debug!(conversation = %conversation_name, "candidate ignored: already committed");
-        return Ok(ProcessResult::Noop);
+        return Ok(ProcessResult::Noop(NoopReason::AlreadyCommitted));
     }
 
     if candidate_msg.mls_proposals.is_empty() || candidate_msg.commit_message.is_empty() {
         tracing::debug!(conversation = %conversation_name, "candidate ignored: empty proposals or commit");
-        return Ok(ProcessResult::Noop);
+        return Ok(ProcessResult::Noop(NoopReason::EmptyCandidatePayload));
     }
 
     if candidate_msg.steward_identity.is_empty() {
         tracing::debug!(conversation = %conversation_name, "candidate ignored: empty steward_identity");
-        return Ok(ProcessResult::Noop);
+        return Ok(ProcessResult::Noop(NoopReason::EmptyStewardIdentity));
     }
 
     // Wire-level kind check — no MLS staging.
@@ -98,9 +98,16 @@ pub fn process_commit_candidate<M: MlsService>(
         Ok(MlsMessageKind::Commit)
     );
     if !proposals_ok || !commit_ok {
-        return Ok(ProcessResult::Noop);
+        tracing::debug!(
+            conversation = %conversation_name,
+            proposals_ok,
+            commit_ok,
+            "candidate ignored: wire kind mismatch (not Proposal/Commit)"
+        );
+        return Ok(ProcessResult::Noop(NoopReason::WireKindMismatch));
     }
 
+    let steward = candidate_msg.steward_identity.clone();
     let epoch = mls.current_epoch()?;
     let outcome = conversation.add_freeze_candidate(
         BufferedCommitCandidate {
@@ -119,12 +126,16 @@ pub fn process_commit_candidate<M: MlsService>(
                 total_candidates = conversation.freeze_candidate_count(),
                 "remote candidate buffered"
             );
-            Ok(ProcessResult::CommitCandidateReceived)
+            Ok(ProcessResult::CommitCandidateReceived { steward })
         }
         // Legitimate runtime states, not errors — drop quietly.
-        FreezeBufferOutcome::SelectionLocked
-        | FreezeBufferOutcome::StaleEpoch
-        | FreezeBufferOutcome::DuplicateHash => Ok(ProcessResult::Noop),
+        FreezeBufferOutcome::SelectionLocked => {
+            Ok(ProcessResult::Noop(NoopReason::SelectionLocked))
+        }
+        FreezeBufferOutcome::StaleEpoch => Ok(ProcessResult::Noop(NoopReason::StaleEpoch)),
+        FreezeBufferOutcome::DuplicateHash => {
+            Ok(ProcessResult::Noop(NoopReason::DuplicateBufferedHash))
+        }
     }
 }
 

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -11,6 +11,7 @@ use crate::{
         Conversation, CoreError, FreezeBufferOutcome, NoopReason, ProcessResult, ScoreOp,
         StewardListPlugin, conversation::BufferedCommitCandidate,
     },
+    ds::OutboundPacket,
     mls_crypto::{MlsMessageKind, MlsService},
     protos::de_mls::messages::v1::{
         CommitCandidate, ConversationUpdateRequest, conversation_update_request::Payload,
@@ -31,14 +32,12 @@ pub struct FreezeFinalizeResult {
     pub committed_batch: Vec<ConversationUpdateRequest>,
 }
 
-/// `result` is boxed because [`ProcessResult`] is a large enum (~240 bytes)
-/// and `NoCandidate` is the common case.
 #[derive(Debug, Clone, Default)]
 pub enum FreezeOutcome {
     Applied {
-        result: Box<ProcessResult>,
+        result: ProcessResult,
         /// Deferred welcomes when our own candidate won.
-        outbound: Option<crate::ds::OutboundPacket>,
+        outbound: Option<OutboundPacket>,
     },
     #[default]
     NoCandidate,

--- a/src/core/inbound.rs
+++ b/src/core/inbound.rs
@@ -10,7 +10,9 @@ use tracing::{info, warn};
 
 use crate::{
     core::{
-        conversation::Conversation, error::CoreError, freeze::process_commit_candidate,
+        conversation::Conversation,
+        error::CoreError,
+        freeze::process_commit_candidate,
         process_result::{NoopReason, ProcessResult},
     },
     identity::{ShortId, parse_wallet_to_bytes},

--- a/src/core/inbound.rs
+++ b/src/core/inbound.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 use crate::{
     core::{
         conversation::Conversation, error::CoreError, freeze::process_commit_candidate,
-        process_result::ProcessResult,
+        process_result::{NoopReason, ProcessResult},
     },
     identity::{ShortId, parse_wallet_to_bytes},
     mls_crypto::{DecryptResult, MlsService},
@@ -75,7 +75,7 @@ pub fn process_inbound<M: MlsService>(
                     owner = %ShortId::new(&proposal.proposal_owner),
                     "fast-path proposal rejected: sender is not the self-removal target"
                 );
-                return Ok(ProcessResult::Noop);
+                return Ok(ProcessResult::Noop(NoopReason::FastPathRejected));
             }
             // Drop BanRequests whose target isn't in the conversation — saves a
             // useless consensus round.
@@ -87,7 +87,7 @@ pub fn process_inbound<M: MlsService>(
                         target = %ShortId::new(&target),
                         "ban request skipped: target not a member"
                     );
-                    return Ok(ProcessResult::Noop);
+                    return Ok(ProcessResult::Noop(NoopReason::BanTargetNotMember));
                 }
             }
             app_msg.try_into()
@@ -98,14 +98,14 @@ pub fn process_inbound<M: MlsService>(
                 conversation = conversation.name(),
                 "app message ignored (wrong epoch/conversation)"
             );
-            Ok(ProcessResult::Noop)
+            Ok(ProcessResult::Noop(NoopReason::DecryptIgnored))
         }
         _ => {
             warn!(
                 conversation = conversation.name(),
                 "unexpected MLS message type on app subtopic"
             );
-            Ok(ProcessResult::Noop)
+            Ok(ProcessResult::Noop(NoopReason::UnexpectedMlsType))
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -81,4 +81,4 @@ pub use consensus_plugin::{ConsensusPlugin, DefaultConsensusPlugin, PluginConsen
 pub use plugins::ConversationPluginsFactory;
 
 // ── Process results ──
-pub use process_result::ProcessResult;
+pub use process_result::{NoopReason, ProcessResult};

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -19,22 +19,28 @@ use crate::{
 
 /// Outcome of processing one inbound packet. The app layer matches this
 /// directly and dispatches the side effects.
+///
+/// Heavy protobuf payloads (`AppMessage`, `Proposal`, `Vote`,
+/// `ConversationUpdateRequest`, `ConversationSync` — each 88–144 bytes) are
+/// boxed so the enum stays small. Without boxing the enum is sized to its
+/// largest variant and every return / clone / match-move copies ~150 bytes;
+/// with boxing it drops to ~32 bytes.
 #[derive(Debug, Clone)]
 pub enum ProcessResult {
     /// Decrypted application message ready to deliver to the UI.
-    AppMessage(AppMessage),
+    AppMessage(Box<AppMessage>),
 
     /// Consensus proposal from a peer — forward to the consensus service.
-    Proposal(Proposal),
+    Proposal(Box<Proposal>),
 
     /// Consensus vote from a peer — forward to the consensus service.
-    Vote(Vote),
+    Vote(Box<Vote>),
 
     /// We were removed from the conversation.
     LeaveConversation,
 
     /// Steward received a membership change (invite KP / ban) — start a vote.
-    MembershipChangeReceived(ConversationUpdateRequest),
+    MembershipChangeReceived(Box<ConversationUpdateRequest>),
 
     /// Successfully joined via a welcome message; carries the conversation name.
     JoinedConversation(String),
@@ -49,7 +55,7 @@ pub enum ProcessResult {
 
     /// Conversation-sync message from the steward (steward list, scores, timing,
     /// protocol flags). Meaningful only for joiners with no steward list yet.
-    ConversationSyncReceived(ConversationSync),
+    ConversationSyncReceived(Box<ConversationSync>),
 
     /// Nothing to do. The reason variant names the specific case so the
     /// app layer can match precisely instead of relying on producer-side
@@ -249,24 +255,26 @@ impl TryFrom<AppMessage> for ProcessResult {
     fn try_from(value: AppMessage) -> Result<Self, Self::Error> {
         match &value.payload {
             Some(app_message::Payload::ConversationMessage(_)) => {
-                Ok(ProcessResult::AppMessage(value))
+                Ok(ProcessResult::AppMessage(Box::new(value)))
             }
             Some(app_message::Payload::Proposal(proposal)) => {
-                Ok(ProcessResult::Proposal(proposal.clone()))
+                Ok(ProcessResult::Proposal(Box::new(proposal.clone())))
             }
-            Some(app_message::Payload::Vote(vote)) => Ok(ProcessResult::Vote(vote.clone())),
+            Some(app_message::Payload::Vote(vote)) => {
+                Ok(ProcessResult::Vote(Box::new(vote.clone())))
+            }
             Some(app_message::Payload::BanRequest(ban_request)) => Ok(
-                ProcessResult::MembershipChangeReceived(ConversationUpdateRequest {
+                ProcessResult::MembershipChangeReceived(Box::new(ConversationUpdateRequest {
                     payload: Some(conversation_update_request::Payload::RemoveMember(
                         RemoveMember {
                             identity: parse_wallet_to_bytes(ban_request.user_to_ban.as_str())?,
                         },
                     )),
-                }),
+                })),
             ),
-            Some(app_message::Payload::ConversationSync(sync)) => {
-                Ok(ProcessResult::ConversationSyncReceived(sync.clone()))
-            }
+            Some(app_message::Payload::ConversationSync(sync)) => Ok(
+                ProcessResult::ConversationSyncReceived(Box::new(sync.clone())),
+            ),
             other => {
                 tracing::debug!(
                     payload_kind = ?other.as_ref().map(std::mem::discriminant),

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -43,14 +43,52 @@ pub enum ProcessResult {
     ConversationUpdated,
 
     /// Remote commit candidate was buffered in the active freeze round.
-    CommitCandidateReceived,
+    /// `steward` is the wire-claimed identity from the candidate; the app
+    /// layer uses it for dispatch context (logging, scoring attribution).
+    CommitCandidateReceived { steward: Vec<u8> },
 
     /// Conversation-sync message from the steward (steward list, scores, timing,
     /// protocol flags). Meaningful only for joiners with no steward list yet.
     ConversationSyncReceived(ConversationSync),
 
-    /// Nothing to do (not for us, duplicate, or already handled).
-    Noop,
+    /// Nothing to do. The reason variant names the specific case so the
+    /// app layer can match precisely instead of relying on producer-side
+    /// log lines for context.
+    Noop(NoopReason),
+}
+
+/// Why a [`ProcessResult::Noop`] was returned. One variant per producer
+/// site so the dispatch layer can match on the specific case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoopReason {
+    /// Decrypted application message had no recognized payload variant.
+    UnknownAppMessage,
+    /// Fast-path proposal rejected: MLS sender doesn't match the
+    /// self-removal target.
+    FastPathRejected,
+    /// Ban request dropped: target is not a conversation member.
+    BanTargetNotMember,
+    /// Decrypt returned `Ignored` (wrong epoch or wrong conversation).
+    DecryptIgnored,
+    /// Decrypt returned a non-Application MLS payload on the app subtopic.
+    UnexpectedMlsType,
+    /// `process_commit_candidate` found no approved proposals to commit.
+    NoApprovedProposals,
+    /// Commit hash matches a recent committed batch — duplicate broadcast.
+    AlreadyCommitted,
+    /// Candidate carried an empty proposals or commit payload.
+    EmptyCandidatePayload,
+    /// Candidate carried an empty `steward_identity` field.
+    EmptyStewardIdentity,
+    /// Candidate's wire kind doesn't match Proposal/Commit.
+    WireKindMismatch,
+    /// Freeze round selection is locked — the buffer no longer accepts
+    /// candidates.
+    SelectionLocked,
+    /// Caller's epoch doesn't match the buffered round's epoch.
+    StaleEpoch,
+    /// Identical commit hash is already buffered for this round.
+    DuplicateBufferedHash,
 }
 
 // ── ViolationEvidence constructors ────────────────────────────────
@@ -229,7 +267,13 @@ impl TryFrom<AppMessage> for ProcessResult {
             Some(app_message::Payload::ConversationSync(sync)) => {
                 Ok(ProcessResult::ConversationSyncReceived(sync.clone()))
             }
-            _ => Ok(ProcessResult::Noop),
+            other => {
+                tracing::debug!(
+                    payload_kind = ?other.as_ref().map(std::mem::discriminant),
+                    "app message ignored: payload variant not consumed by core dispatch"
+                );
+                Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage))
+            }
         }
     }
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -13,7 +13,14 @@
 use alloy::{hex, primitives::Address};
 use std::str::FromStr;
 
-use crate::mls_crypto::MlsError;
+/// Errors from identity-domain helpers (currently wallet-address parsing).
+/// Kept separate from `MlsError` so identity code doesn't return an MLS
+/// error for non-MLS failures.
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    #[error("Invalid wallet address: {0}")]
+    InvalidWalletAddress(String),
+}
 
 /// Pluggable user identity.
 ///
@@ -73,10 +80,10 @@ impl Identity for WalletIdentity {
 /// let addr = parse_wallet_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")?;
 /// let addr = parse_wallet_address("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266")?;
 /// ```
-pub fn parse_wallet_address(address: &str) -> Result<Address, MlsError> {
+pub fn parse_wallet_address(address: &str) -> Result<Address, IdentityError> {
     let trimmed = address.trim();
     if trimmed.is_empty() {
-        return Err(MlsError::InvalidWalletAddress(address.to_string()));
+        return Err(IdentityError::InvalidWalletAddress(address.to_string()));
     }
 
     let hex_part = trimmed
@@ -85,11 +92,12 @@ pub fn parse_wallet_address(address: &str) -> Result<Address, MlsError> {
         .unwrap_or(trimmed);
 
     if hex_part.len() != 40 || !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(MlsError::InvalidWalletAddress(trimmed.to_string()));
+        return Err(IdentityError::InvalidWalletAddress(trimmed.to_string()));
     }
 
     let normalized = format!("0x{}", hex_part.to_ascii_lowercase());
-    Address::from_str(&normalized).map_err(|_| MlsError::InvalidWalletAddress(trimmed.to_string()))
+    Address::from_str(&normalized)
+        .map_err(|_| IdentityError::InvalidWalletAddress(trimmed.to_string()))
 }
 
 /// Format raw wallet bytes (20 bytes) as a hex string.
@@ -109,7 +117,7 @@ pub fn format_wallet_address(raw: &[u8]) -> String {
 ///
 /// Combines `parse_wallet_address` with byte extraction.
 /// Useful for creating removal requests from user input.
-pub fn parse_wallet_to_bytes(address: &str) -> Result<Vec<u8>, MlsError> {
+pub fn parse_wallet_to_bytes(address: &str) -> Result<Vec<u8>, IdentityError> {
     let addr = parse_wallet_address(address)?;
     Ok(addr.as_slice().to_vec())
 }

--- a/src/mls_crypto/error.rs
+++ b/src/mls_crypto/error.rs
@@ -40,9 +40,6 @@ pub enum MlsError {
     #[error("JSON encoding error: {0}")]
     InvalidJson(serde_json::Error),
 
-    #[error("Invalid wallet address: {0}")]
-    InvalidWalletAddress(String),
-
     // ── MLS wire format (not parameterised over storage) ──
     #[error(transparent)]
     MlsMessageDeserialize(#[from] openmls::prelude::Error),

--- a/src/mls_crypto/error.rs
+++ b/src/mls_crypto/error.rs
@@ -27,7 +27,7 @@ pub type BoxedError = Box<dyn StdError + Send + Sync>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MlsError {
-    // ── Identity ──
+    // ── Crypto + key-package serialization ──
     #[error(transparent)]
     UnableToCreateKeyPackage(#[from] KeyPackageNewError),
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -322,7 +322,7 @@ pub fn process_inbound_compat(
                 {
                     return Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage));
                 }
-                Ok(ProcessResult::MembershipChangeReceived(
+                Ok(ProcessResult::MembershipChangeReceived(Box::new(
                     ConversationUpdateRequest {
                         payload: Some(conversation_update_request::Payload::InviteMember(
                             InviteMember {
@@ -331,7 +331,7 @@ pub fn process_inbound_compat(
                             },
                         )),
                     },
-                ))
+                )))
             }
             Some(welcome_message::Payload::InvitationToJoin(_)) => {
                 panic!(
@@ -581,7 +581,7 @@ pub fn steward_add_joiner(
     let welcome_packet = match finalize.outcome {
         FreezeOutcome::Applied { result, outbound } => {
             assert!(
-                matches!(*result, ProcessResult::ConversationUpdated),
+                matches!(result, ProcessResult::ConversationUpdated),
                 "Expected ConversationUpdated, got {:?}",
                 result
             );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,8 +18,8 @@ use de_mls::core::PeerScoringService;
 use de_mls::core::default_score_deltas;
 use de_mls::core::{
     BufferedCommitCandidate, CallbackError, Conversation, ConversationEventHandler, CoreError,
-    DeterministicStewardList, FreezeOutcome, OperatingMode, ProcessResult, ProposalKind,
-    ScoringConfig, StewardListConfig, StewardListPlugin, build_key_package_message,
+    DeterministicStewardList, FreezeOutcome, NoopReason, OperatingMode, ProcessResult,
+    ProposalKind, ScoringConfig, StewardListConfig, StewardListPlugin, build_key_package_message,
     compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
 };
 use de_mls::ds::{APP_MSG_SUBTOPIC, OutboundPacket, WELCOME_SUBTOPIC};
@@ -320,7 +320,7 @@ pub fn process_inbound_compat(
                 if let Some(mls) = mls
                     && mls.is_member(&identity)
                 {
-                    return Ok(ProcessResult::Noop);
+                    return Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage));
                 }
                 Ok(ProcessResult::MembershipChangeReceived(
                     ConversationUpdateRequest {
@@ -339,13 +339,13 @@ pub fn process_inbound_compat(
                      use JoinerHandle::accept_welcome_packet"
                 );
             }
-            None => Ok(ProcessResult::Noop),
+            None => Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage)),
         }
     } else if subtopic == APP_MSG_SUBTOPIC {
         let Some(mls) = mls else {
             // Pre-refactor behaviour: app messages on a group with no MLS
             // state are silently ignored. Mirrors the User-layer dispatch.
-            return Ok(ProcessResult::Noop);
+            return Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage));
         };
         process_inbound(group, mls, payload)
     } else {

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -50,7 +50,7 @@ fn test_process_inbound_app_msg_before_mls_init() {
 
     let result =
         process_inbound_compat(&mut group, None, b"some payload", APP_MSG_SUBTOPIC).unwrap();
-    assert!(matches!(result, ProcessResult::Noop));
+    assert!(matches!(result, ProcessResult::Noop(_)));
 }
 
 #[test]
@@ -284,7 +284,7 @@ fn test_process_inbound_leave_group() {
     .unwrap();
 
     assert!(
-        matches!(remove_result, ProcessResult::CommitCandidateReceived),
+        matches!(remove_result, ProcessResult::CommitCandidateReceived { .. }),
         "Expected CommitCandidateReceived, got {:?}",
         remove_result
     );
@@ -511,7 +511,7 @@ fn test_process_inbound_raw_commit_payload_is_ignored() {
         APP_MSG_SUBTOPIC,
     )
     .unwrap();
-    assert!(matches!(result, ProcessResult::Noop));
+    assert!(matches!(result, ProcessResult::Noop(_)));
 }
 
 // ─────────────────────────── Auto-fill steward list tests ───────────────────────────

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -302,7 +302,7 @@ fn test_process_inbound_leave_group() {
     .unwrap();
     let matched = matches!(
         &finalize.outcome,
-        FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::LeaveConversation)
+        FreezeOutcome::Applied { result, .. } if matches!(*result, ProcessResult::LeaveConversation)
     );
     assert!(
         matched,
@@ -383,7 +383,7 @@ fn test_rejoin_after_eviction() {
     assert!(
         matches!(
             &finalize_joiner.outcome,
-            FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::LeaveConversation)
+            FreezeOutcome::Applied { result, .. } if matches!(*result, ProcessResult::LeaveConversation)
         ),
         "Expected LeaveConversation on joiner finalize, got {finalize_joiner:?}"
     );
@@ -400,7 +400,7 @@ fn test_rejoin_after_eviction() {
     .unwrap();
     assert!(matches!(
         &finalize_steward.outcome,
-        FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::ConversationUpdated)
+        FreezeOutcome::Applied { result, .. } if matches!(*result, ProcessResult::ConversationUpdated)
     ));
     assert!(!steward_handle.mls.is_member(&joiner_id),);
 

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -173,7 +173,7 @@ fn test_emergency_mixed_with_regular_returns_error() {
     )
     .unwrap();
     let gur = match result {
-        ProcessResult::MembershipChangeReceived(gur) => gur,
+        ProcessResult::MembershipChangeReceived(gur) => *gur,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
 
@@ -237,7 +237,7 @@ fn test_duplicate_batch_returns_noop() {
     )
     .unwrap();
     let gur = match result {
-        ProcessResult::MembershipChangeReceived(gur) => gur,
+        ProcessResult::MembershipChangeReceived(gur) => *gur,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
 
@@ -347,7 +347,7 @@ fn test_candidate_ignored_without_freeze_round() {
     )
     .unwrap();
     let gur = match result {
-        ProcessResult::MembershipChangeReceived(gur) => gur,
+        ProcessResult::MembershipChangeReceived(gur) => *gur,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
 
@@ -413,7 +413,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     )
     .unwrap();
     let gur = match result {
-        ProcessResult::MembershipChangeReceived(gur) => gur,
+        ProcessResult::MembershipChangeReceived(gur) => *gur,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
 
@@ -467,7 +467,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     .unwrap();
     let matched = matches!(
         &finalize.outcome,
-        FreezeOutcome::Applied { result, .. } if matches!(**result, ProcessResult::ConversationUpdated)
+        FreezeOutcome::Applied { result, .. } if matches!(*result, ProcessResult::ConversationUpdated)
     );
     assert!(
         matched,
@@ -531,7 +531,7 @@ fn test_backup_commit_scores_absent_steward() {
     )
     .unwrap()
     {
-        ProcessResult::MembershipChangeReceived(g) => g,
+        ProcessResult::MembershipChangeReceived(g) => *g,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
     let proposal_id: ProposalId = 90;
@@ -571,7 +571,7 @@ fn test_backup_commit_scores_absent_steward() {
 
     let matched = matches!(
         &result.outcome,
-        FreezeOutcome::Applied { result: r, .. } if matches!(**r, ProcessResult::ConversationUpdated)
+        FreezeOutcome::Applied { result: r, .. } if matches!(*r, ProcessResult::ConversationUpdated)
     );
     assert!(
         matched,
@@ -661,7 +661,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
     )
     .unwrap();
     let gur = match result {
-        ProcessResult::MembershipChangeReceived(gur) => gur,
+        ProcessResult::MembershipChangeReceived(gur) => *gur,
         other => panic!("Expected MembershipChangeReceived, got {:?}", other),
     };
 

--- a/tests/core_violations.rs
+++ b/tests/core_violations.rs
@@ -271,7 +271,7 @@ fn test_duplicate_batch_returns_noop() {
     )
     .unwrap();
     assert!(
-        matches!(r1, ProcessResult::CommitCandidateReceived),
+        matches!(r1, ProcessResult::CommitCandidateReceived { .. }),
         "Expected CommitCandidateReceived, got {:?}",
         r1
     );
@@ -285,7 +285,7 @@ fn test_duplicate_batch_returns_noop() {
     )
     .unwrap();
     assert!(
-        matches!(r2, ProcessResult::Noop),
+        matches!(r2, ProcessResult::Noop(_)),
         "Expected Noop (duplicate), got {:?}",
         r2
     );
@@ -376,7 +376,7 @@ fn test_candidate_ignored_without_freeze_round() {
     )
     .unwrap();
     assert!(
-        matches!(result, ProcessResult::Noop),
+        matches!(result, ProcessResult::Noop(_)),
         "Expected Noop (no freeze round), got {:?}",
         result
     );
@@ -448,7 +448,7 @@ fn test_commit_candidate_roundtrip_sender_identity() {
     )
     .unwrap();
     assert!(
-        matches!(result, ProcessResult::CommitCandidateReceived),
+        matches!(result, ProcessResult::CommitCandidateReceived { .. }),
         "Expected CommitCandidateReceived, got {:?}",
         result
     );
@@ -710,7 +710,7 @@ fn test_forged_steward_identity_scores_mls_sender() {
     )
     .unwrap();
     assert!(
-        matches!(result, ProcessResult::CommitCandidateReceived),
+        matches!(result, ProcessResult::CommitCandidateReceived { .. }),
         "Expected CommitCandidateReceived after wire forgery, got {:?}",
         result
     );


### PR DESCRIPTION
Four small refactors across the error-handling surface.

`ProcessResult::Noop` is no longer a catch-all: a new `NoopReason` enum with one variant per producer site (`FastPathRejected`, `NoApprovedProposals`, `WireKindMismatch`, …) tags each return so the dispatch layer can match precisely. The orchestrator's dispatcher logs the reason at debug. `ProcessResult::CommitCandidateReceived` carries the wire-claimed steward identity for the same reason — the app layer logs which peer sent the candidate. Two previously-silent producer sites (`WireKindMismatch`, unknown `AppMessage` payload) gain debug logs with context.

`ProcessResult`'s heavy protobuf variants (`AppMessage`, `Proposal`, `Vote`, `MembershipChangeReceived`, `ConversationSyncReceived`) are now boxed. The enum shrinks from 152 → 32 bytes (4.75x), making every move/clone cheaper. `FreezeOutcome::Applied.result` drops its outer `Box<ProcessResult>` wrapper — the inner enum is already small.

`MlsError::InvalidWalletAddress` was a domain leak: returned by `identity::parse_wallet_address` but typed as an MLS error. Moved into a dedicated `IdentityError` enum in `identity.rs`, with `From<IdentityError>` for both `CoreError` and `UserError` so `?` propagation keeps working at the existing call sites. The broader engine/service split inside `MlsError` is deferred to Q8 (which already restructures the MLS trait surface).

`UserError::is_fatal` was a hardcoded `matches!` list that silently defaulted new variants to non-fatal. Removed entirely from `UserError`; the gateway polling loop (the only consumer) now owns its own `is_polling_fatal` helper with an exhaustive match — the compiler now refuses to compile if a new `UserError` variant lands without an explicit fatal/non-fatal decision. Also drops the dead `CoreError::JsonError` variant (zero production refs) and fixes a stale section header in `mls_crypto/error.rs`.