### PR TITLE
refactor(consensus): drain event bus in-session via tick_deadlines

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -1,13 +1,11 @@
 use std::sync::{Arc, atomic::Ordering};
 
 use de_mls::{
-    app::{SessionRunner, UserError},
-    ds::WakuDeliveryService,
+    app::UserError, ds::WakuDeliveryService,
     protos::de_mls::messages::v1::ConversationUpdateRequest,
 };
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo, encode_hex, format_conversation_request};
 use futures::channel::mpsc::UnboundedSender;
-use hashgraph_like_consensus::events::ConsensusEventBus;
 
 use crate::{CoreCtx, Gateway, SessionRef, UserRef};
 
@@ -144,52 +142,6 @@ pub(crate) async fn push_member_scores(
 }
 
 impl Gateway<WakuDeliveryService> {
-    /// Spawn a per-conversation consensus event forwarder. One task per
-    /// conversation; it subscribes to that conversation's private event bus
-    /// and exits naturally when the bus is dropped (conversation removed).
-    pub(crate) fn spawn_consensus_forwarder(&self, user: UserRef, conversation_id: String) {
-        let evt_tx = self.evt_tx.clone();
-        let user_for_sub = user.clone();
-        let cname_owned = conversation_id.clone();
-
-        tokio::spawn(async move {
-            let Ok(session_arc) = lookup_session(&user_for_sub, &cname_owned).await else {
-                tracing::warn!(
-                    conversation = %cname_owned,
-                    "consensus forwarder: no session (conversation already gone)"
-                );
-                return;
-            };
-            let mut rx = match session_arc.read() {
-                Ok(s) => s.consensus.event_bus().subscribe(),
-                Err(_) => {
-                    tracing::warn!(
-                        conversation = %cname_owned,
-                        "consensus forwarder: session lock poisoned at subscribe"
-                    );
-                    return;
-                }
-            };
-            tracing::info!("consensus forwarder started");
-            while let Ok((conversation_id, event)) = rx.recv().await {
-                // Forward to UI
-                let _ = evt_tx.unbounded_send(AppEvent::ProposalDecided(
-                    conversation_id.clone(),
-                    event.clone(),
-                ));
-
-                if let Err(e) = SessionRunner::apply_consensus_outcome(&session_arc, event).await {
-                    tracing::warn!(group = %conversation_id, error = %e, "apply_consensus_outcome failed");
-                }
-
-                // Push refreshed approved queue, epoch history, and member scores
-                push_consensus_state(&user, &evt_tx, &conversation_id).await;
-                push_member_scores(&user, &evt_tx, &conversation_id).await;
-            }
-            tracing::info!("consensus forwarder ended");
-        });
-    }
-
     /// Spawn the pubsub forwarder once, after first successful login.
     ///
     /// Receives inbound packets from the delivery service, passes them to

--- a/crates/de_mls_gateway/src/handler.rs
+++ b/crates/de_mls_gateway/src/handler.rs
@@ -17,8 +17,13 @@ use de_mls::{
     protos::de_mls::messages::v1::{AppMessage, ConversationMessage, app_message},
 };
 use de_mls_ui_protocol::v1::{AppEvent, format_conversation_request};
+use hashgraph_like_consensus::types::ConsensusEvent;
 
-use crate::{EpochHistoryStore, MAX_EPOCH_HISTORY, forwarder::display_batch, welcome_envelope};
+use crate::{
+    EpochHistoryStore, MAX_EPOCH_HISTORY, UserRef,
+    forwarder::{display_batch, push_consensus_state, push_member_scores},
+    welcome_envelope,
+};
 
 /// Fan-out target for [`SessionEvent`]s on a single conversation. Held as
 /// `Arc` because the spawned per-session subscriber task owns a clone.
@@ -33,6 +38,9 @@ pub(crate) struct GatewaySessionFanout {
     /// `app_id` of the local user — stamped on the outbound welcome
     /// packet so the steward's own gateway dedupes the echo.
     pub app_id: Vec<u8>,
+    /// User handle. The `ConsensusReached` arm refreshes epoch state and
+    /// member scores through it.
+    pub user: UserRef,
 }
 
 impl GatewaySessionFanout {
@@ -99,6 +107,30 @@ impl GatewaySessionFanout {
                     conversation_id: conversation_id.to_string(),
                     epochs: formatted,
                 });
+            }
+            SessionEvent::ConsensusReached {
+                proposal_id,
+                approved,
+                timestamp,
+            } => {
+                let event = if approved {
+                    ConsensusEvent::ConsensusReached {
+                        proposal_id,
+                        result: true,
+                        timestamp,
+                    }
+                } else {
+                    ConsensusEvent::ConsensusFailed {
+                        proposal_id,
+                        timestamp,
+                    }
+                };
+                let _ = self.evt_tx.unbounded_send(AppEvent::ProposalDecided(
+                    conversation_id.to_string(),
+                    event,
+                ));
+                push_consensus_state(&self.user, &self.evt_tx, conversation_id).await;
+                push_member_scores(&self.user, &self.evt_tx, conversation_id).await;
             }
             SessionEvent::WelcomeReady(welcome) => {
                 let bytes = welcome.welcome_bytes.len();

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -53,7 +53,7 @@ pub use crate::bootstrap::{
 /// `Arc<MemoryDeMlsStorage>` — so per-group services share one storage
 /// (the `Arc<S>: DeMlsStorage` blanket impl makes this work). MLS
 /// credentials live on `User` and are passed in at service construction.
-type UserRef =
+pub(crate) type UserRef =
     Arc<tokio::sync::RwLock<User<DefaultConsensusPlugin, DefaultConversationPluginsFactory>>>;
 
 /// Type alias for a per-conversation session reference obtained via
@@ -261,7 +261,6 @@ impl Gateway<WakuDeliveryService> {
         let topics = self.core().topics.clone();
         let epoch_history = self.epoch_history.clone();
         let user_for_loop = user.clone();
-        let gateway_for_consensus_spawn = user.clone();
 
         tokio::spawn(async move {
             let mut active_sessions: HashMap<String, Arc<GatewaySessionFanout>> = HashMap::new();
@@ -282,12 +281,9 @@ impl Gateway<WakuDeliveryService> {
                                 epoch_history: epoch_history.clone(),
                                 transport: transport.clone(),
                                 app_id: app_id_snapshot.clone(),
+                                user: user_for_loop.clone(),
                             });
-                            active_sessions.insert(name.clone(), fanout);
-                            GATEWAY.spawn_consensus_forwarder(
-                                gateway_for_consensus_spawn.clone(),
-                                name,
-                            );
+                            active_sessions.insert(name, fanout);
                         }
                         de_mls::core::ConversationLifecycle::Removed(name) => {
                             active_sessions.remove(&name);

--- a/src/app/session/consensus.rs
+++ b/src/app/session/consensus.rs
@@ -1,10 +1,10 @@
 //! Proposal submission + voting on `SessionRunner`.
 //!
-//! Outgoing proposals run as a background task: submit to consensus, register
-//! ownership, broadcast (bundled or unbundled per `creator_vote`), resolve on
-//! timeout. The spawn helpers take `Arc<RwLock<SessionRunner>>` so the task
-//! body can release the runner lock across `.await` points without holding
-//! it during the consensus timeout sleep.
+//! Outgoing proposals submit to consensus, register ownership, broadcast
+//! (bundled or unbundled per `creator_vote`), and resolve on timeout. The
+//! methods take `Arc<RwLock<SessionRunner>>` so the body can release the
+//! runner lock across `.await` points rather than holding it through a
+//! consensus call.
 
 use std::sync::{Arc, RwLock};
 
@@ -24,7 +24,7 @@ use crate::{
     },
     core::{
         ConsensusPlugin, ConversationPluginsFactory, ProposalKind, SessionEvent, StewardListPlugin,
-        self_leave_proposal_id, target_member_id_of,
+        SyncConsensusReceiver, self_leave_proposal_id, target_member_id_of,
     },
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
@@ -221,10 +221,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         Ok(())
     }
 
-    /// Walk pending deadlines and fire any whose `fire_at` has elapsed.
-    /// Call from the caller's polling loop. Drains entries synchronously
-    /// under a brief write guard, then awaits the async fire (consensus
-    /// call or vote cast + publish) without holding the lock.
+    /// Walk pending deadlines, fire any whose `fire_at` has elapsed, then
+    /// drain the consensus event bus and dispatch each event through
+    /// `apply_consensus_outcome`. Call from the caller's polling
+    /// loop.
     pub async fn tick_deadlines(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
         let now = std::time::Instant::now();
         let (auto_votes_due, timeouts_due) = {
@@ -261,6 +261,24 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
         for proposal_id in timeouts_due {
             Self::resolve_on_timeout(arc, proposal_id).await;
+        }
+
+        loop {
+            // The bus is per-session and single-scope, so the scope on each
+            // event is always this conversation's — drained, not matched.
+            let next = {
+                let mut s = arc.write_or_err("session")?;
+                <_ as SyncConsensusReceiver<_>>::try_recv(&mut s.consensus_rx)
+            };
+            let Some((_scope, event)) = next else { break };
+            if let Err(e) = Self::apply_consensus_outcome(arc, event).await {
+                let conversation_id = arc.read_or_err("session")?.conversation_id.clone();
+                tracing::warn!(
+                    conversation = %conversation_id,
+                    error = %e,
+                    "apply_consensus_outcome failed"
+                );
+            }
         }
 
         Ok(arc.read_or_err("session")?.tick())
@@ -387,8 +405,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// shows, same path peers use).
     ///
     /// Ownership is stored *before* the vote is cast, so a single-voter
-    /// consensus transition can't race `is_owner=false` when the event
-    /// forwarder picks it up.
+    /// consensus transition can't race `is_owner=false` when the drain
+    /// loop in `tick_deadlines` picks it up.
     async fn register_new_proposal(
         arc: &Arc<RwLock<Self>>,
         np: NewProposal,

--- a/src/app/session/consensus_events.rs
+++ b/src/app/session/consensus_events.rs
@@ -5,7 +5,8 @@
 //! All five handlers are associated functions taking
 //! `Arc<RwLock<SessionRunner>>` because they fan out into steward
 //! initiations (election, deadlock ECP, score removals, buffered-update
-//! drains), each of which spawns a background proposal lifecycle.
+//! drains), each of which opens a follow-up proposal that releases the
+//! runner lock across its `.await` points.
 
 use std::sync::{Arc, RwLock};
 
@@ -30,29 +31,32 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// apply the result to the conversation, and dispatch to the correct
     /// follow-up handler (election-accepted / election-rejected /
     /// emergency-scored).
-    pub async fn apply_consensus_outcome(
+    pub(crate) async fn apply_consensus_outcome(
         arc: &Arc<RwLock<Self>>,
         event: ConsensusEvent,
     ) -> Result<SessionTick, UserError> {
-        let (proposal_id, approved) = match &event {
+        let (proposal_id, approved, timestamp) = match &event {
             ConsensusEvent::ConsensusReached {
                 proposal_id,
                 result,
-                ..
-            } => (*proposal_id, *result),
-            ConsensusEvent::ConsensusFailed { proposal_id, .. } => (*proposal_id, false),
+                timestamp,
+            } => (*proposal_id, *result, *timestamp),
+            ConsensusEvent::ConsensusFailed {
+                proposal_id,
+                timestamp,
+            } => (*proposal_id, false, *timestamp),
         };
 
-        // Proposal resolved — any pending auto-vote timer for it is moot.
-        arc.write_or_err("session")?.cancel_auto_vote(proposal_id);
-
-        // Drop re-emissions from the consensus library (timeout-path race)
-        // so we don't re-apply state or double-fire UI events.
-        let already_applied = arc
-            .read_or_err("session")?
-            .handle
-            .conversation
-            .is_consensus_outcome_applied(proposal_id);
+        let already_applied = {
+            let mut s = arc.write_or_err("session")?;
+            // Proposal resolved — any pending auto-vote timer is now moot.
+            s.cancel_auto_vote(proposal_id);
+            // Drop re-emissions from the consensus library (timeout-path
+            // race) so we don't re-apply state or double-fire UI events.
+            s.handle
+                .conversation
+                .is_consensus_outcome_applied(proposal_id)
+        };
         if already_applied {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             tracing::debug!(
@@ -60,12 +64,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 proposal_id,
                 "duplicate consensus outcome dropped"
             );
-            return Ok(arc.read_or_err("session")?.tick());
+            return Self::current_tick(arc);
         }
 
-        // Fetch payload from the per-conversation consensus storage.
+        // Surface the decision before any effects so UI fanout sees it in
+        // the same polling cycle as the state change that follows; grab the
+        // payload-fetch handles under the same read guard.
         let (consensus, conversation_id) = {
             let s = arc.read_or_err("session")?;
+            s.emit_event(SessionEvent::ConsensusReached {
+                proposal_id,
+                approved,
+                timestamp,
+            });
             (s.consensus.clone(), s.conversation_id.clone())
         };
         let scope = P::Scope::from(conversation_id.clone());
@@ -93,7 +104,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             ConsensusApplyResult::NoAction => {}
             ConsensusApplyResult::ElectionAccepted(election) => {
                 Self::handle_election_accepted(arc, election).await?;
-                return Ok(arc.read_or_err("session")?.tick());
+                return Self::current_tick(arc);
             }
             ConsensusApplyResult::RecoveryModeOpened => {
                 arc.write_or_err("session")?.handle.enter_recovery_mode();
@@ -130,19 +141,34 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             Self::handle_emergency_scored(arc, proposal_id, &payload, &score_ops).await?;
         }
 
+        Self::current_tick(arc)
+    }
+
+    /// Latest [`SessionTick`] under a brief read guard. Terminal value of
+    /// every `apply_consensus_outcome` exit path.
+    fn current_tick(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
         Ok(arc.read_or_err("session")?.tick())
     }
 
-    /// Bypass the inactivity timer and emit the resulting phase change.
-    /// Called by [`Self::apply_consensus_outcome`] for `UrgentRemoval` and
-    /// `RecoveryModeOpened` outcomes that need an immediate commit.
-    fn force_freezing_and_emit(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let event = arc.write_or_err("session")?.force_freezing();
-        if let Some(event) = event {
+    /// Emit a [`SessionEvent::PhaseChange`] for `transition`, if a state
+    /// change occurred. Shared by the freeze / election / emergency paths.
+    fn emit_phase_change(
+        arc: &Arc<RwLock<Self>>,
+        transition: Option<ConversationState>,
+    ) -> Result<(), UserError> {
+        if let Some(state) = transition {
             arc.read_or_err("session")?
-                .emit_event(SessionEvent::PhaseChange(event));
+                .emit_event(SessionEvent::PhaseChange(state));
         }
         Ok(())
+    }
+
+    /// Bypass the inactivity timer and emit the resulting phase change.
+    /// Called by `apply_consensus_outcome` for `UrgentRemoval` and
+    /// `RecoveryModeOpened` outcomes that need an immediate commit.
+    fn force_freezing_and_emit(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+        let transition = arc.write_or_err("session")?.force_freezing();
+        Self::emit_phase_change(arc, transition)
     }
 
     /// When the removal target is a current steward, fire a fresh election
@@ -217,10 +243,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 None
             }
         };
-        if let Some(event) = resumed_from_reelection {
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::PhaseChange(event));
-        }
+        Self::emit_phase_change(arc, resumed_from_reelection)?;
         {
             let s = arc.read_or_err("session")?;
             info!(
@@ -308,10 +331,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 None
             }
         };
-        if let Some(event) = resumed_event {
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::PhaseChange(event));
-        }
+        Self::emit_phase_change(arc, resumed_event)?;
 
         if let Err(e) = Self::check_and_initiate_score_removals(arc).await {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();

--- a/src/app/session/runner.rs
+++ b/src/app/session/runner.rs
@@ -12,6 +12,8 @@ use std::{
 
 use tracing::info;
 
+use hashgraph_like_consensus::events::ConsensusEventBus;
+
 use crate::{
     app::{PhaseTimer, SessionTick, UserError},
     core::{
@@ -21,6 +23,13 @@ use crate::{
     },
     ds::{OutboundPacket, SharedDeliveryService},
 };
+
+/// Receiver type the runner drains from `tick_deadlines`. Resolves to the
+/// `Receiver` associated type on the plugin's [`ConsensusEventBus`], which
+/// is bound to implement [`crate::core::SyncConsensusReceiver`].
+pub(crate) type ConsensusReceiver<P> = <<P as ConsensusPlugin>::EventBus as ConsensusEventBus<
+    <P as ConsensusPlugin>::Scope,
+>>::Receiver;
 
 /// Free helper that publishes a packet on the supplied transport. Pure sync —
 /// the caller's task does the publish directly. Multi-thread integrators
@@ -37,8 +46,6 @@ pub(crate) fn send_packet(
     Ok(())
 }
 
-/// Default capacity for a session's [`SessionEvent`] broadcast channel.
-/// Sized for bursty proposal sessions (proposals + votes + UI pushes in
 /// One pending auto-vote: cast `vote` for `proposal_id` once the wall-clock
 /// catches up to `fire_at`. Registered by `initiate_proposal` (Deferred
 /// path) and `on_incoming_proposal`; cancelled on manual vote or consensus
@@ -56,12 +63,14 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     pub(crate) handle: ConversationHandle<CP>,
     /// Per-conversation consensus service. Owns this conversation's scope
     /// in the shared storage and a private event bus. Constructed at
-    /// conversation creation by `User::build_consensus_service` and held
-    /// here so consensus calls hit the local service directly without
-    /// User-level lookup. `pub` so integrators can reach
-    /// `session.consensus.event_bus().subscribe()` for per-conv consensus
-    /// event forwarding.
+    /// conversation creation by `User::build_consensus_service`.
     pub consensus: PluginConsensus<P>,
+    /// Subscriber on `consensus.event_bus()`. Drained by
+    /// [`Self::tick_deadlines`], which dispatches each event through
+    /// `apply_consensus_outcome`. Subscribed in
+    /// [`crate::app::User::start_conversation`] before the runner is
+    /// registered.
+    pub(crate) consensus_rx: ConsensusReceiver<P>,
     /// Wall-clock anchor combined with `handle.state_machine` by
     /// coordinator methods.
     phase_timer: PhaseTimer,
@@ -100,7 +109,8 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
 impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Build a fresh runner. Creator path passes `Some(mls)`; joiner
     /// path passes `None` and attaches the MLS service later via
-    /// `handle.attach_mls`.
+    /// `handle.attach_mls`. `consensus_rx` is a subscriber on
+    /// `consensus.event_bus()`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         conversation_id: String,
@@ -112,6 +122,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         scoring: CP::Scoring,
         steward_list: CP::StewardList,
         consensus: PluginConsensus<P>,
+        consensus_rx: ConsensusReceiver<P>,
         transport: SharedDeliveryService,
         self_member_id: Arc<[u8]>,
         member_id_display: Arc<str>,
@@ -128,6 +139,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 steward_list,
             ),
             consensus,
+            consensus_rx,
             phase_timer,
             pending_auto_votes: HashMap::new(),
             pending_consensus_timeouts: HashMap::new(),
@@ -379,6 +391,7 @@ mod tests {
             commit_inactivity_duration: commit_inactivity,
             ..ConversationConfig::default()
         };
+        let (consensus, consensus_rx) = make_test_consensus_service();
         let mut runner = SessionRunner::new(
             "g".to_string(),
             Conversation::new("g"),
@@ -388,7 +401,8 @@ mod tests {
             config,
             StubScoring,
             StubStewardList::member(),
-            make_test_consensus_service(),
+            consensus,
+            consensus_rx,
             Arc::new(Mutex::new(crate::test_fixtures::UnusedTransport)),
             Arc::from(&b"test-member-id"[..]),
             Arc::from("0xtest-display"),
@@ -399,6 +413,7 @@ mod tests {
     }
 
     fn make_runner_working() -> SessionRunner<DefaultConsensusPlugin, StubPluginsFactory> {
+        let (consensus, consensus_rx) = make_test_consensus_service();
         SessionRunner::new(
             "g".to_string(),
             Conversation::new("g"),
@@ -408,7 +423,8 @@ mod tests {
             ConversationConfig::default(),
             StubScoring,
             StubStewardList::member(),
-            make_test_consensus_service(),
+            consensus,
+            consensus_rx,
             Arc::new(Mutex::new(crate::test_fixtures::UnusedTransport)),
             Arc::from(&b"test-member-id"[..]),
             Arc::from("0xtest-display"),

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, RwLock};
 
+use hashgraph_like_consensus::events::ConsensusEventBus;
 use tracing::info;
 
 use crate::{
@@ -95,6 +96,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             );
         }
         let consensus = self.build_consensus_service();
+        let consensus_rx = consensus.event_bus().subscribe();
         let session = Arc::new(RwLock::new(SessionRunner::new(
             conversation_id.to_string(),
             conversation,
@@ -105,6 +107,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             scoring,
             steward_list,
             consensus,
+            consensus_rx,
             Arc::clone(&self.transport),
             Arc::from(self.member_id.member_id_bytes()),
             Arc::from(self.member_id.member_id_display()),

--- a/src/core/consensus_plugin.rs
+++ b/src/core/consensus_plugin.rs
@@ -8,8 +8,17 @@
 
 use hashgraph_like_consensus::{
     events::ConsensusEventBus, scope::ConsensusScope, service::ConsensusService,
-    signing::ConsensusSignatureScheme, storage::ConsensusStorage,
+    signing::ConsensusSignatureScheme, storage::ConsensusStorage, types::ConsensusEvent,
 };
+
+/// Pull-side contract on an [`ConsensusEventBus`] receiver: non-blocking,
+/// returns `None` when the queue is empty.
+///
+/// `SessionRunner` holds one receiver per session and drains it from
+/// `tick_deadlines`.
+pub trait SyncConsensusReceiver<Scope: ConsensusScope>: Send + 'static {
+    fn try_recv(&mut self) -> Option<(Scope, ConsensusEvent)>;
+}
 
 /// User-level consensus backend bundle. Carries the four types the
 /// `hashgraph_like_consensus` service is parameterised by: the scope key
@@ -23,8 +32,12 @@ pub trait ConsensusPlugin: 'static {
     /// Proposal/vote persistence (default: `InMemoryConsensusStorage<String>`).
     type ConsensusStorage: ConsensusStorage<Self::Scope> + 'static;
 
-    /// Consensus-outcome delivery (default: `BroadcastEventBus<String>`).
-    type EventBus: ConsensusEventBus<Self::Scope> + 'static;
+    /// Consensus-outcome delivery (default:
+    /// [`crate::defaults::SyncEventBus<String>`]). The receiver implements
+    /// [`SyncConsensusReceiver`] so `SessionRunner` drains it from
+    /// `tick_deadlines`.
+    type EventBus: ConsensusEventBus<Self::Scope, Receiver: SyncConsensusReceiver<Self::Scope>>
+        + 'static;
 
     /// Signature scheme for authenticating votes (default:
     /// [`hashgraph_like_consensus::signing::EthereumConsensusSigner`]).

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -1,12 +1,12 @@
 //! I/O contract between the protocol layer and an integrator.
 //!
-//! Two channels:
+//! Two queues:
 //!
 //! - [`SessionEvent`] — fire-and-forget notifications about a single
-//!   conversation. Each [`crate::app::SessionRunner`] owns a broadcast sender;
-//!   integrators subscribe per session.
+//!   conversation. Each [`crate::app::SessionRunner`] holds a pending
+//!   buffer; integrators drain it once per polling cycle.
 //! - [`ConversationLifecycle`] — User-level create/remove notifications.
-//!   Integrators use this to discover new sessions and subscribe to them.
+//!   Integrators use this to discover new sessions and start draining them.
 //!
 //! Synchronous outbound transport is supplied by
 //! [`crate::ds::DeliveryService`], passed to `User` at construction and
@@ -55,6 +55,17 @@ pub enum SessionEvent {
     /// and the encrypted `ConversationSync` payload bundled for atomic
     /// delivery. The integrator owns delivery to each joiner.
     WelcomeReady(MemberWelcome),
+
+    /// A consensus session on this conversation resolved. Emitted before
+    /// the protocol effects (commit candidate, freeze, score apply, …)
+    /// run, so UI fanout sees the decision in the same polling cycle as
+    /// the state change that follows. `timestamp` is the upstream
+    /// consensus library's stamp on the bus event.
+    ConsensusReached {
+        proposal_id: u32,
+        approved: bool,
+        timestamp: u64,
+    },
 }
 
 /// User-level conversation lifecycle event. Appended to [`crate::app::User`]'s

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -75,7 +75,7 @@ pub use steward_list::{
 };
 
 // ── Consensus plug-in trait ──
-pub use consensus_plugin::{ConsensusPlugin, PluginConsensus};
+pub use consensus_plugin::{ConsensusPlugin, PluginConsensus, SyncConsensusReceiver};
 
 // ── Per-conversation plug-in bundle ──
 pub use conversation_plugins::ConversationPluginsFactory;

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -13,17 +13,19 @@
 //! - [`crate::defaults::DefaultConversationPluginsFactory`] —
 //!   `ConversationPluginsFactory` wired to the above.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex, RwLock};
 
 use hashgraph_like_consensus::{
-    events::BroadcastEventBus, signing::EthereumConsensusSigner, storage::InMemoryConsensusStorage,
+    events::ConsensusEventBus, scope::ConsensusScope, signing::EthereumConsensusSigner,
+    storage::InMemoryConsensusStorage, types::ConsensusEvent,
 };
 use openmls_rust_crypto::MemoryStorage;
 
 use crate::core::{
     ConsensusPlugin, ConversationPluginsFactory, DeterministicStewardList, PeerScoreStorage,
-    PeerScoringService, ScoringConfig, StewardListConfig, default_score_deltas,
+    PeerScoringService, ScoringConfig, StewardListConfig, SyncConsensusReceiver,
+    default_score_deltas,
 };
 use crate::mls_crypto::{DeMlsStorage, KeyPackageBytes, MlsCredentials, MlsError, OpenMlsService};
 
@@ -102,6 +104,56 @@ impl PeerScoreStorage for InMemoryPeerScoreStorage {
 }
 
 // ═══════════════════════════════════════════════════════════════════
+// Sync consensus event bus
+// ═══════════════════════════════════════════════════════════════════
+
+/// Single-consumer FIFO event bus for [`ConsensusEvent`]s. The default
+/// `EventBus` for [`DefaultConsensusPlugin`].
+///
+/// `publish` appends to the shared queue; `subscribe` hands back a
+/// receiver that pops from it. Clones share the queue.
+#[derive(Clone)]
+pub struct SyncEventBus<Scope: ConsensusScope> {
+    queue: Arc<Mutex<VecDeque<(Scope, ConsensusEvent)>>>,
+}
+
+impl<Scope: ConsensusScope> Default for SyncEventBus<Scope> {
+    fn default() -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+}
+
+impl<Scope: ConsensusScope> ConsensusEventBus<Scope> for SyncEventBus<Scope> {
+    type Receiver = SyncEventReceiver<Scope>;
+
+    fn subscribe(&self) -> Self::Receiver {
+        SyncEventReceiver {
+            queue: Arc::clone(&self.queue),
+        }
+    }
+
+    fn publish(&self, scope: Scope, event: ConsensusEvent) {
+        if let Ok(mut q) = self.queue.lock() {
+            q.push_back((scope, event));
+        }
+    }
+}
+
+/// Receiver paired with [`SyncEventBus`]. Drained via
+/// [`SyncConsensusReceiver::try_recv`].
+pub struct SyncEventReceiver<Scope: ConsensusScope> {
+    queue: Arc<Mutex<VecDeque<(Scope, ConsensusEvent)>>>,
+}
+
+impl<Scope: ConsensusScope> SyncConsensusReceiver<Scope> for SyncEventReceiver<Scope> {
+    fn try_recv(&mut self) -> Option<(Scope, ConsensusEvent)> {
+        self.queue.lock().ok()?.pop_front()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
 // Default consensus plug-in
 // ═══════════════════════════════════════════════════════════════════
 
@@ -112,7 +164,7 @@ pub struct DefaultConsensusPlugin;
 impl ConsensusPlugin for DefaultConsensusPlugin {
     type Scope = String;
     type ConsensusStorage = InMemoryConsensusStorage<String>;
-    type EventBus = BroadcastEventBus<String>;
+    type EventBus = SyncEventBus<String>;
     type Signer = EthereumConsensusSigner;
 
     fn new_storage() -> Self::ConsensusStorage {
@@ -120,7 +172,7 @@ impl ConsensusPlugin for DefaultConsensusPlugin {
     }
 
     fn new_event_bus() -> Self::EventBus {
-        BroadcastEventBus::default()
+        SyncEventBus::default()
     }
 }
 

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -86,15 +86,21 @@ pub(crate) fn make_user_from_private_key(
     User::new_with_plugins(Box::new(member_id), plugins, transport)
 }
 
-/// Build a `PluginConsensus<DefaultConsensusPlugin>` with a random signer for
-/// tests that need a `SessionRunner` but never exercise consensus operations.
-pub(crate) fn make_test_consensus_service() -> PluginConsensus<DefaultConsensusPlugin> {
-    PluginConsensus::<DefaultConsensusPlugin>::new_with_components(
+/// Build a `PluginConsensus<DefaultConsensusPlugin>` paired with a
+/// subscribed receiver for [`crate::app::SessionRunner::new`].
+pub(crate) fn make_test_consensus_service() -> (
+    PluginConsensus<DefaultConsensusPlugin>,
+    crate::defaults::SyncEventReceiver<String>,
+) {
+    use hashgraph_like_consensus::events::ConsensusEventBus;
+    let service = PluginConsensus::<DefaultConsensusPlugin>::new_with_components(
         DefaultConsensusPlugin::new_storage(),
         DefaultConsensusPlugin::new_event_bus(),
         EthereumConsensusSigner::new(PrivateKeySigner::random()),
         10,
-    )
+    );
+    let rx = service.event_bus().subscribe();
+    (service, rx)
 }
 
 /// Transport stub for tests. `publish` is unreachable (tests should never

--- a/tests/common/session_fixtures.rs
+++ b/tests/common/session_fixtures.rs
@@ -18,7 +18,6 @@ use de_mls::ds::{
     DeliveryService, DeliveryServiceError, InboundPacket, OutboundPacket, SharedDeliveryService,
 };
 use prost::Message;
-use tokio::task::JoinHandle;
 
 use crate::common::wallet::user_from_private_key;
 
@@ -239,30 +238,6 @@ pub async fn route_welcomes(
     delivered
 }
 
-/// Mirror of `de_mls_gateway::Gateway::spawn_consensus_forwarder` — one
-/// task per session that subscribes to the session's private consensus
-/// event bus and drives `apply_consensus_outcome` on each event.
-///
-/// **Required for any test that exercises consensus.** Per the per-conv-
-/// consensus refactor, each `SessionRunner.consensus` owns a fresh private
-/// event bus (see `ConsensusContext::build_service`). The library emits
-/// `ConsensusReached` to that bus, but no code in `de-mls` itself consumes
-/// it — production has the gateway run this forwarder, tests must too.
-/// Without it, proposals reach consensus but never populate
-/// `approved_proposals`.
-///
-/// Task exits naturally when the bus is dropped (conversation removed
-/// from the registry).
-pub fn spawn_consensus_forwarder(session: SessionArc) -> JoinHandle<()> {
-    use hashgraph_like_consensus::events::ConsensusEventBus;
-    tokio::spawn(async move {
-        let mut rx = session.read().unwrap().consensus.event_bus().subscribe();
-        while let Ok((_conversation_id, event)) = rx.recv().await {
-            let _ = SessionRunner::apply_consensus_outcome(&session, event).await;
-        }
-    })
-}
-
 /// Default fast-timing config for SessionRunner-driven tests. All inactivity
 /// and consensus deadlines are sub-second so a polling loop converges in a
 /// handful of rounds. Override individual fields where the test needs
@@ -306,9 +281,6 @@ pub async fn poll_once(session: &SessionArc) {
 /// `retry_round` to 1, and every subsequent `check_member_freeze` call
 /// flips to the recovery-inactivity window instead of the commit one.
 ///
-/// One consensus forwarder is spawned per session — its `JoinHandle` is
-/// detached and the task lives for the duration of the test process.
-///
 /// Panics if convergence does not happen within `MAX_ROUNDS` rounds.
 pub async fn bootstrap_joined_conversation(
     keys: &[&str],
@@ -344,13 +316,6 @@ pub async fn bootstrap_joined_conversation(
                 .unwrap()
                 .expect("session registered"),
         );
-    }
-
-    // One forwarder per session — without this, consensus events fire
-    // but `approved_proposals` never populates. JoinHandles are detached;
-    // tasks live for the duration of the test process.
-    for s in &sessions {
-        std::mem::drop(spawn_consensus_forwarder(s.clone()));
     }
 
     // Joiners send KPs. Drain joiner transports, deliver to creator.


### PR DESCRIPTION
Move consensus-outcome iteration out of the gateway's spawned forwarder task into `SessionRunner::tick_deadlines`, backed by a per-session synchronous event bus (`SyncEventBus`/`SyncConsensusReceiver`). The external forwarder was a leftover from when one consensus service backed the whole gateway; each session now owns its bus and drains it inline once per polling cycle.

Add `SessionEvent::ConsensusReached { proposal_id, approved, timestamp }`, emitted before the protocol effects run so integrators see the decision in the same cycle as the state change that follows. The gateway just fans it out instead of running its own subscriber.

Also slim `apply_consensus_outcome`: merge redundant lock acquisitions, and factor the duplicated phase-change emission and tick-return into shared `emit_phase_change` / `current_tick` helpers. Drop the dead foreign-scope guard (the per-session bus is single-scope) and demote the now crate-internal entry point to `pub(crate)`.
