### PR TITLE
fix(steward): regenerate small-group list locally without election

### DIFF
--- a/src/app/session/freeze.rs
+++ b/src/app/session/freeze.rs
@@ -165,11 +165,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     // delivers both atomically. The joiner replays the
                     // sync payload through `process_inbound_packet`
                     // after MLS attaches.
-                    welcome.conversation_sync_bytes = arc
-                        .write_or_err("session")?
-                        .build_conversation_sync_packet()?
-                        .map(|p| p.payload)
-                        .unwrap_or_default();
+                    //
+                    // Reconcile the list to the just-merged epoch first, so a
+                    // small group's sync carries the regenerated, joiner-
+                    // inclusive list rather than the pre-commit one. A large
+                    // group leaves the list for the post-commit election.
+                    welcome.conversation_sync_bytes = {
+                        let mut s = arc.write_or_err("session")?;
+                        let _ = s.reconcile_steward_list()?;
+                        s.build_conversation_sync_packet()?
+                            .map(|p| p.payload)
+                            .unwrap_or_default()
+                    };
                     arc.read_or_err("session")?
                         .emit_event(SessionEvent::WelcomeReady(welcome));
                 }

--- a/src/app/session/inbound.rs
+++ b/src/app/session/inbound.rs
@@ -232,8 +232,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     /// A commit merged. Sync scoring + pending-update buffers, transition to
-    /// Working, and run steward housekeeping (auto-fill, election kick-off,
-    /// buffered-update drain). The commit author's `SuccessfulCommit`
+    /// Working, and run steward housekeeping (list reconcile, election
+    /// kick-off, buffered-update drain). The commit author's `SuccessfulCommit`
     /// reward is emitted by `finalize_freeze_round`, not here.
     async fn on_conversation_updated(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let mls_members = {

--- a/src/app/session/steward.rs
+++ b/src/app/session/steward.rs
@@ -26,6 +26,18 @@ use crate::{
     },
 };
 
+/// Outcome of reconciling the steward list to the current epoch — see
+/// [`SessionRunner::reconcile_steward_list`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StewardListReconcile {
+    /// List already covered the epoch, or a small group's list was
+    /// reinstalled deterministically. No consensus round needed.
+    Settled,
+    /// The group is large enough (`members > sn_max`) that the list is a
+    /// genuine subset peers must agree: the caller runs the voted election.
+    NeedsElection,
+}
+
 impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     // ── Public API ───────────────────────────────────────────────────
 
@@ -53,37 +65,52 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
     }
 
