### PR TITLE
refactor(consensus): clean up consensus-plugin surface

### DIFF
--- a/src/app/session/consensus_bridge.rs
+++ b/src/app/session/consensus_bridge.rs
@@ -16,7 +16,7 @@ use tracing::info;
 
 use crate::{
     app::error::UserError,
-    core::{ConsensusPlugin, CoreError, PluginConsensus, self_leave_proposal_id},
+    core::{ConsensusPlugin, ConsensusServiceFor, CoreError, self_leave_proposal_id},
     protos::de_mls::messages::v1::{
         AppMessage, ConversationUpdateRequest, RemoveMember, conversation_update_request,
     },
@@ -47,7 +47,7 @@ pub(crate) async fn submit_proposal<P: ConsensusPlugin>(
     conversation_id: &str,
     request: &ConversationUpdateRequest,
     creator_id: &[u8],
-    consensus: &PluginConsensus<P>,
+    consensus: &ConsensusServiceFor<P>,
     params: ProposalParams,
 ) -> Result<(u32, AppMessage), CoreError> {
     let create_request = CreateProposalRequest::new(
@@ -95,7 +95,7 @@ pub(crate) async fn cast_vote<P>(
     conversation_id: &str,
     proposal_id: u32,
     vote: bool,
-    consensus: &PluginConsensus<P>,
+    consensus: &ConsensusServiceFor<P>,
 ) -> Result<AppMessage, UserError>
 where
     P: ConsensusPlugin,
@@ -119,7 +119,7 @@ where
 pub(crate) async fn forward_incoming_proposal<P: ConsensusPlugin>(
     conversation_id: &str,
     proposal: Proposal,
-    consensus: &PluginConsensus<P>,
+    consensus: &ConsensusServiceFor<P>,
 ) -> Result<(), UserError> {
     let scope = P::Scope::from(conversation_id.to_string());
     consensus
@@ -148,7 +148,7 @@ pub(crate) async fn forward_incoming_proposal<P: ConsensusPlugin>(
 pub(crate) async fn forward_incoming_vote<P: ConsensusPlugin>(
     conversation_id: &str,
     vote: Vote,
-    consensus: &PluginConsensus<P>,
+    consensus: &ConsensusServiceFor<P>,
     outcome_applied_locally: bool,
 ) -> Result<(), CoreError> {
     let proposal_id = vote.proposal_id;
@@ -197,7 +197,7 @@ pub(crate) async fn forward_incoming_vote<P: ConsensusPlugin>(
 pub(crate) async fn submit_self_leave_proposal<P>(
     conversation_id: &str,
     self_member_id: &[u8],
-    consensus: &PluginConsensus<P>,
+    consensus: &ConsensusServiceFor<P>,
     params: ProposalParams,
 ) -> Result<Option<(u32, AppMessage)>, UserError>
 where

--- a/src/app/session/runner.rs
+++ b/src/app/session/runner.rs
@@ -17,9 +17,9 @@ use hashgraph_like_consensus::events::ConsensusEventBus;
 use crate::{
     app::{PhaseTimer, SessionTick, UserError},
     core::{
-        ConsensusPlugin, Conversation, ConversationConfig, ConversationPluginsFactory,
-        ConversationQueues, ConversationState, ConversationStateMachine, PluginConsensus,
-        SessionEvent,
+        ConsensusPlugin, ConsensusServiceFor, Conversation, ConversationConfig,
+        ConversationPluginsFactory, ConversationQueues, ConversationState,
+        ConversationStateMachine, SessionEvent,
     },
     ds::{OutboundPacket, SharedDeliveryService},
 };
@@ -64,7 +64,7 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     /// Per-conversation consensus service. Owns this conversation's scope
     /// in the shared storage and a private event bus. Constructed at
     /// conversation creation by `User::build_consensus_service`.
-    pub consensus: PluginConsensus<P>,
+    pub consensus: ConsensusServiceFor<P>,
     /// Subscriber on `consensus.event_bus()`. Drained by
     /// [`Self::tick_deadlines`], which dispatches each event through
     /// `apply_consensus_outcome`. Subscribed in
@@ -120,7 +120,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         config: ConversationConfig,
         scoring: CP::Scoring,
         steward_list: CP::StewardList,
-        consensus: PluginConsensus<P>,
+        consensus: ConsensusServiceFor<P>,
         consensus_rx: ConsensusReceiver<P>,
         transport: SharedDeliveryService,
         self_member_id: Arc<[u8]>,

--- a/src/app/user/plugins/consensus_context.rs
+++ b/src/app/user/plugins/consensus_context.rs
@@ -1,13 +1,13 @@
 //! [`ConsensusContext`] — User-level consensus-plugin state.
 //!
 //! Holds the shared storage + signer once on the User; mints fresh
-//! per-conversation [`PluginConsensus`] services on demand and tears down a
+//! per-conversation [`ConsensusServiceFor`] services on demand and tears down a
 //! conversation's scope on leave. Each per-conv service gets its own
 //! private event bus (per upstream "service shape" recommendation).
 
 use hashgraph_like_consensus::storage::ConsensusStorage;
 
-use crate::core::{ConsensusPlugin, PluginConsensus};
+use crate::core::{ConsensusPlugin, ConsensusServiceFor};
 
 pub struct ConsensusContext<P: ConsensusPlugin> {
     storage: P::ConsensusStorage,
@@ -29,8 +29,8 @@ impl<P: ConsensusPlugin> ConsensusContext<P> {
     /// storage so all per-conv services share one underlying
     /// persistence (scope-keyed); clones the signer; mints a fresh private
     /// event bus.
-    pub fn build_service(&self) -> PluginConsensus<P> {
-        PluginConsensus::<P>::new_with_components(
+    pub fn build_service(&self) -> ConsensusServiceFor<P> {
+        ConsensusServiceFor::<P>::new_with_components(
             self.storage.clone(),
             P::new_event_bus(),
             self.signer.clone(),

--- a/src/app/user/state.rs
+++ b/src/app/user/state.rs
@@ -14,7 +14,7 @@ use crate::{
         UserPlugins,
     },
     core::{
-        ConsensusPlugin, ConversationLifecycle, ConversationPluginsFactory, PluginConsensus,
+        ConsensusPlugin, ConsensusServiceFor, ConversationLifecycle, ConversationPluginsFactory,
         ScoringConfig, SessionEvent, StewardListConfig,
     },
     ds::SharedDeliveryService,
@@ -476,7 +476,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
     /// Build a fresh per-conversation `ConsensusService` via the User's
     /// `ConsensusContext`.
-    pub fn build_consensus_service(&self) -> PluginConsensus<P> {
+    pub fn build_consensus_service(&self) -> ConsensusServiceFor<P> {
         self.plugins.consensus.build_service()
     }
 

--- a/src/core/consensus.rs
+++ b/src/core/consensus.rs
@@ -1,12 +1,6 @@
 //! Pure consensus result application.
 //!
-//! Updates a [`ConversationQueues`] in response to a consensus
-//! outcome. No I/O, no service calls. Score deltas for emergency outcomes
-//! are derived alongside in [`crate::core::emergency_score_ops`].
-//!
-//! App-layer helpers that wire consensus events to the UI and transport
-//! (`submit_proposal`, `cast_vote`, `relay_incoming_proposal`,
-//! `forward_incoming_vote`) live in `crate::app::consensus_bridge`.
+//! Updates a [`ConversationQueues`] in response to a consensus outcome.
 
 use tracing::info;
 
@@ -19,11 +13,7 @@ use crate::{
 };
 
 /// Outcome of applying a consensus result to a conversation. Each variant
-/// encodes exactly the follow-up the app caller must perform — no
-/// independent boolean flags.
-///
-/// Score deltas for emergency outcomes are derived separately by
-/// [`crate::core::emergency_score_ops`].
+/// encodes exactly the follow-up the app caller must perform
 #[derive(Debug, Clone)]
 pub enum ConsensusApplyResult {
     /// Nothing for the caller to do. The contract is "no follow-up", not

--- a/src/core/consensus_plugin.rs
+++ b/src/core/consensus_plugin.rs
@@ -1,61 +1,67 @@
-//! [`ConsensusPlugin`] — user-level bundle of consensus-library backends
-//! (scope key, proposal/vote storage, event bus). One plug-in per `User`
-//! today; per-conversation consensus is on the roadmap and will expand
-//! this surface. The concrete consensus service type is derived via
-//! [`PluginConsensus<P>`] — the voting algorithm itself is fixed.
+//! Consensus backend "plugin" contract.
 //!
-//! Reference impl: [`crate::defaults::DefaultConsensusPlugin`].
+//! [`ConsensusPlugin`] pins the concrete types used by the consensus library:
+//! - **`Scope`**: the per-conversation partition key
+//! - **storage**: proposal/vote persistence
+//! - **event bus**: delivery of consensus outcomes
+//! - **signer**: vote authentication (must match across peers)
+//!
+//! The app layer constructs a per-conversation [`ConsensusServiceFor<P>`] using
+//! these associated types and factories.
+//!
+//! Reference implementation: [`crate::defaults::DefaultConsensusPlugin`].
 
 use hashgraph_like_consensus::{
     events::ConsensusEventBus, scope::ConsensusScope, service::ConsensusService,
     signing::ConsensusSignatureScheme, storage::ConsensusStorage, types::ConsensusEvent,
 };
 
-/// Pull-side contract on an [`ConsensusEventBus`] receiver: non-blocking,
-/// returns `None` when the queue is empty.
+/// Pull-side contract for a [`ConsensusEventBus`] receiver: non-blocking.
+///
+/// Returns `None` when the queue is empty.
 ///
 /// `SessionRunner` holds one receiver per session and drains it from
 /// `tick_deadlines`.
-pub trait SyncConsensusReceiver<Scope: ConsensusScope>: Send + 'static {
+pub trait SyncConsensusReceiver<Scope: ConsensusScope>: Send {
     fn try_recv(&mut self) -> Option<(Scope, ConsensusEvent)>;
 }
 
-/// User-level consensus backend bundle. Carries the four types the
-/// `hashgraph_like_consensus` service is parameterised by: the scope key
-/// (one consensus partition per conversation), proposal/vote storage,
-/// outcome event bus, and the signature scheme used to authenticate votes.
-/// The concrete service is materialised via [`PluginConsensus`].
-pub trait ConsensusPlugin: 'static {
-    /// Conversation-identifier type used as consensus scope (default: `String`).
-    type Scope: ConsensusScope + From<String> + 'static;
+/// User-level consensus backend bundle.
+///
+/// This trait only selects the concrete types the consensus library runs with:
+/// scope key, storage, event bus, and signer. The app layer decides how to
+/// instantiate and share those pieces across conversations, then builds a
+/// per-conversation service via [`ConsensusServiceFor`].
+pub trait ConsensusPlugin {
+    /// Conversation identifier type used as a consensus scope key.
+    type Scope: ConsensusScope + From<String>;
 
-    /// Proposal/vote persistence (default: `InMemoryConsensusStorage<String>`).
-    type ConsensusStorage: ConsensusStorage<Self::Scope> + 'static;
+    /// Proposal/vote persistence.
+    type ConsensusStorage: ConsensusStorage<Self::Scope>;
 
-    /// Consensus-outcome delivery (default:
-    /// [`crate::defaults::SyncEventBus<String>`]). The receiver implements
-    /// [`SyncConsensusReceiver`] so `SessionRunner` drains it from
-    /// `tick_deadlines`.
-    type EventBus: ConsensusEventBus<Self::Scope, Receiver: SyncConsensusReceiver<Self::Scope>>
-        + 'static;
+    /// Consensus-outcome delivery (event bus).
+    ///
+    /// The receiver must implement [`SyncConsensusReceiver`] so the app can
+    /// drain it from a tick loop.
+    type EventBus: ConsensusEventBus<Self::Scope, Receiver: SyncConsensusReceiver<Self::Scope>>;
 
-    /// Signature scheme for authenticating votes (default:
-    /// [`hashgraph_like_consensus::signing::EthereumConsensusSigner`]).
-    /// All peers on a network must agree.
+    /// Signature scheme for authenticating votes.
+    ///
+    /// All peers on a network must agree on this.
     type Signer: ConsensusSignatureScheme + Clone + 'static;
 
-    /// Build a fresh storage.
+    /// Build storage.
     fn new_storage() -> Self::ConsensusStorage;
 
-    /// Build a fresh event bus for one conversation. Each per-conv
-    /// `ConsensusService` owns its own bus; subscribers automatically see
-    /// only that conversation's events.
+    /// Build an event bus.
+    ///
+    /// Most app wiring uses one bus per conversation.
     fn new_event_bus() -> Self::EventBus;
 }
 
 /// Concrete consensus service derived from a [`ConsensusPlugin`]'s
 /// associated types.
-pub type PluginConsensus<P> = ConsensusService<
+pub type ConsensusServiceFor<P> = ConsensusService<
     <P as ConsensusPlugin>::Scope,
     <P as ConsensusPlugin>::ConsensusStorage,
     <P as ConsensusPlugin>::EventBus,

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -4,7 +4,6 @@ use crate::mls_crypto;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CoreError {
-    /// MLS error (covers service, wire-format, and storage variants).
     #[error("MLS error: {0}")]
     Mls(#[from] mls_crypto::MlsError),
 
@@ -14,19 +13,15 @@ pub enum CoreError {
     #[error("System time error: {0}")]
     SystemTimeError(#[from] std::time::SystemTimeError),
 
-    /// Message encoding/decoding error.
     #[error("Message error: {0}")]
     MessageError(#[from] prost::DecodeError),
 
-    /// MLS group is not initialized for this conversation.
     #[error("MLS group not initialized")]
     MlsGroupNotInitialized,
 
-    /// Caller is not a steward of this conversation.
-    #[error("caller is not a steward")]
+    #[error("Caller is not a steward")]
     NotASteward,
 
-    /// No proposals available for the requested operation.
     #[error("No proposals available")]
     NoProposals,
 
@@ -42,12 +37,6 @@ pub enum CoreError {
     #[error("Invalid config size")]
     InvalidConfigSize,
 
-    /// Governance proposals (emergency criteria, steward election) slipped into
-    /// the approved queue — `apply_consensus_result` should have removed them
-    /// before `create_commit_candidate` ran.
-    #[error(
-        "Non-MLS proposals found in approved queue (ids: {proposal_ids:?}). \
-         They should have been removed by apply_consensus_result."
-    )]
+    #[error("Non-MLS proposals found in approved queue (ids: {proposal_ids:?})")]
     UnexpectedNonMlsProposals { proposal_ids: Vec<u32> },
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -75,7 +75,7 @@ pub use steward_list::{
 };
 
 // ── Consensus plug-in trait ──
-pub use consensus_plugin::{ConsensusPlugin, PluginConsensus, SyncConsensusReceiver};
+pub use consensus_plugin::{ConsensusPlugin, ConsensusServiceFor, SyncConsensusReceiver};
 
 // ── Per-conversation plug-in bundle ──
 pub use conversation_plugins::ConversationPluginsFactory;

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -113,17 +113,6 @@ impl ViolationEvidence {
         }
     }
 
-    /// Steward didn't commit within the threshold duration.
-    pub fn censorship_inactivity(target: Vec<u8>, epoch: u64) -> Self {
-        Self {
-            violation_type: ViolationType::CensorshipInactivity as i32,
-            target_member_id: target,
-            evidence_payload: Vec::new(),
-            epoch,
-            creator_member_id: Vec::new(),
-        }
-    }
-
     /// Member's peer score dropped to or below the removal threshold.
     pub fn score_below_threshold(target: Vec<u8>, epoch: u64, current_score: i64) -> Self {
         Self {

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -157,8 +157,9 @@ impl<Scope: ConsensusScope> SyncConsensusReceiver<Scope> for SyncEventReceiver<S
 // Default consensus plug-in
 // ═══════════════════════════════════════════════════════════════════
 
-/// In-memory consensus plug-in suitable for tests and simple deployments.
-/// The [`ConsensusPlugin`] trait itself is defined in [`crate::core`].
+/// In-memory consensus backend for tests and simple deployments.
+///
+/// Implements [`crate::core::ConsensusPlugin`].
 pub struct DefaultConsensusPlugin;
 
 impl ConsensusPlugin for DefaultConsensusPlugin {

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -17,8 +17,8 @@ use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use crate::{
     app::{ConsensusContext, ConversationConfig, User, UserPlugins},
     core::{
-        ConsensusPlugin, ConversationPluginsFactory, ElectionDecision, PeerScoringPlugin,
-        PluginConsensus, ScoreOp, ScoreSnapshot, ScoringConfig, StewardList, StewardListConfig,
+        ConsensusPlugin, ConsensusServiceFor, ConversationPluginsFactory, ElectionDecision,
+        PeerScoringPlugin, ScoreOp, ScoreSnapshot, ScoringConfig, StewardList, StewardListConfig,
         StewardListEvent, StewardListPlugin,
     },
     defaults::{DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage},
@@ -86,14 +86,14 @@ pub(crate) fn make_user_from_private_key(
     User::new_with_plugins(Box::new(member_id), plugins, transport)
 }
 
-/// Build a `PluginConsensus<DefaultConsensusPlugin>` paired with a
+/// Build a `ConsensusServiceFor<DefaultConsensusPlugin>` paired with a
 /// subscribed receiver for [`crate::app::SessionRunner::new`].
 pub(crate) fn make_test_consensus_service() -> (
-    PluginConsensus<DefaultConsensusPlugin>,
+    ConsensusServiceFor<DefaultConsensusPlugin>,
     crate::defaults::SyncEventReceiver<String>,
 ) {
     use hashgraph_like_consensus::events::ConsensusEventBus;
-    let service = PluginConsensus::<DefaultConsensusPlugin>::new_with_components(
+    let service = ConsensusServiceFor::<DefaultConsensusPlugin>::new_with_components(
         DefaultConsensusPlugin::new_storage(),
         DefaultConsensusPlugin::new_event_bus(),
         EthereumConsensusSigner::new(PrivateKeySigner::random()),


### PR DESCRIPTION
Follow-up cleanup that the #100 squash missed.

Renames the `PluginConsensus<P>` type alias to `ConsensusServiceFor<P>` — the name now reads as "the concrete consensus service derived from a plugin's associated types" rather than implying the plugin is the service. Propagated across the app session layer, the User consensus context, and test fixtures.

Slims the `ConsensusPlugin` trait: drops the unnecessary `'static`/`Send` bounds from the trait and its associated types, and rewrites the trait/module docs to describe what the plugin selects (scope, storage, event bus, signer) versus what the app layer instantiates.

Also trims stale doc comments on `CoreError` variants and the `consensus` module, and removes the dead `ViolationEvidence::censorship_inactivity` constructor.

No behavior change; rename and doc/dead-code cleanup only.