-    /// Post-epoch-advance sequence: (1) auto-fill if membership dropped
-    /// below `sn_min`, (2) kick off an election if the list is exhausted.
-    /// Election-initiate failures are logged, not surfaced — conversation
-    /// state may legitimately reject a new proposal right now.
+    /// Post-epoch-advance reconcile: bring the steward list to the new epoch.
+    /// Small groups regenerate locally (no consensus); only a large group,
+    /// whose list is a genuine subset, opens a voted election. Election-init
+    /// failures are logged, not surfaced — conversation state may legitimately
+    /// reject a new proposal right now.
     pub async fn steward_list_housekeeping(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        arc.write_or_err("session")?.try_auto_fill_steward_list()?;
-        if let Err(e) = Self::initiate_steward_election(arc, false).await {
+        let reconcile = arc.write_or_err("session")?.reconcile_steward_list()?;
+        if reconcile == StewardListReconcile::NeedsElection
+            && let Err(e) = Self::initiate_steward_election(arc, false).await
+        {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             info!(conversation = %conv_name, error = %e, "election initiation deferred");
         }
         Ok(())
     }
 
-    /// Regenerate the steward list at the current epoch against the current
-    /// MLS member set — same effect as a successful election. Intended for
-    /// tests and administrative tooling.
-    pub fn regenerate_steward_list(&mut self) -> Result<(), UserError> {
-        let mls = self.handle.expect_mls()?;
-        let current_epoch = mls.current_epoch()?;
-        let members = mls.members()?;
+    /// Reconcile the steward list to the current MLS epoch. No-op if the
+    /// installed list still covers this epoch. Otherwise the group size
+    /// decides: small (`members <= sn_max`, every member is a steward) →
+    /// install the deterministic list locally, no vote; large (`members >
+    /// sn_max`) → return [`StewardListReconcile::NeedsElection`] for the
+    /// caller to run a voted election. The local install is the same list a
+    /// successful election would yield: every node — the committer before it
+    /// builds the `ConversationSync`, and each peer on its own commit-merge —
+    /// computes the identical list.
+    pub(crate) fn reconcile_steward_list(&mut self) -> Result<StewardListReconcile, UserError> {
+        let (current_epoch, members) = {
+            let mls = self.handle.expect_mls()?;
+            (mls.current_epoch()?, mls.members()?)
+        };
+        if !self.handle.steward_list.is_exhausted(current_epoch) {
+            return Ok(StewardListReconcile::Settled);
+        }
+        if self.handle.steward_list.election_required(members.len()) {
+            return Ok(StewardListReconcile::NeedsElection);
+        }
         let sn = self
             .handle
             .steward_list
             .config()
             .compute_list_size(members.len());
-        // Test/admin regenerate — no election, no retry seed.
         let _events = self
             .handle
             .steward_list
             .install_list(current_epoch, &members, sn, 0)?;
-        Ok(())
+        Ok(StewardListReconcile::Settled)
     }
 
     /// Drop Add entries whose target is now a member and Remove entries
@@ -496,20 +523,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Bundle YES — the proposer's observation that the deadlock is
         // real is their vote.
         Self::initiate_proposal(arc, request, CreatorVote::Yes).await?;
-        Ok(())
-    }
-
-    // ── Private ──────────────────────────────────────────────────────
-
-    /// Plug-in decides whether the current list still satisfies its
-    /// policy (the deterministic impl re-installs when membership drops
-    /// below `sn_min`). Coordinator just supplies `epoch` + `members`
-    /// and drains events.
-    fn try_auto_fill_steward_list(&mut self) -> Result<(), UserError> {
-        let mls = self.handle.expect_mls()?;
-        let epoch = mls.current_epoch()?;
-        let members = mls.members()?;
-        let _events = self.handle.steward_list.maybe_auto_fill(epoch, &members)?;
         Ok(())
     }
 }

--- a/src/app/session/tick.rs
+++ b/src/app/session/tick.rs
@@ -12,6 +12,38 @@ use std::time::Duration;
 /// [`crate::app::SessionRunner::drain_events`] independently. Keeping
 /// the two concerns separate lets internal session methods emit events
 /// without coordinating with op return values.
+///
+/// # What the deadline means
+///
+/// `next_wakeup_in` is never a measure of the call's own success — it is
+/// "the soonest moment something in this session will fire on its own (a
+/// timer), so wake me by then." The returning op determines *which*
+/// deadline that is:
+///
+/// - **Ops that open a consensus session** — [`User::initiate_proposal`],
+///   [`User::add_member`], [`User::process_ban_request`],
+///   [`User::process_user_vote`], [`User::initiate_self_leave`]: the tick
+///   is when the local auto-vote casts or the consensus session times out.
+///   Informally, "wait until we vote, then the steward commits."
+/// - **Lifecycle / poll ops** — [`User::accept_welcome`],
+///   [`User::process_inbound_packet`], [`User::poll_session`],
+///   [`User::tick_deadlines`]: the tick is the earliest of *all* currently
+///   armed deadlines (commit-inactivity, freeze, recovery-inactivity,
+///   `PendingJoin` expiry) after this op re-derived them.
+/// - **Pure sends** — [`User::send_app_message`], [`User::send_key_package`]:
+///   nothing time-based is started, so the tick is usually `None`.
+///
+/// [`User::initiate_proposal`]: crate::app::User::initiate_proposal
+/// [`User::add_member`]: crate::app::User::add_member
+/// [`User::process_ban_request`]: crate::app::User::process_ban_request
+/// [`User::process_user_vote`]: crate::app::User::process_user_vote
+/// [`User::initiate_self_leave`]: crate::app::User::initiate_self_leave
+/// [`User::accept_welcome`]: crate::app::User::accept_welcome
+/// [`User::process_inbound_packet`]: crate::app::User::process_inbound_packet
+/// [`User::poll_session`]: crate::app::User::poll_session
+/// [`User::tick_deadlines`]: crate::app::User::tick_deadlines
+/// [`User::send_app_message`]: crate::app::User::send_app_message
+/// [`User::send_key_package`]: crate::app::User::send_key_package
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SessionTick {
     pub next_wakeup_in: Option<Duration>,

--- a/src/core/steward_list/deterministic.rs
+++ b/src/core/steward_list/deterministic.rs
@@ -205,18 +205,6 @@ impl StewardListPlugin for DeterministicStewardList {
         })
     }
 
-    fn maybe_auto_fill(
-        &mut self,
-        epoch: u64,
-        members: &[Vec<u8>],
-    ) -> Result<Vec<StewardListEvent>, CoreError> {
-        if members.len() >= self.config.sn_min {
-            return Ok(Vec::new());
-        }
-        let sn = self.config.compute_list_size(members.len());
-        self.install_list(epoch, members, sn, 0)
-    }
-
     fn bump_retry(&mut self) -> Vec<StewardListEvent> {
         self.retry_round = self.retry_round.saturating_add(1);
         if self.retry_round > self.max_retries {
@@ -410,37 +398,14 @@ mod tests {
     }
 
     #[test]
-    fn maybe_auto_fill_installs_full_member_set_when_below_sn_min() {
-        let cfg = StewardListConfig::new(3, 5).unwrap();
-        let mut p = DeterministicStewardList::empty(b"g".to_vec(), cfg);
-        let mems = members(&[1, 2]); // below sn_min = 3
-
-        let events = p.maybe_auto_fill(5, &mems).unwrap();
-        assert_eq!(
-            events,
-            vec![StewardListEvent::ListInstalled {
-                epoch: 5,
-                retry_round: 0,
-                len: 2,
-            }]
-        );
-
-        let list = p.current_list().expect("auto-fill installed a list");
-        assert_eq!(list.len(), 2);
-        assert_eq!(list.retry_round(), 0);
-        for m in &mems {
-            assert!(list.contains(m), "auto-filled list must cover every member");
-        }
-    }
-
-    #[test]
-    fn maybe_auto_fill_no_op_when_at_or_above_sn_min() {
-        let cfg = StewardListConfig::new(2, 5).unwrap();
-        let mut p = DeterministicStewardList::empty(b"g".to_vec(), cfg);
-        let mems = members(&[1, 2, 3]); // ≥ sn_min = 2
-
-        let events = p.maybe_auto_fill(0, &mems).unwrap();
-        assert!(events.is_empty(), "no-op above sn_min");
-        assert!(p.current_list().is_none(), "no list installed");
+    fn election_required_only_above_sn_max() {
+        let cfg = StewardListConfig::new(2, 3).unwrap();
+        let p = DeterministicStewardList::empty(b"g".to_vec(), cfg);
+        // At or below sn_max the list is the full membership — regenerate
+        // locally, no vote.
+        assert!(!p.election_required(1));
+        assert!(!p.election_required(3));
+        // Above sn_max the list is a genuine subset — needs a voted election.
+        assert!(p.election_required(4));
     }
 }

--- a/src/core/steward_list/plugin.rs
+++ b/src/core/steward_list/plugin.rs
@@ -54,6 +54,15 @@ pub trait StewardListPlugin {
     /// `true` when `epoch` is outside `[election_epoch, election_epoch + len)`.
     fn is_exhausted(&self, epoch: u64) -> bool;
 
+    /// Whether a steward list over `member_count` members needs a *voted*
+    /// election. `false` while every member is a steward (`member_count <=
+    /// sn_max`): the list is then the full membership, fully determined and
+    /// regenerated deterministically with no consensus. `true` once the list
+    /// is a genuine subset, where peers must agree which members serve.
+    fn election_required(&self, member_count: usize) -> bool {
+        member_count > self.config().sn_max
+    }
+
     /// See [`StewardList::epoch_steward`].
     fn epoch_steward<F: Fn(&[u8]) -> bool>(&self, epoch: u64, eligible: F) -> Option<&[u8]>;
 
@@ -71,20 +80,13 @@ pub trait StewardListPlugin {
     fn election_proposer<F: Fn(&[u8]) -> bool>(&self, eligible: F) -> Option<&[u8]>;
 
     /// Build and install a list of size `sn`. `retry_round` seeds the SHA256 sort
-    /// and is stored on the list; use `0` for bootstrap / auto-fill.
+    /// and is stored on the list; use `0` for bootstrap and deterministic regen.
     fn install_list(
         &mut self,
         epoch: u64,
         candidate_pool: &[Vec<u8>],
         sn: usize,
         retry_round: u32,
-    ) -> Result<Vec<StewardListEvent>, CoreError>;
-
-    /// Re-install when `members.len() < sn_min` (everyone becomes a steward).
-    fn maybe_auto_fill(
-        &mut self,
-        epoch: u64,
-        members: &[Vec<u8>],
     ) -> Result<Vec<StewardListEvent>, CoreError>;
 
     /// `true` if `proposed` matches [`StewardList::validate`] for these parameters.

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -254,13 +254,6 @@ impl StewardListPlugin for StubStewardList {
     ) -> Result<Vec<StewardListEvent>, crate::core::CoreError> {
         unreachable!()
     }
-    fn maybe_auto_fill(
-        &mut self,
-        _: u64,
-        _: &[Vec<u8>],
-    ) -> Result<Vec<StewardListEvent>, crate::core::CoreError> {
-        unreachable!()
-    }
     fn validate_proposed(
         &self,
         _: &[Vec<u8>],

--- a/tests/common/session_fixtures.rs
+++ b/tests/common/session_fixtures.rs
@@ -201,16 +201,21 @@ pub async fn route_welcomes(
     use de_mls::core::SessionEvent;
     use de_mls::protos::de_mls::messages::v1::MemberWelcome;
 
-    let mut welcomes: Vec<MemberWelcome> = Vec::new();
-    for s in sessions {
+    // Pair each welcome with its emitter's app_id. The bundled sync is the
+    // welcomer's outbound packet, so the replayed `InboundPacket` must carry
+    // the welcomer's app_id — replaying it under the joiner's own app_id
+    // would trip `process_inbound_packet`'s echo-dedup and silently drop it.
+    let mut welcomes: Vec<(MemberWelcome, Vec<u8>)> = Vec::new();
+    for (i, s) in sessions.iter().enumerate() {
+        let welcomer_app_id = users[i].0.app_id().to_vec();
         for event in s.read().unwrap().drain_events() {
             if let SessionEvent::WelcomeReady(welcome) = event {
-                welcomes.push(welcome);
+                welcomes.push((welcome, welcomer_app_id.clone()));
             }
         }
     }
     let mut delivered = 0;
-    for welcome in welcomes {
+    for (welcome, welcomer_app_id) in welcomes {
         let conv_name = sessions
             .first()
             .map(|s| s.read().unwrap().conversation_id().to_string())
@@ -227,7 +232,7 @@ pub async fn route_welcomes(
                         welcome.conversation_sync_bytes.clone(),
                         de_mls::ds::APP_MSG_SUBTOPIC,
                         &conv_name,
-                        u.app_id().to_vec(),
+                        welcomer_app_id.clone(),
                         0,
                     );
                     let _ = u.process_inbound_packet(sync_pkt).await;
@@ -272,14 +277,16 @@ pub async fn poll_once(session: &SessionArc) {
 /// in [`ConversationState::Working`] AND no packets have flowed for
 /// `QUIET_THRESHOLD` consecutive polling rounds.
 ///
-/// The quiet-period exit matters: the InviteMember commit's
-/// `on_conversation_updated` handler fires
-/// `steward_list_housekeeping` → `initiate_steward_election` right as
-/// joiners reach Working. If bootstrap exits the instant joiners are
-/// Working, that election gets orphaned — its `consensus_timeout` fires
-/// without enough votes, `handle_election_rejected` bumps the creator's
-/// `retry_round` to 1, and every subsequent `check_member_freeze` call
-/// flips to the recovery-inactivity window instead of the commit one.
+/// The quiet-period exit matters when the group is large enough to need a
+/// voted steward election (`members > sn_max`): the InviteMember commit's
+/// `on_conversation_updated` handler fires `steward_list_housekeeping` →
+/// `initiate_steward_election` right as joiners reach Working. If bootstrap
+/// exits the instant joiners are Working, that election gets orphaned — its
+/// `consensus_timeout` fires without enough votes, `handle_election_rejected`
+/// bumps the creator's `retry_round` to 1, and every subsequent
+/// `check_member_freeze` call flips to the recovery-inactivity window instead
+/// of the commit one. Small groups (`members <= sn_max`) reconcile the list
+/// locally with no election, so they have nothing to orphan.
 ///
 /// Panics if convergence does not happen within `MAX_ROUNDS` rounds.
 pub async fn bootstrap_joined_conversation(
@@ -335,11 +342,12 @@ pub async fn bootstrap_joined_conversation(
 
     // Drive every session's polling and shuttle outbound packets until
     // every joiner is Working AND no packets have flowed for several
-    // consecutive rounds. The quiet-period check is important: the
-    // post-commit `steward_list_housekeeping` fires an election right
-    // as joiners reach Working; if we exit immediately the election
-    // gets orphaned (its consensus_timeout fires with no votes counted,
-    // and the next session-poll observes `retry_round = 1`).
+    // consecutive rounds. The quiet-period check matters for large groups:
+    // post-commit `steward_list_housekeeping` fires a voted election right
+    // as joiners reach Working; if we exit immediately the election gets
+    // orphaned (its consensus_timeout fires with no votes counted, and the
+    // next session-poll observes `retry_round = 1`). Small groups reconcile
+    // the list locally with no election.
     const QUIET_THRESHOLD: usize = 3;
     let mut quiet_rounds = 0;
     for round in 0..MAX_ROUNDS {

--- a/tests/steward_small_group_rotation.rs
+++ b/tests/steward_small_group_rotation.rs
@@ -1,0 +1,154 @@
+//! Steward-list rotation reconciles by group size.
+//!
+//! `members <= sn_max`: every member is a steward, so the list is the full
+//! membership — each node regenerates it deterministically on commit-merge,
+//! no consensus round. `members > sn_max`: the list is a genuine subset, so
+//! peers run a voted election to agree which members serve.
+//!
+//! The small-group path is the fix for the doomed-election storm: a 2-member
+//! group used to open a steward election that could never reach quorum, time
+//! out, and escalate to a `Deadlock` ECP. These tests pin both branches.
+
+use std::time::Duration;
+
+use de_mls::app::MemberRole;
+use de_mls::core::{ConversationState, StewardListConfig};
+use de_mls::member_id::MemberId;
+
+mod common;
+use common::WalletMemberId;
+use common::session_fixtures::{
+    SessionArc, TestUser, TransportHandle, bootstrap_joined_conversation, fast_test_config,
+    poll_once, settle_for, to_inbound,
+};
+
+const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+
+/// Sorted member ids carrying any steward role.
+fn steward_set(roles: &[(Vec<u8>, MemberRole)]) -> Vec<Vec<u8>> {
+    let mut ids: Vec<Vec<u8>> = roles
+        .iter()
+        .filter(|(_, role)| {
+            matches!(
+                role,
+                MemberRole::EpochSteward | MemberRole::BackupSteward | MemberRole::Steward
+            )
+        })
+        .map(|(id, _)| id.clone())
+        .collect();
+    ids.sort();
+    ids
+}
+
+fn member_id(users: &[(TestUser, TransportHandle)], idx: usize) -> Vec<u8> {
+    WalletMemberId::from_hex(&users[idx].0.member_id_string())
+        .member_id_bytes()
+        .to_vec()
+}
+
+/// Drain every transport and feed each packet to every user, mirroring the
+/// gateway relay. Echo-dedup drops a user's own packets.
+async fn relay_all(users: &[(TestUser, TransportHandle)]) {
+    let mut packets = Vec::new();
+    for (_, h) in users {
+        packets.extend(h.lock().unwrap().drain_packets());
+    }
+    for p in &packets {
+        for (u, _) in users {
+            let _ = u.process_inbound_packet(to_inbound(p)).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn small_group_regenerates_locally_no_election() {
+    // n = 2, sn_max = 3 → every member is a steward; the list is the full
+    // membership, installed locally with no vote.
+    let users = bootstrap_joined_conversation(
+        &[ALICE, BOB],
+        "sg",
+        fast_test_config(),
+        StewardListConfig::new(1, 3).unwrap(),
+    )
+    .await;
+
+    let alice_session = users[0].0.lookup_entry("sg").unwrap().unwrap();
+    let bob_session = users[1].0.lookup_entry("sg").unwrap().unwrap();
+
+    let mut both = vec![member_id(&users, 0), member_id(&users, 1)];
+    both.sort();
+
+    // Both nodes installed the identical full-membership list: every member
+    // is a steward, no plain `Member`.
+    let alice_roles = alice_session.read().unwrap().get_member_roles().unwrap();
+    let bob_roles = bob_session.read().unwrap().get_member_roles().unwrap();
+    assert_eq!(
+        steward_set(&alice_roles),
+        both,
+        "alice's steward list must be the full membership"
+    );
+    assert_eq!(
+        steward_set(&bob_roles),
+        both,
+        "bob's steward list must match alice's exactly"
+    );
+
+    // No election ever ran: a doomed steward election would bump retry_round
+    // off zero and (after retries) escalate to a Deadlock ECP, flipping state
+    // out of Working. Poll well past every inactivity/consensus deadline and
+    // assert sustained stability.
+    for _ in 0..20 {
+        settle_for(Duration::from_millis(40)).await;
+        for s in [&alice_session, &bob_session] {
+            poll_once(s).await;
+        }
+        relay_all(&users).await;
+    }
+
+    for (label, s) in [("alice", &alice_session), ("bob", &bob_session)] {
+        let (_, retry) = s.read().unwrap().get_epoch_and_retry().unwrap();
+        assert_eq!(
+            retry, 0,
+            "{label} retry_round must stay 0 (no election fired)"
+        );
+        assert_eq!(
+            s.read().unwrap().get_conversation_state(),
+            ConversationState::Working,
+            "{label} must stay Working (no Deadlock ECP storm)"
+        );
+    }
+}
+
+#[tokio::test]
+async fn large_group_elects_proper_subset() {
+    // n = 3, sn_max = 2 → the list is a genuine subset; a voted election
+    // picks exactly two stewards, agreed by every node.
+    let users = bootstrap_joined_conversation(
+        &[ALICE, BOB, CHARLIE],
+        "lg",
+        fast_test_config(),
+        StewardListConfig::new(1, 2).unwrap(),
+    )
+    .await;
+
+    let sessions: Vec<SessionArc> = (0..3)
+        .map(|i| users[i].0.lookup_entry("lg").unwrap().unwrap())
+        .collect();
+
+    let reference = steward_set(&sessions[0].read().unwrap().get_member_roles().unwrap());
+    assert_eq!(
+        reference.len(),
+        2,
+        "sn_max=2 with 3 members must elect a 2-steward subset, got {reference:?}"
+    );
+    for (i, s) in sessions.iter().enumerate() {
+        let roles = s.read().unwrap().get_member_roles().unwrap();
+        assert_eq!(
+            steward_set(&roles),
+            reference,
+            "node {i} must agree on the elected steward subset"
+        );
+    }
+}


### PR DESCRIPTION
A conversation whose membership fits within `sn_max` is the full steward list — every member already serves. Such a group used to open a voted steward election on every commit-merge, which could never reach quorum in a small group, timed out, and escalated to a `Deadlock` ECP storm.

`reconcile_steward_list` now decides by size. When `members <= sn_max` it reinstalls the deterministic list locally with no consensus round; only a genuine subset (`members > sn_max`) opens a voted election. Every node computes the identical list, so a joiner that picks the list up from the welcome-bundled `ConversationSync` matches the committer.

This removes the now-redundant `maybe_auto_fill` plug-in path and the dead `regenerate_steward_list` public method (absorbed into the reconcile). A test-fixture bug surfaced in passing: `route_welcomes` replayed the welcome-bundled sync under the joiner's own app_id, so echo-dedup silently dropped it — it only ever passed because the election path used to supply the list. Fixed to replay under the welcomer's app_id, matching the gateway.

New `steward_small_group_rotation` tests pin both branches: a 2-member group converges to an identical full-membership list with no election (retry stays 0, state stays Working), and a 3-member `sn_max=2` group still elects an agreed 2-steward subset.