### PR TITLE
fix(add-member): deliver welcome and apply commit on proposer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,28 +821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,20 +3383,17 @@ dependencies = [
 
 [[package]]
 name = "hashgraph-like-consensus"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d846ed9b2da5aa98872bbc7a0c143ccb7a4b2145d41bb4d5f9ad298030b38d5"
+checksum = "b6505a8e7032d4060a54c22578807de3f3ef5eedf1fde62fc3b58354d42e91c1"
 dependencies = [
  "alloy",
  "alloy-signer",
- "async-stream",
- "futures",
  "parking_lot",
  "prost",
  "prost-build",
  "sha2",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "uuid",
 ]
@@ -7060,7 +7035,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ indexmap = "2.14.0"
 
 libc = { version = "0.2", optional = true }
 prost = "0.13.5"
-hashgraph-like-consensus = "0.4.0"
+hashgraph-like-consensus = "0.5.0"
 
 [dev-dependencies]
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "time"] }

--- a/apps/de_mls_desktop_ui/Cargo.toml
+++ b/apps/de_mls_desktop_ui/Cargo.toml
@@ -27,7 +27,7 @@ parking_lot = "0.12.5"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2.3"
-hashgraph-like-consensus = "0.4.0"
+hashgraph-like-consensus = "0.5.0"
 prost = "0.13.5"
 alloy = { version = "1.0.37", default-features = false, features = [
     "signer-local",

--- a/crates/de_mls_gateway/Cargo.toml
+++ b/crates/de_mls_gateway/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.41"
 tokio-util = { version = "0.7", features = ["rt"] }
 thiserror = "2.0"
 
-hashgraph-like-consensus = "0.4.0"
+hashgraph-like-consensus = "0.5.0"
 alloy = { version = "1.0.37", default-features = false, features = [
     "signer-local",
 ] }

--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -184,7 +184,7 @@ impl Gateway<WakuDeliveryService> {
                 if pkt.subtopic == de_mls::ds::WELCOME_SUBTOPIC
                     && let Some(mw) = crate::welcome_envelope::decode(&pkt.payload)
                 {
-                    let accepted = user.write().await.accept_welcome(&mw.welcome_bytes).await;
+                    let accepted = user.write().await.accept_welcome(&mw.welcome_bytes);
                     match accepted {
                         Ok(_) if !mw.conversation_sync_bytes.is_empty() => {
                             // Replay the bundled ConversationSync
@@ -199,8 +199,7 @@ impl Gateway<WakuDeliveryService> {
                                 pkt.app_id.clone(),
                                 pkt.timestamp,
                             );
-                            if let Err(e) = user.read().await.process_inbound_packet(sync_pkt).await
-                            {
+                            if let Err(e) = user.read().await.process_inbound_packet(sync_pkt) {
                                 tracing::warn!(
                                     group = %conversation_id,
                                     error = %e,
@@ -220,7 +219,7 @@ impl Gateway<WakuDeliveryService> {
                     continue;
                 }
 
-                if let Err(e) = user.read().await.process_inbound_packet(pkt).await {
+                if let Err(e) = user.read().await.process_inbound_packet(pkt) {
                     tracing::error!(group = %conversation_id, error = %e, "process_inbound_packet failed");
                 }
 

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -46,8 +46,7 @@ impl Gateway<WakuDeliveryService> {
         user_ref
             .write()
             .await
-            .start_conversation(&conversation_id, true)
-            .await?;
+            .start_conversation(&conversation_id, true)?;
         core.topics.add_many(&conversation_id)?;
         tracing::info!(group = %conversation_id, "group ready, subtopics subscribed");
 
@@ -70,12 +69,11 @@ impl Gateway<WakuDeliveryService> {
         user_ref
             .write()
             .await
-            .start_conversation(&conversation_id, false)
-            .await?;
+            .start_conversation(&conversation_id, false)?;
         core.topics.add_many(&conversation_id)?;
         let key_package = user_ref.read().await.generate_key_package()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::send_key_package(&session, key_package).await?;
+        SessionRunner::send_key_package(&session, key_package)?;
         tracing::info!(group = %conversation_id, "key package sent");
 
         // Phase 1 (PendingJoin): Poll every 5s until joined or timed out
@@ -119,7 +117,6 @@ impl Gateway<WakuDeliveryService> {
                             .read()
                             .await
                             .finalize_self_leave(&group_name_clone)
-                            .await
                         {
                             tracing::error!(group = %group_name_clone, error = %e, "pending-join cleanup failed");
                         }
@@ -158,14 +155,14 @@ impl Gateway<WakuDeliveryService> {
                 tracing::warn!(group = %conversation_id, "polling loop: session gone");
                 break;
             };
-            if let Err(e) = SessionRunner::tick_deadlines(&session).await {
+            if let Err(e) = SessionRunner::tick_deadlines(&session) {
                 if is_polling_fatal(&e) {
                     tracing::warn!(group = %conversation_id, error = %e, "polling loop exiting (tick_deadlines)");
                     break;
                 }
                 tracing::warn!(group = %conversation_id, error = %e, "tick_deadlines failed");
             }
-            let freeze_outcome = match SessionRunner::poll_freeze_status(&session).await {
+            let freeze_outcome = match SessionRunner::poll_freeze_status(&session) {
                 Ok(o) => o,
                 Err(e) => {
                     if is_polling_fatal(&e) {
@@ -177,19 +174,14 @@ impl Gateway<WakuDeliveryService> {
             };
             let (freeze_status, dispatch) = freeze_outcome;
             if matches!(dispatch, DispatchOutcome::LeaveRequested) {
-                if let Err(e) = user
-                    .read()
-                    .await
-                    .finalize_self_leave(&conversation_id)
-                    .await
-                {
+                if let Err(e) = user.read().await.finalize_self_leave(&conversation_id) {
                     tracing::error!(group = %conversation_id, error = %e, "self-leave cleanup failed");
                 }
                 break;
             }
             match freeze_status {
                 FreezeTimeoutStatus::NotFreezing => {
-                    match SessionRunner::check_member_freeze(&session).await {
+                    match SessionRunner::check_member_freeze(&session) {
                         Ok(true) => { /* entered Freezing (+ created candidate if steward) */ }
                         Ok(false) => {}
                         Err(e) => {
@@ -241,7 +233,7 @@ impl Gateway<WakuDeliveryService> {
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::send_app_message(&session, message.into_bytes()).await?;
+        SessionRunner::send_app_message(&session, message.into_bytes())?;
         tracing::debug!(group = %conversation_id, "app message sent");
         Ok(())
     }
@@ -261,7 +253,7 @@ impl Gateway<WakuDeliveryService> {
             conversation_id: conversation_id.clone(),
         };
 
-        SessionRunner::process_ban_request(&session, ban_request).await?;
+        SessionRunner::process_ban_request(&session, ban_request)?;
 
         Ok(())
     }
@@ -274,7 +266,7 @@ impl Gateway<WakuDeliveryService> {
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::process_user_vote(&session, proposal_id, vote).await?;
+        SessionRunner::process_user_vote(&session, proposal_id, vote)?;
         Ok(())
     }
 
@@ -283,8 +275,7 @@ impl Gateway<WakuDeliveryService> {
         user_ref
             .write()
             .await
-            .leave_conversation(&conversation_id)
-            .await?;
+            .leave_conversation(&conversation_id)?;
         Ok(())
     }
 

--- a/crates/de_mls_ui_protocol/Cargo.toml
+++ b/crates/de_mls_ui_protocol/Cargo.toml
@@ -10,5 +10,5 @@ serde_json = "1.0"
 serde = { version = "1.0.163", features = ["derive"] }
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
 thiserror = "2.0.17"
-hashgraph-like-consensus = "0.4.0"
+hashgraph-like-consensus = "0.5.0"
 de-mls = { path = "../../" }

--- a/src/app/session/consensus.rs
+++ b/src/app/session/consensus.rs
@@ -3,7 +3,7 @@
 //! Outgoing proposals submit to consensus, register ownership, broadcast
 //! (bundled or unbundled per `creator_vote`), and resolve on timeout. The
 //! methods take `Arc<RwLock<SessionRunner>>` so the body can release the
-//! runner lock across `.await` points rather than holding it through a
+//! runner lock across `` points rather than holding it through a
 //! consensus call.
 
 use std::sync::{Arc, RwLock};
@@ -92,7 +92,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// [`Self::tick_deadlines`] once the deadline elapses.
     ///
     /// `creator_vote` — see [`CreatorVote`] for wire shape and local UI behavior.
-    pub async fn initiate_proposal(
+    pub fn initiate_proposal(
         arc: &Arc<RwLock<Self>>,
         request: ConversationUpdateRequest,
         creator_vote: CreatorVote,
@@ -107,8 +107,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 kind,
                 creator_vote,
             },
-        )
-        .await?;
+        )?;
         Ok(())
     }
 
@@ -116,7 +115,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// `RemoveMember`): buffer it so every member has a durable record, then
     /// promote it to a voting proposal if this node is the current epoch
     /// steward and the conversation accepts new proposals.
-    pub async fn handle_incoming_update_request(
+    pub fn handle_incoming_update_request(
         arc: &Arc<RwLock<Self>>,
         request: ConversationUpdateRequest,
     ) -> Result<(), UserError> {
@@ -181,7 +180,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // let the banner drive the steward's vote like any other member.
             // `check_proposal_allowed` may still reject (active emergency
             // etc.) — leave the entry in the buffer for next rotation.
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred).await {
+            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred) {
                 info!(conversation = %conversation_id, error = %e, "proposal deferred");
             }
         }
@@ -191,7 +190,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Cast a manual vote on behalf of the local member. Blocked in
     /// `Freezing` and `Selection`; cancels any pending auto-vote so the
     /// manual choice wins.
-    pub async fn process_user_vote(
+    pub fn process_user_vote(
         arc: &Arc<RwLock<Self>>,
         proposal_id: u32,
         vote: bool,
@@ -208,7 +207,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Manual vote takes precedence over the pending auto-vote timer.
         arc.write_or_err("session")?.cancel_auto_vote(proposal_id);
 
-        let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus).await?;
+        let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus)?;
         let packet = {
             let mut s = arc.write_or_err("session")?;
             let app_id = Arc::clone(&s.app_id);
@@ -225,7 +224,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// drain the consensus event bus and dispatch each event through
     /// `apply_consensus_outcome`. Call from the caller's polling
     /// loop.
-    pub async fn tick_deadlines(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
+    pub fn tick_deadlines(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
         let now = std::time::Instant::now();
         let (auto_votes_due, timeouts_due) = {
             let mut s = arc.write_or_err("session")?;
@@ -251,7 +250,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         };
 
         for (proposal_id, vote) in auto_votes_due {
-            if let Err(e) = Self::cast_auto_vote(arc, proposal_id, vote).await {
+            if let Err(e) = Self::cast_auto_vote(arc, proposal_id, vote) {
                 tracing::debug!(
                     proposal_id,
                     error = %e,
@@ -260,7 +259,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
         }
         for proposal_id in timeouts_due {
-            Self::resolve_on_timeout(arc, proposal_id).await;
+            Self::resolve_on_timeout(arc, proposal_id);
         }
 
         loop {
@@ -271,7 +270,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 <_ as SyncConsensusReceiver<_>>::try_recv(&mut s.consensus_rx)
             };
             let Some((_scope, event)) = next else { break };
-            if let Err(e) = Self::apply_consensus_outcome(arc, event).await {
+            if let Err(e) = Self::apply_consensus_outcome(arc, event) {
                 let conversation_id = arc.read_or_err("session")?.conversation_id.clone();
                 tracing::warn!(
                     conversation = %conversation_id,
@@ -293,7 +292,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// after a successful submit short-circuits on the local pending-leave
     /// check, and a retransmit dedupes inside the consensus library via
     /// the deterministic [`self_leave_proposal_id`].
-    pub async fn initiate_self_leave(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn initiate_self_leave(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let self_member_id = Arc::clone(&arc.read_or_err("session")?.self_member_id);
 
         let (already_pending, conversation_id) = {
@@ -348,8 +347,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 consensus_timeout,
                 liveness_criteria_yes: true,
             },
-        )
-        .await?;
+        )?;
 
         // Dedup (`ProposalAlreadyExist`) — another submit is already driving
         // this proposal_id. Our voting entry resolves on that session.
@@ -409,10 +407,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Ownership is stored *before* the vote is cast, so a single-voter
     /// consensus transition can't race `is_owner=false` when the drain
     /// loop in `tick_deadlines` picks it up.
-    async fn register_new_proposal(
-        arc: &Arc<RwLock<Self>>,
-        np: NewProposal,
-    ) -> Result<u32, UserError> {
+    fn register_new_proposal(arc: &Arc<RwLock<Self>>, np: NewProposal) -> Result<u32, UserError> {
         let NewProposal {
             request,
             expected_voters,
@@ -452,8 +447,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 consensus_timeout,
                 liveness_criteria_yes,
             },
-        )
-        .await?;
+        )?;
 
         {
             let mut s = arc.write_or_err("session")?;
@@ -478,9 +472,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 // `cast_vote` helper sends Vote-only messages, which would
                 // leave peers without the proposal.
                 let scope = P::Scope::from(conversation_id.clone());
-                let proposal = consensus
-                    .cast_vote_and_get_proposal(&scope, proposal_id, true)
-                    .await?;
+                let proposal = consensus.cast_vote_and_get_proposal(&scope, proposal_id, true)?;
                 info!(
                     conversation = %conversation_id,
                     proposal_id,
@@ -542,7 +534,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// as the proposal is in our resolved-proposals cache — we downgrade the
     /// log accordingly and warn only for truly unknown IDs (indicates a logic
     /// bug, not a race).
-    async fn resolve_on_timeout(arc: &Arc<RwLock<Self>>, proposal_id: u32) {
+    fn resolve_on_timeout(arc: &Arc<RwLock<Self>>, proposal_id: u32) {
         let (consensus, conversation_id) = match arc.read_or_err("session") {
             Ok(s) => (s.consensus.clone(), s.conversation_id.clone()),
             Err(e) => {
@@ -554,16 +546,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let still_active = consensus
             .storage()
             .get_active_proposals(&scope)
-            .await
             .map(|active| active.iter().any(|p| p.proposal_id == proposal_id))
             .unwrap_or(false);
         if !still_active {
             return;
         }
-        match consensus
-            .handle_consensus_timeout(&scope, proposal_id)
-            .await
-        {
+        match consensus.handle_consensus_timeout(&scope, proposal_id) {
             Ok(_) => {}
             Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
                 let resolved_locally = arc
@@ -596,7 +584,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Cast the auto-vote on behalf of the local member. Same broadcast
     /// path as a manual vote — the library sees the two identically.
-    async fn cast_auto_vote(
+    fn cast_auto_vote(
         arc: &Arc<RwLock<Self>>,
         proposal_id: u32,
         vote: bool,
@@ -605,7 +593,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             let s = arc.read_or_err("session")?;
             (s.consensus.clone(), s.conversation_id.clone())
         };
-        let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus).await?;
+        let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus)?;
         let packet = {
             let mut s = arc.write_or_err("session")?;
             let app_id = Arc::clone(&s.app_id);

--- a/src/app/session/consensus.rs
+++ b/src/app/session/consensus.rs
@@ -141,7 +141,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
             let inserted = s
                 .conversation
-                .conversation
+                .queues
                 .insert_pending_update(request.clone(), current_epoch);
 
             // Only the epoch steward proposes immediately. The buffer
@@ -149,7 +149,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             let self_member_id = Arc::clone(&s.self_member_id);
             let eligible = s
                 .conversation
-                .conversation
+                .queues
                 .steward_eligibility(&members_for_rotation);
             let is_es = s
                 .conversation
@@ -157,7 +157,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == &*self_member_id);
             let state = s.conversation.current_state();
-            let total = s.conversation.conversation.pending_update_count();
+            let total = s.conversation.queues.pending_update_count();
             let should = is_es && state == ConversationState::Working;
             let name = s.conversation_id.clone();
             (inserted, is_es, state, total, should, name)
@@ -298,9 +298,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let (already_pending, conversation_id) = {
             let s = arc.read_or_err("session")?;
             (
-                s.conversation
-                    .conversation
-                    .is_pending_self_leave(&self_member_id),
+                s.conversation.queues.is_pending_self_leave(&self_member_id),
                 s.conversation_id.clone(),
             )
         };
@@ -328,7 +326,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let (consensus, proposal_expiration, consensus_timeout) = {
             let mut s = arc.write_or_err("session")?;
             s.conversation
-                .conversation
+                .queues
                 .insert_voting_proposal(proposal_id, request);
             (
                 s.consensus.clone(),
@@ -379,7 +377,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 if !kind.is_emergency() && !kind.is_steward_election() {
                     return Err(UserError::ConversationBlocked(state.to_string()));
                 }
-                if self.conversation.conversation.partial_freeze_blocks(kind) {
+                if self.conversation.queues.partial_freeze_blocks(kind) {
                     return Err(UserError::PartialFreeze);
                 }
             }
@@ -387,7 +385,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 return Err(UserError::ConversationBlocked(state.to_string()));
             }
             _ => {
-                if self.conversation.conversation.partial_freeze_blocks(kind) {
+                if self.conversation.queues.partial_freeze_blocks(kind) {
                     return Err(UserError::PartialFreeze);
                 }
             }
@@ -452,10 +450,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         {
             let mut s = arc.write_or_err("session")?;
             s.conversation
-                .conversation
+                .queues
                 .insert_voting_proposal(proposal_id, request.clone());
             if kind.is_emergency() {
-                s.conversation.conversation.insert_emergency(proposal_id);
+                s.conversation.queues.insert_emergency(proposal_id);
             }
             // Register the consensus timeout deadline. The caller's polling
             // loop fires `resolve_on_timeout` via `tick_deadlines` once the
@@ -558,7 +556,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     .read_or_err("session")
                     .map(|s| {
                         s.conversation
-                            .conversation
+                            .queues
                             .is_consensus_outcome_applied(proposal_id)
                     })
                     .unwrap_or(false);

--- a/src/app/session/consensus_bridge.rs
+++ b/src/app/session/consensus_bridge.rs
@@ -43,7 +43,7 @@ pub(crate) struct ProposalParams {
 /// In both cases the caller must record ownership *before*
 /// casting, so a single-voter consensus transition can't fire before
 /// [`crate::core::ConversationQueues::is_owner_of_proposal`] is true.
-pub(crate) async fn submit_proposal<P: ConsensusPlugin>(
+pub(crate) fn submit_proposal<P: ConsensusPlugin>(
     conversation_id: &str,
     request: &ConversationUpdateRequest,
     creator_id: &[u8],
@@ -60,13 +60,11 @@ pub(crate) async fn submit_proposal<P: ConsensusPlugin>(
     )?;
 
     let scope = P::Scope::from(conversation_id.to_string());
-    let proposal = consensus
-        .create_proposal_with_config(
-            &scope,
-            create_request,
-            Some(ConsensusConfig::gossipsub().with_timeout(params.consensus_timeout)?),
-        )
-        .await?;
+    let proposal = consensus.create_proposal_with_config(
+        &scope,
+        create_request,
+        Some(ConsensusConfig::gossipsub().with_timeout(params.consensus_timeout)?),
+    )?;
 
     info!(
         conversation = conversation_id,
@@ -91,7 +89,7 @@ pub(crate) async fn submit_proposal<P: ConsensusPlugin>(
 /// `consensus.cast_vote_and_get_proposal` directly rather than this
 /// helper, because that is the only legitimate case for broadcasting
 /// proposal + vote atomically in a single wire message.
-pub(crate) async fn cast_vote<P>(
+pub(crate) fn cast_vote<P>(
     conversation_id: &str,
     proposal_id: u32,
     vote: bool,
@@ -108,7 +106,7 @@ where
         proposal_id, choice, "vote cast"
     );
 
-    let vote_msg = consensus.cast_vote(&scope, proposal_id, vote).await?;
+    let vote_msg = consensus.cast_vote(&scope, proposal_id, vote)?;
     Ok(vote_msg.into())
 }
 
@@ -116,15 +114,13 @@ where
 /// decides whether to emit a banner event — for fast-path proposals
 /// (`expected_voters_count == 1`) the session resolves on arrival, so
 /// there's nothing to vote on.
-pub(crate) async fn forward_incoming_proposal<P: ConsensusPlugin>(
+pub(crate) fn forward_incoming_proposal<P: ConsensusPlugin>(
     conversation_id: &str,
     proposal: Proposal,
     consensus: &PluginConsensus<P>,
 ) -> Result<(), UserError> {
     let scope = P::Scope::from(conversation_id.to_string());
-    consensus
-        .process_incoming_proposal(&scope, proposal)
-        .await?;
+    consensus.process_incoming_proposal(&scope, proposal)?;
     Ok(())
 }
 
@@ -133,7 +129,7 @@ pub(crate) async fn forward_incoming_proposal<P: ConsensusPlugin>(
 /// `outcome_applied_locally` is the result of
 /// `ConversationQueues::is_consensus_outcome_applied(vote.proposal_id)` computed
 /// by the caller — passed in eagerly so this helper doesn't have to borrow
-/// the conversation across the consensus `.await`. It's only consulted on
+/// the conversation across the consensus-service call. It's only consulted on
 /// the `SessionNotFound` branch.
 ///
 /// Late-arrival classification:
@@ -145,7 +141,7 @@ pub(crate) async fn forward_incoming_proposal<P: ConsensusPlugin>(
 ///   Warn-log, swallow the error so inbound dispatch keeps draining.
 ///
 /// Other consensus errors propagate.
-pub(crate) async fn forward_incoming_vote<P: ConsensusPlugin>(
+pub(crate) fn forward_incoming_vote<P: ConsensusPlugin>(
     conversation_id: &str,
     vote: Vote,
     consensus: &PluginConsensus<P>,
@@ -153,7 +149,7 @@ pub(crate) async fn forward_incoming_vote<P: ConsensusPlugin>(
 ) -> Result<(), CoreError> {
     let proposal_id = vote.proposal_id;
     let scope = P::Scope::from(conversation_id.to_string());
-    match consensus.process_incoming_vote(&scope, vote).await {
+    match consensus.process_incoming_vote(&scope, vote) {
         Ok(()) => Ok(()),
         Err(ConsensusError::SessionNotActive) => {
             tracing::debug!(
@@ -194,7 +190,7 @@ pub(crate) async fn forward_incoming_vote<P: ConsensusPlugin>(
 ///
 /// `Ok(Some(_))` — newly opened; caller broadcasts the `AppMessage`.
 /// `Ok(None)` — already in flight (e.g. double-click); no broadcast.
-pub(crate) async fn submit_self_leave_proposal<P>(
+pub(crate) fn submit_self_leave_proposal<P>(
     conversation_id: &str,
     self_member_id: &[u8],
     consensus: &PluginConsensus<P>,
@@ -232,14 +228,11 @@ where
         liveness_criteria_yes: params.liveness_criteria_yes,
     };
 
-    let yes_vote = build_vote(&proposal, true, consensus.signer()).await?;
+    let yes_vote = build_vote(&proposal, true, consensus.signer())?;
     proposal.votes.push(yes_vote);
 
     let scope = P::Scope::from(conversation_id.to_string());
-    match consensus
-        .process_incoming_proposal(&scope, proposal.clone())
-        .await
-    {
+    match consensus.process_incoming_proposal(&scope, proposal.clone()) {
         Ok(()) => {
             info!(
                 conversation = conversation_id,

--- a/src/app/session/consensus_events.rs
+++ b/src/app/session/consensus_events.rs
@@ -105,6 +105,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             )?
         };
 
+        // A commit candidate may have arrived before this approval landed (a
+        // peer steward can reach consensus and broadcast the commit before we
+        // apply our own vote). Now that the approved queue is populated, replay
+        // any stashed candidate so the freeze round picks it up instead of
+        // starting empty and forcing a needless reelection.
+        arc.write_or_err("session")?
+            .conversation
+            .replay_early_candidates()?;
+
         match consensus_apply {
             ConsensusApplyResult::NoAction => {}
             ConsensusApplyResult::ElectionAccepted(election) => {

--- a/src/app/session/consensus_events.rs
+++ b/src/app/session/consensus_events.rs
@@ -53,7 +53,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // Drop re-emissions from the consensus library (timeout-path
             // race) so we don't re-apply state or double-fire UI events.
             s.conversation
-                .conversation
+                .queues
                 .is_consensus_outcome_applied(proposal_id)
         };
         if already_applied {
@@ -92,14 +92,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 proposal_id, approved, "consensus reached"
             );
             s.conversation
-                .conversation
+                .queues
                 .mark_consensus_outcome_applied(proposal_id);
-            apply_consensus_result(
-                &mut s.conversation.conversation,
-                proposal_id,
-                approved,
-                &request,
-            )?
+            apply_consensus_result(&mut s.conversation.queues, proposal_id, approved, &request)?
         };
 
         // A commit candidate may have arrived before this approval landed (a
@@ -136,7 +131,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             ConsensusApplyResult::RejectedMembership { target } => {
                 arc.write_or_err("session")?
                     .conversation
-                    .conversation
+                    .queues
                     .remove_pending_update(&target);
             }
         }
@@ -238,7 +233,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         let resumed_from_reelection = {
             let mut s = arc.write_or_err("session")?;
-            let _events = s.conversation.steward_list.install_list(
+            s.conversation.steward_list.install_list(
                 election.election_epoch,
                 &election.proposed_stewards,
                 election.proposed_stewards.len(),
@@ -274,7 +269,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     fn handle_election_rejected(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let (round, max) = {
             let mut s = arc.write_or_err("session")?;
-            let _events = s.conversation.steward_list.bump_retry();
+            s.conversation.steward_list.bump_retry();
             (
                 s.conversation.steward_list.next_retry_round(),
                 s.conversation.steward_list.max_retries(),
@@ -327,14 +322,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 && let Some(ev) = &ec.evidence
             {
                 s.conversation
-                    .conversation
+                    .queues
                     .remove_pending_removal(&ev.target_member_id);
             }
         }
 
         let resumed_event = {
             let mut s = arc.write_or_err("session")?;
-            s.conversation.conversation.remove_emergency(proposal_id);
+            s.conversation.queues.remove_emergency(proposal_id);
             if s.conversation.current_state() == ConversationState::Reelection {
                 Some(s.start_working())
             } else {

--- a/src/app/session/consensus_events.rs
+++ b/src/app/session/consensus_events.rs
@@ -6,7 +6,7 @@
 //! `Arc<RwLock<SessionRunner>>` because they fan out into steward
 //! initiations (election, deadlock ECP, score removals, buffered-update
 //! drains), each of which opens a follow-up proposal that releases the
-//! runner lock across its `.await` points.
+//! runner lock across its `` points.
 
 use std::sync::{Arc, RwLock};
 
@@ -30,7 +30,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// apply the result to the conversation, and dispatch to the correct
     /// follow-up handler (election-accepted / election-rejected /
     /// emergency-scored).
-    pub(crate) async fn apply_consensus_outcome(
+    pub(crate) fn apply_consensus_outcome(
         arc: &Arc<RwLock<Self>>,
         event: ConsensusEvent,
     ) -> Result<SessionTick, UserError> {
@@ -79,10 +79,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             (s.consensus.clone(), s.conversation_id.clone())
         };
         let scope = P::Scope::from(conversation_id.clone());
-        let proposal = consensus
-            .storage()
-            .get_proposal(&scope, proposal_id)
-            .await?;
+        let proposal = consensus.storage().get_proposal(&scope, proposal_id)?;
         // Decode once and thread the request through every downstream step.
         let request = ConversationUpdateRequest::decode(proposal.payload.as_slice())?;
 
@@ -117,11 +114,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         match consensus_apply {
             ConsensusApplyResult::NoAction => {}
             ConsensusApplyResult::ElectionAccepted(election) => {
-                Self::handle_election_accepted(arc, election).await?;
+                Self::handle_election_accepted(arc, election)?;
                 return Self::current_tick(arc);
             }
             ConsensusApplyResult::ElectionRejected => {
-                Self::handle_election_rejected(arc).await?;
+                Self::handle_election_rejected(arc)?;
             }
             ConsensusApplyResult::RecoveryModeOpened => {
                 arc.write_or_err("session")?
@@ -131,10 +128,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
             ConsensusApplyResult::UrgentRemoval { target } => {
                 Self::start_freezing_and_emit(arc)?;
-                Self::refresh_stewards_after_removal(arc, &target).await?;
+                Self::refresh_stewards_after_removal(arc, &target)?;
             }
             ConsensusApplyResult::QueuedRemoval { target } => {
-                Self::refresh_stewards_after_removal(arc, &target).await?;
+                Self::refresh_stewards_after_removal(arc, &target)?;
             }
             ConsensusApplyResult::RejectedMembership { target } => {
                 arc.write_or_err("session")?
@@ -151,7 +148,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         let score_ops = emergency_score_ops(&request, approved);
         if !score_ops.is_empty() {
-            Self::handle_emergency_scored(arc, proposal_id, &request, &score_ops).await?;
+            Self::handle_emergency_scored(arc, proposal_id, &request, &score_ops)?;
         }
 
         Self::current_tick(arc)
@@ -187,7 +184,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// When the removal target is a current steward, fire a fresh election
     /// in parallel so the next epoch keeps a healthy ES + BS.
-    async fn refresh_stewards_after_removal(
+    fn refresh_stewards_after_removal(
         arc: &Arc<RwLock<Self>>,
         target: &[u8],
     ) -> Result<(), UserError> {
@@ -199,7 +196,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         if !target_was_steward {
             return Ok(());
         }
-        if let Err(e) = Self::initiate_steward_election(arc, true).await {
+        if let Err(e) = Self::initiate_steward_election(arc, true) {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             info!(
                 conversation = %conv_name,
@@ -213,7 +210,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Accepted election: validate, install the new list, exit Reelection
     /// if we were in it, close any open recovery window, and drain
     /// buffered updates so the fresh epoch steward picks them up.
-    async fn handle_election_accepted(
+    fn handle_election_accepted(
         arc: &Arc<RwLock<Self>>,
         election: StewardElectionProposal,
     ) -> Result<(), UserError> {
@@ -269,12 +266,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             );
         }
 
-        Self::process_buffered_updates(arc).await
+        Self::process_buffered_updates(arc)
     }
 
     /// Rejected election: bump the retry round and retry under the max
     /// (idempotent), or escalate to a `Deadlock` ECP once exhausted.
-    async fn handle_election_rejected(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    fn handle_election_rejected(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let (round, max) = {
             let mut s = arc.write_or_err("session")?;
             let _events = s.conversation.steward_list.bump_retry();
@@ -289,7 +286,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 conversation = %conversation_id,
                 round, max, "election retries exhausted; escalating to Layer 3"
             );
-            if let Err(e) = Self::initiate_deadlock_ecp(arc).await {
+            if let Err(e) = Self::initiate_deadlock_ecp(arc) {
                 error!(conversation = %conversation_id, error = %e, "Deadlock ECP filing failed");
                 arc.read_or_err("session")?.emit_event(SessionEvent::Error {
                     operation: "Reelection stuck".to_string(),
@@ -302,7 +299,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             conversation = %conversation_id,
             round, max, "steward election rejected, retrying"
         );
-        if let Err(e) = Self::initiate_steward_election(arc, true).await {
+        if let Err(e) = Self::initiate_steward_election(arc, true) {
             info!(conversation = %conversation_id, error = %e, "election retry deferred");
         }
         Ok(())
@@ -312,7 +309,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// pending-removal / pending-ECP buffers, lift the partial freeze (and
     /// exit Reelection if we landed there), then check for new
     /// below-threshold removals.
-    async fn handle_emergency_scored(
+    fn handle_emergency_scored(
         arc: &Arc<RwLock<Self>>,
         proposal_id: u32,
         request: &ConversationUpdateRequest,
@@ -346,7 +343,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         };
         Self::emit_phase_change(arc, resumed_event)?;
 
-        if let Err(e) = Self::check_and_initiate_score_removals(arc).await {
+        if let Err(e) = Self::check_and_initiate_score_removals(arc) {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             error!(conversation = %conv_name, error = %e, "score-removal check failed");
         }

--- a/src/app/session/freeze.rs
+++ b/src/app/session/freeze.rs
@@ -85,23 +85,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
             // Early selection: skip remaining freeze time if all expected
             // stewards have submitted candidates.
-            let all_candidates_in =
-                s.conversation
-                    .steward_list
-                    .current_list()
-                    .is_some_and(|list| {
-                        s.conversation.conversation.freeze_candidate_count() >= list.len()
-                    });
+            let all_candidates_in = s
+                .conversation
+                .steward_list
+                .current_list()
+                .is_some_and(|list| s.conversation.queues.freeze_candidate_count() >= list.len());
 
             if !all_candidates_in && !s.is_freeze_timed_out() {
                 return Ok((FreezeTimeoutStatus::StillFreezing, DispatchOutcome::Done));
             }
 
             let event = s.start_selection();
-            (
-                s.conversation.conversation.approved_proposals_count() > 0,
-                event,
-            )
+            (s.conversation.queues.approved_proposals_count() > 0, event)
         };
 
         arc.read_or_err("session")?
@@ -212,8 +207,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                                 let violation_epoch = mls.current_epoch()?;
                                 let members = mls.members()?;
                                 let self_member_id: &[u8] = &s.self_member_id;
-                                let eligible =
-                                    s.conversation.conversation.steward_eligibility(&members);
+                                let eligible = s.conversation.queues.steward_eligibility(&members);
                                 s.conversation
                                     .steward_list
                                     .epoch_steward(violation_epoch, &eligible)
@@ -233,7 +227,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
                         (event, cross)
                     } else {
-                        s.conversation.conversation.clear_freeze_round();
+                        s.conversation.queues.clear_freeze_round();
                         let event = s.start_working();
                         (event, false)
                     }
@@ -280,10 +274,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 return Ok(false);
             }
 
-            let proposal_count = s.conversation.conversation.approved_proposals_count();
+            let proposal_count = s.conversation.queues.approved_proposals_count();
             // Hold the freeze while an election is in flight — committing on
             // the known-stale list would just produce a NoCandidate.
-            if s.conversation.conversation.has_election_in_flight() {
+            if s.conversation.queues.has_election_in_flight() {
                 return Ok(false);
             }
             // Recovery uses the shorter retry inactivity window so we don't
@@ -300,7 +294,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 return Ok(false);
             };
             let epoch = s.conversation.expect_mls()?.current_epoch()?;
-            s.conversation.conversation.start_freeze_round(epoch);
+            s.conversation.queues.start_freeze_round(epoch);
 
             let self_member_id = Arc::clone(&s.self_member_id);
             let app_id = Arc::clone(&s.app_id);

--- a/src/app/session/freeze.rs
+++ b/src/app/session/freeze.rs
@@ -72,7 +72,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// freeze status. The [`DispatchOutcome`] is `LeaveRequested` if the
     /// applied commit ejected the local member — the caller drives the
     /// User-side registry teardown.
-    pub async fn poll_freeze_status(
+    pub fn poll_freeze_status(
         arc: &Arc<RwLock<Self>>,
     ) -> Result<(FreezeTimeoutStatus, DispatchOutcome), UserError> {
         let (has_proposals, selection_event) = {
@@ -147,10 +147,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Lock split is intentional: `check_and_initiate_score_removals`
         // re-acquires the runner write lock and calls `initiate_proposal`,
-        // which `.await`s on the consensus service. Holding the runner
+        // which ``s on the consensus service. Holding the runner
         // lock across that await would block other operations on this
         // conversation, so we drop the lock above before chaining.
-        if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc).await {
+        if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc) {
             error!(conversation = %conversation_id, error = %e, "score-removal check failed (freeze finalize)");
         }
 
@@ -178,7 +178,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                         .emit_event(SessionEvent::WelcomeReady(welcome));
                 }
 
-                let outcome = match Self::dispatch_inbound_result(arc, result).await {
+                let outcome = match Self::dispatch_inbound_result(arc, result) {
                     Ok(o) => o,
                     Err(e) => {
                         error!(conversation = %conversation_id, error = %e, "finalize result dispatch failed");
@@ -239,8 +239,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     }
                 };
 
-                if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc).await
-                {
+                if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc) {
                     error!(conversation = %conversation_id, error = %e, "score-removal check failed (freeze timeout)");
                 }
 
@@ -250,9 +249,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
                 // Layer 2 recovery: regenerate the steward list. Only the
                 // responsible proposer's call actually submits.
-                if entered_reelection
-                    && let Err(e) = Self::initiate_steward_election(arc, true).await
-                {
+                if entered_reelection && let Err(e) = Self::initiate_steward_election(arc, true) {
                     info!(conversation = %conversation_id, error = %e, "recovery election deferred");
                 }
             }
@@ -273,7 +270,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     ///
     /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
     /// awaiting on the transport for the steward's own candidate send.
-    pub async fn check_member_freeze(arc: &Arc<RwLock<Self>>) -> Result<bool, UserError> {
+    pub fn check_member_freeze(arc: &Arc<RwLock<Self>>) -> Result<bool, UserError> {
         // Sync phase: under the runner write lock, run the inactivity
         // check and (for stewards) build the outbound candidate.
         let (transitioned, transport, outbound) = {

--- a/src/app/session/inbound.rs
+++ b/src/app/session/inbound.rs
@@ -2,7 +2,7 @@
 //!
 //! `dispatch_inbound_result` and every `ProcessResult` branch handler live
 //! on `SessionRunner` as associated functions taking `Arc<RwLock<Self>>` so
-//! they can release the runner lock across `.await` points without holding
+//! they can release the runner lock across `` points without holding
 //! it during proposal lifecycles.
 //!
 //! `LeaveConversation` is split: the session-side helper `prepare_self_leave`
@@ -59,7 +59,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// `process_inbound` returns a result, and by other call sites that
     /// produce a `ProcessResult` (e.g. the welcome-side
     /// `JoinedConversation`).
-    pub(crate) async fn dispatch_inbound_result(
+    pub(crate) fn dispatch_inbound_result(
         arc: &Arc<RwLock<Self>>,
         result: ProcessResult,
     ) -> Result<DispatchOutcome, UserError> {
@@ -70,7 +70,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Proposal(proposal) => {
-                Self::on_incoming_proposal(arc, *proposal).await?;
+                Self::on_incoming_proposal(arc, *proposal)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Vote(vote) => {
@@ -85,23 +85,22 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                             .is_consensus_outcome_applied(proposal_id),
                     )
                 };
-                forward_incoming_vote::<P>(&conversation_id, *vote, &consensus, outcome_applied)
-                    .await?;
+                forward_incoming_vote::<P>(&conversation_id, *vote, &consensus, outcome_applied)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::MembershipChangeReceived(request) => {
-                Self::handle_incoming_update_request(arc, *request).await?;
+                Self::handle_incoming_update_request(arc, *request)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::JoinedConversation(_name) => {
                 // `name` is always this conversation's name — `process_inbound`
                 // emits it via the local MLS service. Use the session's own
                 // `conversation_id` rather than the parameter.
-                Self::on_joined_conversation(arc).await?;
+                Self::on_joined_conversation(arc)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::ConversationUpdated => {
-                Self::on_conversation_updated(arc).await?;
+                Self::on_conversation_updated(arc)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::LeaveConversation => {
@@ -111,7 +110,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             ProcessResult::CommitCandidateReceived {
                 steward_id: steward,
             } => {
-                Self::on_commit_candidate_received(arc, &steward).await?;
+                Self::on_commit_candidate_received(arc, &steward)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::ConversationSyncReceived(sync) => {
@@ -141,10 +140,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// blocked. We don't drop today — the RFC's Δ-synchrony assumption keeps
     /// divergence windows small. Consensus-service-level priority gating is
     /// tracked as a backlog item in `docs/ROADMAP.md`.
-    async fn on_incoming_proposal(
-        arc: &Arc<RwLock<Self>>,
-        proposal: Proposal,
-    ) -> Result<(), UserError> {
+    fn on_incoming_proposal(arc: &Arc<RwLock<Self>>, proposal: Proposal) -> Result<(), UserError> {
         let decoded = match ConversationUpdateRequest::decode(proposal.payload.as_slice()) {
             Ok(req) => Some(req),
             Err(e) => {
@@ -188,7 +184,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             let s = arc.read_or_err("session")?;
             (s.consensus.clone(), s.conversation_id.clone())
         };
-        forward_incoming_proposal::<P>(&conversation_id, proposal, &consensus).await?;
+        forward_incoming_proposal::<P>(&conversation_id, proposal, &consensus)?;
         // Skip the banner + auto-vote for fast-path proposals: the
         // creator's bundled YES already resolved the session, so peers have
         // nothing to vote on.
@@ -212,7 +208,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// We just joined via welcome. Broadcast a system "joined" chat
     /// message, seed scoring with the current member set, and
     /// transition to Working.
-    async fn on_joined_conversation(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    fn on_joined_conversation(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let (packet, mls_members, conversation_id) = {
             let mut s = arc.write_or_err("session")?;
             let msg: AppMessage = ConversationMessage {
@@ -245,7 +241,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Working, and run steward housekeeping (list reconcile, election
     /// kick-off, buffered-update drain). The commit author's `SuccessfulCommit`
     /// reward is emitted by `finalize_freeze_round`, not here.
-    async fn on_conversation_updated(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    fn on_conversation_updated(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let mls_members = {
             let s = arc.read_or_err("session")?;
             match s.conversation.mls() {
@@ -278,9 +274,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
         };
 
-        Self::steward_list_housekeeping(arc).await?;
-        Self::process_buffered_updates(arc).await?;
-        Self::maybe_close_recovery_window(arc).await;
+        Self::steward_list_housekeeping(arc)?;
+        Self::process_buffered_updates(arc)?;
+        Self::maybe_close_recovery_window(arc);
 
         if let Some(event) = working_event {
             arc.read_or_err("session")?
@@ -291,7 +287,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Fire a steward election while `recovery_mode` is set so the next
     /// list installs and closes the window.
-    async fn maybe_close_recovery_window(arc: &Arc<RwLock<Self>>) {
+    fn maybe_close_recovery_window(arc: &Arc<RwLock<Self>>) {
         let in_recovery_mode = match arc.read_or_err("session") {
             Ok(s) => s.conversation.is_in_recovery_mode(),
             Err(e) => {
@@ -302,7 +298,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         if !in_recovery_mode {
             return;
         }
-        if let Err(e) = Self::initiate_steward_election(arc, true).await {
+        if let Err(e) = Self::initiate_steward_election(arc, true) {
             let conv_name = arc
                 .read_or_err("session")
                 .map(|s| s.conversation_id.clone())
@@ -340,7 +336,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Peer broadcast a commit candidate. If we were in Working, enter
     /// Freezing and — if we're a steward — build our own candidate too.
-    async fn on_commit_candidate_received(
+    fn on_commit_candidate_received(
         arc: &Arc<RwLock<Self>>,
         steward: &[u8],
     ) -> Result<(), UserError> {

--- a/src/app/session/inbound.rs
+++ b/src/app/session/inbound.rs
@@ -81,7 +81,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                         s.consensus.clone(),
                         s.conversation_id.clone(),
                         s.conversation
-                            .conversation
+                            .queues
                             .is_consensus_outcome_applied(proposal_id),
                     )
                 };
@@ -160,14 +160,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             };
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
-                    s.conversation
-                        .conversation
-                        .insert_emergency(proposal.proposal_id);
+                    s.conversation.queues.insert_emergency(proposal.proposal_id);
                 }
                 Some(conversation_update_request::Payload::MemberInvite(_))
                 | Some(conversation_update_request::Payload::RemoveMember(_)) => {
                     s.conversation
-                        .conversation
+                        .queues
                         .insert_pending_update(req.clone(), current_epoch);
                 }
                 _ => {}
@@ -350,11 +348,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
         let (event, outbound) = {
             let mut s = arc.write_or_err("session")?;
-            // A valid commit landing supersedes a pending reelection: a member
-            // that gave up waiting (Reelection) must still apply the steward's
-            // commit, not ignore it. `start_freezing` is allowed from both
-            // Working and Reelection; the buffered candidate is finalized on
-            // the next poll.
             let state = s.conversation.current_state();
             if state != ConversationState::Working && state != ConversationState::Reelection {
                 return Ok(());
@@ -364,7 +357,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 return Ok(());
             };
             let epoch = s.conversation.expect_mls()?.current_epoch()?;
-            s.conversation.conversation.start_freeze_round(epoch);
+            s.conversation.queues.start_freeze_round(epoch);
 
             let self_member_id = Arc::clone(&s.self_member_id);
             let app_id = Arc::clone(&s.app_id);
@@ -454,7 +447,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         let sn = sync.steward_members.len();
         self.conversation.steward_list.set_config(protocol_config);
-        let _events = self.conversation.steward_list.install_list(
+        self.conversation.steward_list.install_list(
             sync.election_epoch,
             &sync.steward_members,
             sn,

--- a/src/app/session/inbound.rs
+++ b/src/app/session/inbound.rs
@@ -350,7 +350,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
         let (event, outbound) = {
             let mut s = arc.write_or_err("session")?;
-            if s.conversation.current_state() != ConversationState::Working {
+            // A valid commit landing supersedes a pending reelection: a member
+            // that gave up waiting (Reelection) must still apply the steward's
+            // commit, not ignore it. `start_freezing` is allowed from both
+            // Working and Reelection; the buffered candidate is finalized on
+            // the next poll.
+            let state = s.conversation.current_state();
+            if state != ConversationState::Working && state != ConversationState::Reelection {
                 return Ok(());
             }
 

--- a/src/app/session/messaging.rs
+++ b/src/app/session/messaging.rs
@@ -45,7 +45,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     ///
     /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
     /// awaiting on the transport.
-    pub async fn send_key_package(
+    pub fn send_key_package(
         arc: &Arc<RwLock<Self>>,
         key_package: KeyPackageBytes,
     ) -> Result<SessionTick, UserError> {
@@ -65,7 +65,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     ///
     /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
     /// awaiting on the transport.
-    pub async fn send_app_message(
+    pub fn send_app_message(
         arc: &Arc<RwLock<Self>>,
         message: Vec<u8>,
     ) -> Result<SessionTick, UserError> {
@@ -103,7 +103,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// The requester's click means "I want this person removed" → the
     /// creator's vote is bundled as YES at submit; no banner is shown to
     /// the requester.
-    pub async fn process_ban_request(
+    pub fn process_ban_request(
         arc: &Arc<RwLock<Self>>,
         ban_request: BanRequest,
     ) -> Result<SessionTick, UserError> {
@@ -125,8 +125,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 )),
             },
             CreatorVote::Yes,
-        )
-        .await?;
+        )?;
 
         Ok(arc.read_or_err("session")?.tick())
     }

--- a/src/app/session/query.rs
+++ b/src/app/session/query.rs
@@ -34,13 +34,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// to verify buffer hygiene (e.g., that a joiner's buffer is empty right
     /// after they receive the welcome).
     pub fn get_pending_update_count(&self) -> usize {
-        self.conversation.conversation.pending_update_count()
+        self.conversation.queues.pending_update_count()
     }
 
     /// Freeze round progress: `(received, expected)`. Returns `(0, 0)` if not
     /// in freeze or no steward list is known.
     pub fn get_freeze_candidate_count(&self) -> (usize, usize) {
-        let received = self.conversation.conversation.freeze_candidate_count();
+        let received = self.conversation.queues.freeze_candidate_count();
         let expected = self
             .conversation
             .steward_list
@@ -80,7 +80,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let members = self.conversation.expect_mls()?.members()?;
         Ok(members
             .into_iter()
-            .filter(|id| self.conversation.conversation.is_pending_self_leave(id))
+            .filter(|id| self.conversation.queues.is_pending_self_leave(id))
             .collect())
     }
 
@@ -91,7 +91,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let epoch = mls.current_epoch()?;
         let members = mls.members()?;
 
-        let eligible = self.conversation.conversation.steward_eligibility(&members);
+        let eligible = self.conversation.queues.steward_eligibility(&members);
         let (live_epoch, live_backup) = self
             .conversation
             .steward_list
@@ -127,7 +127,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     pub fn get_approved_proposals_for_current_epoch(&self) -> Vec<ConversationUpdateRequest> {
         self.conversation
-            .conversation
+            .queues
             .approved_proposals()
             .values()
             .cloned()

--- a/src/app/session/runner.rs
+++ b/src/app/session/runner.rs
@@ -210,7 +210,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             ConversationState::Freezing => Some(anchor + cfg.freeze_duration),
             ConversationState::PendingJoin => Some(anchor + cfg.commit_inactivity_duration * 3),
             ConversationState::Working => {
-                if self.conversation.conversation.approved_proposals_count() == 0 {
+                if self.conversation.queues.approved_proposals_count() == 0 {
                     return None;
                 }
                 let dur = if self.conversation.is_in_recovery_mode() {

--- a/src/app/session/steward.rs
+++ b/src/app/session/steward.rs
@@ -98,10 +98,21 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         if !self.conversation.steward_list.is_exhausted(current_epoch) {
             return Ok(StewardListReconcile::Settled);
         }
+        // Trigger a voted election only when *settled* members exceed sn_max. A
+        // member added by this epoch's commit may not have attached MLS yet, so
+        // electing on their account would fire a vote they'd miss, diverging the
+        // steward list. The deterministic local install below is computed
+        // identically by every node, so it can safely include just-joined
+        // members (they receive the same list via ConversationSync).
+        let settled_count = self
+            .conversation
+            .conversation
+            .settled_members(&members, current_epoch)
+            .len();
         if self
             .conversation
             .steward_list
-            .election_required(members.len())
+            .election_required(settled_count)
         {
             return Ok(StewardListReconcile::NeedsElection);
         }
@@ -422,11 +433,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 return Ok(());
             }
 
-            // Build the candidate pool: MLS members minus queued
+            // Build the candidate pool: settled MLS members minus queued
             // removals (recovery only — non-recovery elections trust the
-            // current MLS roster).
+            // current MLS roster). Unsettled (just-joined) members are excluded
+            // — they may not have attached MLS and can't serve as stewards yet.
             let candidate_pool: Vec<Vec<u8>> = mls_members
                 .iter()
+                .filter(|m| s.conversation.conversation.is_settled(m, epoch))
                 .filter(|m| !(recovery && s.conversation.conversation.has_approved_removal(m)))
                 .cloned()
                 .collect();

--- a/src/app/session/steward.rs
+++ b/src/app/session/steward.rs
@@ -70,10 +70,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// whose list is a genuine subset, opens a voted election. Election-init
     /// failures are logged, not surfaced — conversation state may legitimately
     /// reject a new proposal right now.
-    pub async fn steward_list_housekeeping(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn steward_list_housekeeping(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let reconcile = arc.write_or_err("session")?.reconcile_steward_list()?;
         if reconcile == StewardListReconcile::NeedsElection
-            && let Err(e) = Self::initiate_steward_election(arc, false).await
+            && let Err(e) = Self::initiate_steward_election(arc, false)
         {
             let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             info!(conversation = %conv_name, error = %e, "election initiation deferred");
@@ -167,7 +167,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// On epoch advance, the new live epoch steward drains the pending-update
     /// buffer into voting proposals. Skips entries already covered by the
     /// current voting/approved queues so we don't double-propose.
-    pub async fn process_buffered_updates(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn process_buffered_updates(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let (current_epoch, to_propose, conversation_id): (
             u64,
             Vec<ConversationUpdateRequest>,
@@ -232,7 +232,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Buffered updates inherit the same banner path as fresh
         // steward-auto-propose — the steward still decides per proposal.
         for request in to_propose {
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred).await {
+            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred) {
                 info!(
                     conversation = %conversation_id,
                     error = %e,
@@ -324,9 +324,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Steward-only: file `ScoreBelowThreshold` ECPs for any member whose
     /// score fell at or below the removal threshold. Skips self and any
     /// target already covered by a pending removal.
-    pub async fn check_and_initiate_score_removals(
-        arc: &Arc<RwLock<Self>>,
-    ) -> Result<(), UserError> {
+    pub fn check_and_initiate_score_removals(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         // Reactive entry: callers chain into this after a scoring apply
         // emitted a downward cross, so we expect at least one tracked
         // member to be at-or-below threshold. The scan is the source of
@@ -388,7 +386,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // SCORE_BELOW_THRESHOLD is self-executing: threshold crossed ⇒
             // member must be removed. The steward's vote is YES by
             // protocol, so we bundle it at submit and skip the banner.
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Yes).await {
+            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Yes) {
                 arc.write_or_err("session")?
                     .conversation
                     .conversation
@@ -416,7 +414,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// already in `approved_proposals` thanks to
     /// [`crate::core::apply_consensus_result`], so `has_approved_removal`
     /// catches them without an explicit exclude.
-    pub async fn initiate_steward_election(
+    pub fn initiate_steward_election(
         arc: &Arc<RwLock<Self>>,
         recovery: bool,
     ) -> Result<(), UserError> {
@@ -498,7 +496,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Elections are conversation-wide decisions — broadcast unbundled
         // so the responsible proposer still votes via the banner.
-        Self::initiate_proposal(arc, request, CreatorVote::Deferred).await?;
+        Self::initiate_proposal(arc, request, CreatorVote::Deferred)?;
 
         Ok(())
     }
@@ -506,7 +504,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Layer 3 escalation: file a `Deadlock` ECP after re-election retries
     /// exhaust. Only the deterministic responsible proposer submits;
     /// others no-op. On YES the ECP opens `recovery_mode`.
-    pub async fn initiate_deadlock_ecp(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn initiate_deadlock_ecp(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let (is_authorized, self_id, epoch, conversation_id) = {
             let s = arc.read_or_err("session")?;
             let mls = s.conversation.expect_mls()?;
@@ -548,7 +546,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Bundle YES — the proposer's observation that the deadlock is
         // real is their vote.
-        Self::initiate_proposal(arc, request, CreatorVote::Yes).await?;
+        Self::initiate_proposal(arc, request, CreatorVote::Yes)?;
         Ok(())
     }
 }

--- a/src/app/session/steward.rs
+++ b/src/app/session/steward.rs
@@ -30,11 +30,11 @@ use crate::{
 /// [`SessionRunner::reconcile_steward_list`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StewardListReconcile {
-    /// List already covered the epoch, or a small group's list was
-    /// reinstalled deterministically. No consensus round needed.
+    /// List already covered the epoch, or the settled members were installed
+    /// locally and deterministically. No consensus round needed.
     Settled,
-    /// The group is large enough (`members > sn_max`) that the list is a
-    /// genuine subset peers must agree: the caller runs the voted election.
+    /// The settled members exceed `sn_max`, so the list is a genuine subset
+    /// peers must agree on: the caller runs the voted election.
     NeedsElection,
 }
 
@@ -65,11 +65,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
     }
 
-    /// Post-epoch-advance reconcile: bring the steward list to the new epoch.
-    /// Small groups regenerate locally (no consensus); only a large group,
-    /// whose list is a genuine subset, opens a voted election. Election-init
-    /// failures are logged, not surfaced — conversation state may legitimately
-    /// reject a new proposal right now.
+    /// Reconcile the list after an epoch advance, opening a voted election when
+    /// it's needed. Election-init failures are logged, not surfaced — the
+    /// conversation may legitimately reject a new proposal right now.
     pub fn steward_list_housekeeping(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
         let reconcile = arc.write_or_err("session")?.reconcile_steward_list()?;
         if reconcile == StewardListReconcile::NeedsElection
@@ -81,15 +79,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         Ok(())
     }
 
-    /// Reconcile the steward list to the current MLS epoch. No-op if the
-    /// installed list still covers this epoch. Otherwise the group size
-    /// decides: small (`members <= sn_max`, every member is a steward) →
-    /// install the deterministic list locally, no vote; large (`members >
-    /// sn_max`) → return [`StewardListReconcile::NeedsElection`] for the
-    /// caller to run a voted election. The local install is the same list a
-    /// successful election would yield: every node — the committer before it
-    /// builds the `ConversationSync`, and each peer on its own commit-merge —
-    /// computes the identical list.
+    /// Reconcile the steward list to the current epoch. No-op while the list
+    /// still covers it. Otherwise the settled-member count decides: `<= sn_max`
+    /// installs them locally (deterministic, no vote); `> sn_max` returns
+    /// [`StewardListReconcile::NeedsElection`]. Every node computes the same
+    /// local list, so they agree without a round.
     pub(crate) fn reconcile_steward_list(&mut self) -> Result<StewardListReconcile, UserError> {
         let (current_epoch, members) = {
             let mls = self.conversation.expect_mls()?;
@@ -98,21 +92,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         if !self.conversation.steward_list.is_exhausted(current_epoch) {
             return Ok(StewardListReconcile::Settled);
         }
-        // Trigger a voted election only when *settled* members exceed sn_max. A
-        // member added by this epoch's commit may not have attached MLS yet, so
-        // electing on their account would fire a vote they'd miss, diverging the
-        // steward list. The deterministic local install below is computed
-        // identically by every node, so it can safely include just-joined
-        // members (they receive the same list via ConversationSync).
-        let settled_count = self
+        // Stewards are settled members only — a just-joined member can't commit
+        // or vote yet, so it's excluded until the next epoch.
+        let settled = self
             .conversation
-            .conversation
-            .settled_members(&members, current_epoch)
-            .len();
+            .queues
+            .settled_members(&members, current_epoch);
         if self
             .conversation
             .steward_list
-            .election_required(settled_count)
+            .election_required(settled.len())
         {
             return Ok(StewardListReconcile::NeedsElection);
         }
@@ -120,11 +109,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             .conversation
             .steward_list
             .config()
-            .compute_list_size(members.len());
-        let _events =
-            self.conversation
-                .steward_list
-                .install_list(current_epoch, &members, sn, 0)?;
+            .compute_list_size(settled.len());
+        self.conversation
+            .steward_list
+            .install_list(current_epoch, &settled, sn, 0)?;
         Ok(StewardListReconcile::Settled)
     }
 
@@ -143,15 +131,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             )
         };
 
-        let before = self.conversation.conversation.pending_update_count();
+        let before = self.conversation.queues.pending_update_count();
         self.conversation
-            .conversation
+            .queues
             .prune_pending_updates_for_members(&members);
         let expired = self
             .conversation
-            .conversation
+            .queues
             .expire_pending_updates(current_epoch, max_age);
-        let after = self.conversation.conversation.pending_update_count();
+        let after = self.conversation.queues.pending_update_count();
         if before != after {
             info!(
                 conversation = %self.conversation_id,
@@ -180,7 +168,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 None => (0, Vec::new()),
             };
             let self_member_id: &[u8] = &s.self_member_id;
-            let eligible = s.conversation.conversation.steward_eligibility(&members);
+            let eligible = s.conversation.queues.steward_eligibility(&members);
             let is_live = s
                 .conversation
                 .steward_list
@@ -193,14 +181,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // Collect buffered updates whose target isn't already in an
             // active proposal queue. Both the voting and approved queues
             // live on `ConversationQueues`.
-            let approved = s.conversation.conversation.approved_proposals();
+            let approved = s.conversation.queues.approved_proposals();
             let approved_targets: std::collections::HashSet<&[u8]> =
                 approved.values().filter_map(target_member_id_of).collect();
             let members_set = member_set(&members);
 
             let to_propose: Vec<ConversationUpdateRequest> = s
                 .conversation
-                .conversation
+                .queues
                 .pending_updates()
                 .iter()
                 .filter(|(id, _)| !approved_targets.contains(id.as_slice()))
@@ -282,10 +270,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // first epoch.
         let mls_members = self.conversation.expect_mls()?.members()?;
         let steward_members = {
-            let eligible = self
-                .conversation
-                .conversation
-                .steward_eligibility(&mls_members);
+            let eligible = self.conversation.queues.steward_eligibility(&mls_members);
             self.conversation.steward_list.steward_members(&eligible)
         };
 
@@ -355,17 +340,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 .members_below_threshold()
                 .into_iter()
                 .filter(|id| id.as_slice() != self_id)
-                .filter(|id| !s.conversation.conversation.has_pending_removal(id))
-                .filter(|id| !s.conversation.conversation.has_approved_removal(id))
+                .filter(|id| !s.conversation.queues.has_pending_removal(id))
+                .filter(|id| !s.conversation.queues.has_approved_removal(id))
                 .filter_map(|id| {
                     let score = s.conversation.scoring.score_for(&id)?;
                     Some((id, score))
                 })
                 .collect();
             for (id, _) in &to_remove {
-                s.conversation
-                    .conversation
-                    .insert_pending_removal(id.clone());
+                s.conversation.queues.insert_pending_removal(id.clone());
             }
             (epoch, to_remove, self_id_arc, s.conversation_id.clone())
         };
@@ -389,7 +372,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Yes) {
                 arc.write_or_err("session")?
                     .conversation
-                    .conversation
+                    .queues
                     .remove_pending_removal(&target_id);
                 error!(
                     conversation = %conversation_id,
@@ -427,7 +410,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
             // `has_election_in_flight` is a proposal-queue check, not a
             // steward-list one — gated here, before the plug-in call.
-            if s.conversation.conversation.has_election_in_flight() {
+            if s.conversation.queues.has_election_in_flight() {
                 return Ok(());
             }
 
@@ -437,8 +420,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // — they may not have attached MLS and can't serve as stewards yet.
             let candidate_pool: Vec<Vec<u8>> = mls_members
                 .iter()
-                .filter(|m| s.conversation.conversation.is_settled(m, epoch))
-                .filter(|m| !(recovery && s.conversation.conversation.has_approved_removal(m)))
+                .filter(|m| s.conversation.queues.is_settled(m, epoch))
+                .filter(|m| !(recovery && s.conversation.queues.has_approved_removal(m)))
                 .cloned()
                 .collect();
             let pool_set: std::collections::HashSet<&[u8]> =
@@ -515,7 +498,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // predicate (MLS-present and not queued for removal).
             let mls_set: std::collections::HashSet<&[u8]> =
                 mls_members.iter().map(Vec::as_slice).collect();
-            let conversation_ref = &s.conversation.conversation;
+            let conversation_ref = &s.conversation.queues;
             let authorized = s
                 .conversation
                 .steward_list

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -33,10 +33,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// dedup, name-based routing, and the welcome subtopic's plug-in-
     /// factory access. App-message packets are handed off to the session
     /// for MLS processing and dispatch.
-    pub async fn process_inbound_packet(
-        &self,
-        packet: InboundPacket,
-    ) -> Result<SessionTick, UserError> {
+    pub fn process_inbound_packet(&self, packet: InboundPacket) -> Result<SessionTick, UserError> {
         let conversation_id = packet.conversation_id.clone();
 
         // Echo dedup: drop our own messages received back from pub/sub.
@@ -50,8 +47,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
         match packet.subtopic.as_str() {
             WELCOME_SUBTOPIC => {
-                self.process_key_package_broadcast(&conversation_id, &packet.payload, &entry_arc)
-                    .await?;
+                self.process_key_package_broadcast(&conversation_id, &packet.payload, &entry_arc)?;
                 Ok(entry_arc.read_or_err("session")?.tick())
             }
             APP_MSG_SUBTOPIC => {
@@ -68,8 +64,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                     }
                     entry.conversation.process_inbound(&packet.payload)?
                 };
-                self.finish_dispatch(&conversation_id, &entry_arc, result)
-                    .await?;
+                self.finish_dispatch(&conversation_id, &entry_arc, result)?;
                 Ok(entry_arc.read_or_err("session")?.tick())
             }
             other => Err(UserError::Core(CoreError::InvalidSubtopic(
@@ -86,13 +81,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// [`SessionRunner::check_pending_join`]; this method is the cleanup
     /// callers run when those signal "registry should be removed"
     /// (`DispatchOutcome::LeaveRequested` or `PendingJoinTick::Expired`).
-    pub async fn finalize_self_leave(&self, conversation_id: &str) -> Result<(), UserError> {
+    pub fn finalize_self_leave(&self, conversation_id: &str) -> Result<(), UserError> {
         // Clean up (and cancel timers) before removing the entry — the
         // cleanup finds the runner via `lookup_entry`, so the entry must
         // still exist. Eviction and `Removed` are unconditional: a
         // scope-delete failure (timers already cancelled) must not strand a
         // zombie. The cleanup error surfaces after the conversation is gone.
-        let cleanup = self.cleanup_consensus_scope(conversation_id).await;
+        let cleanup = self.cleanup_consensus_scope(conversation_id);
         self.conversations
             .write()
             .map_err(|_| UserError::LockPoisoned("conversation registry"))?
@@ -107,7 +102,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// holder isn't already a member, promote it to a `MemberInvite`
     /// membership-change request. Raw MLS welcomes do not flow here —
     /// they enter through [`User::accept_welcome`].
-    async fn process_key_package_broadcast(
+    fn process_key_package_broadcast(
         &self,
         conversation_id: &str,
         payload: &[u8],
@@ -141,20 +136,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let gur = ConversationUpdateRequest {
             payload: Some(conversation_update_request::Payload::MemberInvite(invite)),
         };
-        SessionRunner::handle_incoming_update_request(entry_arc, gur).await
+        SessionRunner::handle_incoming_update_request(entry_arc, gur)
     }
 
     /// Drive the session-side dispatcher and finish lifecycle work on the
     /// User side when the session signals `LeaveRequested`.
-    pub(crate) async fn finish_dispatch(
+    pub(crate) fn finish_dispatch(
         &self,
         conversation_id: &str,
         entry_arc: &Arc<RwLock<SessionRunner<P, CP>>>,
         result: ProcessResult,
     ) -> Result<(), UserError> {
-        let outcome = SessionRunner::dispatch_inbound_result(entry_arc, result).await?;
+        let outcome = SessionRunner::dispatch_inbound_result(entry_arc, result)?;
         if matches!(outcome, DispatchOutcome::LeaveRequested) {
-            self.finalize_self_leave(conversation_id).await?;
+            self.finalize_self_leave(conversation_id)?;
         }
         Ok(())
     }
@@ -192,11 +187,11 @@ mod tests {
     /// Self-leave must drop the pending auto-vote registry — otherwise
     /// the next `tick_deadlines` would fire against a conversation
     /// we've left.
-    #[tokio::test]
-    async fn finalize_self_leave_clears_pending_auto_votes() {
+    #[test]
+    fn finalize_self_leave_clears_pending_auto_votes() {
         let transport: SharedDeliveryService = Arc::new(Mutex::new(NullTransport));
         let mut user = make_user_from_private_key(ALICE_KEY, transport);
-        user.start_conversation("test-conv", true).await.unwrap();
+        user.start_conversation("test-conv", true).unwrap();
 
         let session = user
             .lookup_entry("test-conv")
@@ -214,7 +209,7 @@ mod tests {
             "auto-vote must be registered before self-leave"
         );
 
-        user.finalize_self_leave("test-conv").await.unwrap();
+        user.finalize_self_leave("test-conv").unwrap();
 
         // Session entry is gone from the registry, so the conversation's
         // pending auto-votes can no longer fire from a poll cycle on this

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
-    pub async fn start_conversation(
+    pub fn start_conversation(
         &mut self,
         conversation_id: &str,
         is_creation: bool,
@@ -25,11 +25,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             is_creation,
             self.plugins.default_conversation_config.clone(),
         )
-        .await
     }
 
     /// Like [`Self::start_conversation`] but with a per-conversation config override.
-    pub async fn start_conversation_with_config(
+    pub fn start_conversation_with_config(
         &mut self,
         conversation_id: &str,
         is_creation: bool,
@@ -140,7 +139,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// consensus session with the leaver's YES bundled at submit. We stay
     /// active until the next steward commit merges the removal; on that
     /// commit `ProcessResult::LeaveConversation` fires.
-    pub async fn leave_conversation(&mut self, conversation_id: &str) -> Result<(), UserError> {
+    pub fn leave_conversation(&mut self, conversation_id: &str) -> Result<(), UserError> {
         info!(conversation = conversation_id, "leaving conversation");
 
         let entry_arc = self
@@ -158,7 +157,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 .emit_event(SessionEvent::Leaving);
             // Cancel auto-vote timers before removing the registry entry —
             // see `finalize_self_leave` for the rationale.
-            self.cleanup_consensus_scope(conversation_id).await?;
+            self.cleanup_consensus_scope(conversation_id)?;
             self.conversations
                 .write()
                 .map_err(|_| UserError::LockPoisoned("conversation registry"))?
@@ -167,6 +166,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             return Ok(());
         }
 
-        SessionRunner::initiate_self_leave(&entry_arc).await
+        SessionRunner::initiate_self_leave(&entry_arc)
     }
 }

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -70,8 +70,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         // Creator path: bootstrap the list with self as sole steward at
         // epoch 0. Joiner path leaves the plug-in empty until `ConversationSync`.
         if is_creation {
-            let _events =
-                steward_list.install_list(0, std::slice::from_ref(&self_member_id_bytes), 1, 0)?;
+            steward_list.install_list(0, std::slice::from_ref(&self_member_id_bytes), 1, 0)?;
         }
 
         let mut scoring = self

--- a/src/app/user/plugins/consensus_context.rs
+++ b/src/app/user/plugins/consensus_context.rs
@@ -40,11 +40,11 @@ impl<P: ConsensusPlugin> ConsensusContext<P> {
 
     /// Drop a conversation's scope from the shared consensus storage.
     /// Called on conversation leave.
-    pub async fn delete_scope(
+    pub fn delete_scope(
         &self,
         scope: &P::Scope,
     ) -> Result<(), hashgraph_like_consensus::error::ConsensusError> {
-        self.storage.delete_scope(scope).await
+        self.storage.delete_scope(scope)
     }
 }
 

--- a/src/app/user/state.rs
+++ b/src/app/user/state.rs
@@ -118,7 +118,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// [`SessionRunner::send_app_message`]. Errors with
     /// `ConversationNotFound` if the conversation has been removed, or
     /// `ConversationBlocked` if the session is gating chat traffic.
-    pub async fn send_app_message(
+    pub fn send_app_message(
         &self,
         conversation_id: &str,
         message: Vec<u8>,
@@ -126,13 +126,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::send_app_message(&entry, message).await
+        SessionRunner::send_app_message(&entry, message)
     }
 
     /// Broadcast `key_package` on `conversation_id`'s welcome subtopic
     /// so existing members can propose adding us. Thin wrapper over
     /// [`SessionRunner::send_key_package`].
-    pub async fn send_key_package(
+    pub fn send_key_package(
         &self,
         conversation_id: &str,
         key_package: KeyPackageBytes,
@@ -140,16 +140,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::send_key_package(&entry, key_package).await
+        SessionRunner::send_key_package(&entry, key_package)
     }
 
     /// Walk pending deadlines on `conversation_id`. Thin wrapper over
     /// [`SessionRunner::tick_deadlines`].
-    pub async fn tick_deadlines(&self, conversation_id: &str) -> Result<SessionTick, UserError> {
+    pub fn tick_deadlines(&self, conversation_id: &str) -> Result<SessionTick, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::tick_deadlines(&entry).await
+        SessionRunner::tick_deadlines(&entry)
     }
 
     /// Advance every per-conversation polling path: deadlines (auto-votes
@@ -161,13 +161,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// transition the session is currently expecting. Drained events
     /// (e.g. `Leaving` on `PendingJoin` expiry) are read separately via
     /// [`Self::drain_events`].
-    pub async fn poll_session(&self, conversation_id: &str) -> Result<SessionTick, UserError> {
+    pub fn poll_session(&self, conversation_id: &str) -> Result<SessionTick, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::tick_deadlines(&entry).await?;
-        SessionRunner::poll_freeze_status(&entry).await?;
-        SessionRunner::check_member_freeze(&entry).await?;
+        SessionRunner::tick_deadlines(&entry)?;
+        SessionRunner::poll_freeze_status(&entry)?;
+        SessionRunner::check_member_freeze(&entry)?;
         SessionRunner::check_pending_join(&entry)?;
         Ok(entry.read_or_err("session")?.tick())
     }
@@ -197,7 +197,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Add; the resulting welcome arrives via
     /// [`crate::core::SessionEvent::WelcomeReady`] for the integrator to
     /// deliver out of band.
-    pub async fn add_member(
+    pub fn add_member(
         &self,
         conversation_id: &str,
         key_package_bytes: &[u8],
@@ -215,7 +215,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 },
             )),
         };
-        SessionRunner::initiate_proposal(&entry, request, CreatorVote::Yes).await?;
+        SessionRunner::initiate_proposal(&entry, request, CreatorVote::Yes)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -224,7 +224,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// through the integrator's transport). Returns the joined
     /// conversation name, or [`UserError::WelcomeNotForUs`] if the
     /// welcome doesn't address this user's key package.
-    pub async fn accept_welcome(
+    pub fn accept_welcome(
         &mut self,
         welcome_bytes: &[u8],
     ) -> Result<(String, SessionTick), UserError> {
@@ -236,7 +236,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let conversation_id = svc.conversation_id().to_string();
 
         if self.lookup_entry(&conversation_id)?.is_none() {
-            self.start_conversation(&conversation_id, false).await?;
+            self.start_conversation(&conversation_id, false)?;
         }
         let entry_arc = self
             .lookup_entry(&conversation_id)?
@@ -260,8 +260,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             &conversation_id,
             &entry_arc,
             crate::core::ProcessResult::JoinedConversation(conversation_id.clone()),
-        )
-        .await?;
+        )?;
         let tick = entry_arc.read_or_err("session")?.tick();
         Ok((conversation_id, tick))
     }
@@ -271,7 +270,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Cast the local member's manual vote on `proposal_id`. Cancels any
     /// pending auto-vote so the manual choice wins. Thin wrapper over
     /// [`SessionRunner::process_user_vote`].
-    pub async fn process_user_vote(
+    pub fn process_user_vote(
         &self,
         conversation_id: &str,
         proposal_id: u32,
@@ -280,14 +279,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::process_user_vote(&entry, proposal_id, vote).await?;
+        SessionRunner::process_user_vote(&entry, proposal_id, vote)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
     /// Open a `RemoveMember` consensus round targeting
     /// `ban_request.user_to_ban`. The local vote is bundled YES at submit.
     /// Thin wrapper over [`SessionRunner::process_ban_request`].
-    pub async fn process_ban_request(
+    pub fn process_ban_request(
         &self,
         conversation_id: &str,
         ban_request: BanRequest,
@@ -295,7 +294,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::process_ban_request(&entry, ban_request).await
+        SessionRunner::process_ban_request(&entry, ban_request)
     }
 
     /// Submit `request` as a fresh consensus proposal with
@@ -303,7 +302,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// [`Self::add_member`] / [`Self::process_ban_request`]; use those
     /// for membership changes. Thin wrapper over
     /// [`SessionRunner::initiate_proposal`].
-    pub async fn initiate_proposal(
+    pub fn initiate_proposal(
         &self,
         conversation_id: &str,
         request: ConversationUpdateRequest,
@@ -312,7 +311,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::initiate_proposal(&entry, request, creator_vote).await?;
+        SessionRunner::initiate_proposal(&entry, request, creator_vote)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -321,14 +320,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// [`SessionEvent::Leaving`] and the caller follows up with
     /// [`Self::finalize_self_leave`]. Thin wrapper over
     /// [`SessionRunner::initiate_self_leave`].
-    pub async fn initiate_self_leave(
-        &self,
-        conversation_id: &str,
-    ) -> Result<SessionTick, UserError> {
+    pub fn initiate_self_leave(&self, conversation_id: &str) -> Result<SessionTick, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::initiate_self_leave(&entry).await?;
+        SessionRunner::initiate_self_leave(&entry)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -483,7 +479,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Drop this conversation's consensus scope from the shared storage and
     /// clear every auto-vote registered for it. Called on leave and
     /// pending-join timeout.
-    pub async fn cleanup_consensus_scope(&self, conversation_id: &str) -> Result<(), UserError> {
+    pub fn cleanup_consensus_scope(&self, conversation_id: &str) -> Result<(), UserError> {
         if let Some(entry_arc) = self.lookup_entry(conversation_id)? {
             entry_arc
                 .write()
@@ -491,7 +487,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 .cancel_all_auto_votes();
         }
         let scope = P::Scope::from(conversation_id.to_string());
-        self.plugins.consensus.delete_scope(&scope).await?;
+        self.plugins.consensus.delete_scope(&scope)?;
         Ok(())
     }
 

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -188,6 +188,9 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         let k_max = mls.commit_batch_max();
         let approved = self.conversation.approved_proposals();
         let mut updates = Vec::with_capacity(approved.len().min(k_max));
+        // Joiners admitted by this batch, in Add order. Travels with the
+        // welcome so any holder can address delivery.
+        let mut joiner_identities = Vec::new();
         for (_pid, proposal) in approved.iter().take(k_max) {
             match proposal.payload.as_ref() {
                 Some(Payload::MemberInvite(im)) => {
@@ -201,6 +204,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
                         im.key_package_bytes.clone(),
                         im.member_id.clone(),
                     )));
+                    joiner_identities.push(im.member_id.clone());
                 }
                 Some(Payload::RemoveMember(rm)) => {
                     if let Some(target) = urgent_target.as_deref()
@@ -245,6 +249,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
                 commit_hash,
                 is_local_candidate: true,
                 welcome_bytes: welcome,
+                joiner_identities,
             },
             epoch,
             max_candidates,

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -10,6 +10,7 @@ use crate::{
         ConversationQueues, ConversationState, ConversationStateMachine, CoreError,
         FreezeBufferOutcome, FreezeFinalizeResult, OperatingMode, ProcessResult, ProposalKind,
         StewardListPlugin, compute_commit_hash, finalize_freeze_round, member_set, process_inbound,
+        replay_early_candidates,
     },
     ds::{APP_MSG_SUBTOPIC, OutboundPacket},
     mls_crypto::{
@@ -297,6 +298,16 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
             allow_subset_candidates,
             self_member_id,
         )
+    }
+
+    /// Re-buffer commit candidates stashed before their proposal was locally
+    /// approved. Call after applying a consensus outcome. No-op when MLS isn't
+    /// attached or nothing is stashed.
+    pub(crate) fn replay_early_candidates(&mut self) -> Result<(), CoreError> {
+        let Some(mls) = self.mls.as_mut() else {
+            return Ok(());
+        };
+        replay_early_candidates(&mut self.conversation, mls)
     }
 
     /// Process an inbound app-subtopic payload. Errors with

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -25,7 +25,7 @@ use crate::{
 /// state, the MLS service, plug-ins, state machine, durable config, and
 /// operating mode behind one type parameter.
 pub struct Conversation<CP: ConversationPluginsFactory> {
-    pub conversation: ConversationQueues,
+    pub queues: ConversationQueues,
     /// Per-conversation MLS service. `None` for joiners in `PendingJoin` who
     /// haven't accepted a welcome yet; once attached via
     /// [`Self::attach_mls`] it stays `Some` for the conversation's lifetime.
@@ -46,7 +46,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
     /// Build a fresh conversation. Creator path passes `Some(mls)`; joiner
     /// path passes `None` and attaches later via [`Self::attach_mls`].
     pub(crate) fn new(
-        conversation: ConversationQueues,
+        queues: ConversationQueues,
         mls: Option<CP::Mls>,
         state_machine: ConversationStateMachine,
         config: ConversationConfig,
@@ -54,7 +54,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         steward_list: CP::StewardList,
     ) -> Self {
         Self {
-            conversation,
+            queues,
             mls,
             state_machine,
             config,
@@ -138,16 +138,16 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
             return Err(CoreError::NotASteward);
         }
 
-        if self.conversation.approved_proposals().is_empty() {
+        if self.queues.approved_proposals().is_empty() {
             return Err(CoreError::NoProposals);
         }
 
         // MLS forbids committing one's own removal. If the approved batch contains
         // RemoveMember(self), skip local candidate creation — another steward will
         // commit the batch (including this node's removal) once they enter freeze.
-        if self.conversation.has_approved_removal(self_member_id) {
+        if self.queues.has_approved_removal(self_member_id) {
             info!(
-                conversation = self.conversation.name(),
+                conversation = self.queues.name(),
                 "commit candidate skipped: approved batch contains self-remove"
             );
             return Ok(None);
@@ -156,7 +156,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         // Governance proposals (emergency, election) are consensus-only and must
         // not be in the approved queue at batch creation time.
         let non_mls_ids: Vec<u32> = self
-            .conversation
+            .queues
             .approved_proposals()
             .iter()
             .filter(|(_, req)| ProposalKind::of(req).is_governance())
@@ -182,12 +182,12 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
 
         // Urgent (ECP-driven) freeze: restrict the batch to just the target's
         // RemoveMember. See `ConversationQueues::urgent_commit_target`.
-        let urgent_target = self.conversation.urgent_commit_target().map(|t| t.to_vec());
+        let urgent_target = self.queues.urgent_commit_target().map(|t| t.to_vec());
 
         // Iterate in insertion order (FIFO): library proposal IDs are
         // content-derived hashes, so sort-by-id is not temporal.
         let k_max = mls.commit_batch_max();
-        let approved = self.conversation.approved_proposals();
+        let approved = self.queues.approved_proposals();
         let mut updates = Vec::with_capacity(approved.len().min(k_max));
         // Joiners admitted by this batch, in Add order. Travels with the
         // welcome so any holder can address delivery.
@@ -233,7 +233,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         } = mls.create_commit_candidate(&updates)?;
 
         let candidate = CommitCandidate {
-            conversation_id: self.conversation.name_bytes().to_vec(),
+            conversation_id: self.queues.name_bytes().to_vec(),
             mls_proposals,
             commit_message: commit,
             steward_member_id: self_member_id.to_vec(),
@@ -244,7 +244,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         let commit_hash = compute_commit_hash(&candidate.commit_message);
         let epoch = mls.current_epoch()?;
         let max_candidates = mls.members()?.len();
-        let outcome = self.conversation.add_freeze_candidate(
+        let outcome = self.queues.add_freeze_candidate(
             BufferedCommitCandidate {
                 candidate_msg: candidate.clone(),
                 commit_hash,
@@ -259,7 +259,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         // `FreezeBufferOutcome`), not errors — log at debug.
         if !matches!(outcome, FreezeBufferOutcome::Buffered) {
             tracing::debug!(
-                conversation = self.conversation.name(),
+                conversation = self.queues.name(),
                 epoch,
                 ?outcome,
                 "local commit candidate not buffered",
@@ -267,7 +267,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         }
 
         info!(
-            conversation = self.conversation.name(),
+            conversation = self.queues.name(),
             epoch,
             proposals = updates.len(),
             "commit candidate created"
@@ -277,7 +277,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         Ok(Some(OutboundPacket::new(
             candidate_msg.encode_to_vec(),
             APP_MSG_SUBTOPIC,
-            self.conversation.name(),
+            self.queues.name(),
             app_id,
         )))
     }
@@ -291,7 +291,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         let in_recovery = self.operating_mode == OperatingMode::Recovery;
         let mls = self.mls.as_mut().ok_or(CoreError::MlsGroupNotInitialized)?;
         finalize_freeze_round(
-            &mut self.conversation,
+            &mut self.queues,
             mls,
             &self.steward_list,
             in_recovery,
@@ -307,7 +307,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
         let Some(mls) = self.mls.as_mut() else {
             return Ok(());
         };
-        replay_early_candidates(&mut self.conversation, mls)
+        replay_early_candidates(&mut self.queues, mls)
     }
 
     /// Process an inbound app-subtopic payload. Errors with
@@ -315,7 +315,7 @@ impl<CP: ConversationPluginsFactory> Conversation<CP> {
     /// attached — caller should check `mls().is_some()` first.
     pub(crate) fn process_inbound(&mut self, payload: &[u8]) -> Result<ProcessResult, CoreError> {
         let mls = self.mls.as_mut().ok_or(CoreError::MlsGroupNotInitialized)?;
-        process_inbound(&mut self.conversation, mls, payload)
+        process_inbound(&mut self.queues, mls, payload)
     }
 }
 
@@ -366,9 +366,7 @@ mod tests {
             .with_creator(vec![0x01])
             .into_update_request()
             .unwrap();
-        conversation
-            .conversation
-            .insert_approved_proposal(50, emergency);
+        conversation.queues.insert_approved_proposal(50, emergency);
 
         let err = conversation
             .create_commit_candidate(b"me", b"app")

--- a/src/core/conversation/queues.rs
+++ b/src/core/conversation/queues.rs
@@ -121,6 +121,13 @@ pub struct ConversationQueues {
     /// and fall an epoch behind. Epoch-tagged; stale-epoch entries are
     /// discarded on the next stash/take.
     early_candidates: Vec<(u64, CommitCandidate)>,
+    /// MLS epoch at which each member was first added. A member is "settled"
+    /// once the epoch has advanced past their join — until then they aren't
+    /// counted toward the `> sn_max` election trigger or chosen as a steward,
+    /// since a just-joined member may not have attached MLS yet. Recorded on
+    /// every commit-merge from that commit's Add set, so all nodes that apply
+    /// the commit agree on who joined when.
+    member_join_epoch: HashMap<Vec<u8>, u64>,
 }
 
 impl ConversationQueues {
@@ -137,6 +144,7 @@ impl ConversationQueues {
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
             early_candidates: Vec::new(),
+            member_join_epoch: HashMap::new(),
         }
     }
 
@@ -156,6 +164,43 @@ impl ConversationQueues {
     pub fn steward_eligibility(&self, mls_members: &[Vec<u8>]) -> impl Fn(&[u8]) -> bool {
         let mls_set = member_set(mls_members);
         move |candidate: &[u8]| !self.has_approved_removal(candidate) && mls_set.contains(candidate)
+    }
+
+    // ─────────────────────────── Settled membership ───────────────────────────
+
+    /// Record the join epoch of each member added by a just-merged commit.
+    /// Idempotent: an existing entry is never overwritten, so a member's join
+    /// epoch is the first time we saw them added.
+    pub fn note_member_joins(&mut self, batch: &[ConversationUpdateRequest], epoch: u64) {
+        for req in batch {
+            if let Some(conversation_update_request::Payload::MemberInvite(im)) =
+                req.payload.as_ref()
+            {
+                self.member_join_epoch
+                    .entry(im.member_id.clone())
+                    .or_insert(epoch);
+            }
+        }
+    }
+
+    /// A member is settled once the epoch has advanced past their join. An
+    /// unknown member (joined before we started tracking, e.g. the creator) is
+    /// treated as settled.
+    pub fn is_settled(&self, member_id: &[u8], current_epoch: u64) -> bool {
+        self.member_join_epoch
+            .get(member_id)
+            .is_none_or(|&join_epoch| join_epoch < current_epoch)
+    }
+
+    /// Members eligible to act as stewards this epoch: present and settled.
+    /// Excludes members added by the current epoch's commit, who may not have
+    /// attached MLS yet.
+    pub fn settled_members(&self, members: &[Vec<u8>], current_epoch: u64) -> Vec<Vec<u8>> {
+        members
+            .iter()
+            .filter(|m| self.is_settled(m, current_epoch))
+            .cloned()
+            .collect()
     }
 
     // ─────────────────────────── Approved Proposals ───────────────────────────
@@ -511,6 +556,8 @@ impl ConversationQueues {
     /// sweep to catch auto-approved entries that survived freeze failures.
     pub fn prune_pending_updates_for_members(&mut self, current_members: &[Vec<u8>]) {
         let in_conversation: HashSet<&Vec<u8>> = current_members.iter().collect();
+        self.member_join_epoch
+            .retain(|member_id, _| in_conversation.contains(member_id));
         self.pending_updates.retain(|member_id, entry| {
             match entry.request.payload.as_ref() {
                 Some(conversation_update_request::Payload::MemberInvite(_)) => {

--- a/src/core/conversation/queues.rs
+++ b/src/core/conversation/queues.rs
@@ -115,18 +115,12 @@ pub struct ConversationQueues {
     /// dilute the fast-removal intent.
     urgent_commit_target: Option<Vec<u8>>,
     /// Commit candidates that arrived before the local node approved their
-    /// proposal (consensus outcome still in flight). Held here instead of
-    /// dropped so they can be replayed once approval lands — otherwise a
-    /// proposer whose steward reaches consensus first would miss the commit
-    /// and fall an epoch behind. Epoch-tagged; stale-epoch entries are
-    /// discarded on the next stash/take.
+    /// proposal; replayed once approval lands so the proposer doesn't fall an
+    /// epoch behind. Epoch-tagged; stale entries dropped on the next stash/take.
     early_candidates: Vec<(u64, CommitCandidate)>,
-    /// MLS epoch at which each member was first added. A member is "settled"
-    /// once the epoch has advanced past their join — until then they aren't
-    /// counted toward the `> sn_max` election trigger or chosen as a steward,
-    /// since a just-joined member may not have attached MLS yet. Recorded on
-    /// every commit-merge from that commit's Add set, so all nodes that apply
-    /// the commit agree on who joined when.
+    /// Join epoch per member, recorded from each commit's Add set. Drives the
+    /// "settled" check (see [`Self::is_settled`]); deterministic across nodes
+    /// that apply the same commit.
     member_join_epoch: HashMap<Vec<u8>, u64>,
 }
 
@@ -168,9 +162,8 @@ impl ConversationQueues {
 
     // ─────────────────────────── Settled membership ───────────────────────────
 
-    /// Record the join epoch of each member added by a just-merged commit.
-    /// Idempotent: an existing entry is never overwritten, so a member's join
-    /// epoch is the first time we saw them added.
+    /// Record the join epoch of each member a just-merged commit added.
+    /// Idempotent — keeps the first epoch we saw a member added.
     pub fn note_member_joins(&mut self, batch: &[ConversationUpdateRequest], epoch: u64) {
         for req in batch {
             if let Some(conversation_update_request::Payload::MemberInvite(im)) =
@@ -183,18 +176,15 @@ impl ConversationQueues {
         }
     }
 
-    /// A member is settled once the epoch has advanced past their join. An
-    /// unknown member (joined before we started tracking, e.g. the creator) is
-    /// treated as settled.
+    /// Settled once the epoch has advanced past the member's join. Unknown
+    /// members (present before tracking, e.g. the creator) count as settled.
     pub fn is_settled(&self, member_id: &[u8], current_epoch: u64) -> bool {
         self.member_join_epoch
             .get(member_id)
             .is_none_or(|&join_epoch| join_epoch < current_epoch)
     }
 
-    /// Members eligible to act as stewards this epoch: present and settled.
-    /// Excludes members added by the current epoch's commit, who may not have
-    /// attached MLS yet.
+    /// The settled subset of `members` — steward-eligible this epoch.
     pub fn settled_members(&self, members: &[Vec<u8>], current_epoch: u64) -> Vec<Vec<u8>> {
         members
             .iter()

--- a/src/core/conversation/queues.rs
+++ b/src/core/conversation/queues.rs
@@ -46,6 +46,10 @@ pub struct BufferedCommitCandidate {
     pub commit_hash: CommitHash,
     pub is_local_candidate: bool,
     pub welcome_bytes: Option<Vec<u8>>,
+    /// Member ids admitted by this commit's welcome (one per Add). Set only
+    /// on the local candidate, where `welcome_bytes` is held; empty on remote
+    /// candidates, which never carry a welcome.
+    pub joiner_identities: Vec<Vec<u8>>,
 }
 
 /// Outcome of [`ConversationQueues::add_freeze_candidate`]. An enum rather than

--- a/src/core/conversation/queues.rs
+++ b/src/core/conversation/queues.rs
@@ -114,6 +114,13 @@ pub struct ConversationQueues {
     /// `RemoveMember(target)` entry; other approvals wait so they don't
     /// dilute the fast-removal intent.
     urgent_commit_target: Option<Vec<u8>>,
+    /// Commit candidates that arrived before the local node approved their
+    /// proposal (consensus outcome still in flight). Held here instead of
+    /// dropped so they can be replayed once approval lands — otherwise a
+    /// proposer whose steward reaches consensus first would miss the commit
+    /// and fall an epoch behind. Epoch-tagged; stale-epoch entries are
+    /// discarded on the next stash/take.
+    early_candidates: Vec<(u64, CommitCandidate)>,
 }
 
 impl ConversationQueues {
@@ -129,6 +136,7 @@ impl ConversationQueues {
             pending_updates: HashMap::new(),
             resolved_proposals: ResolvedProposalCache::new(RESOLVED_PROPOSAL_CACHE_CAPACITY),
             urgent_commit_target: None,
+            early_candidates: Vec::new(),
         }
     }
 
@@ -372,6 +380,33 @@ impl ConversationQueues {
             .as_ref()
             .map(|r| r.candidates.len())
             .unwrap_or(0)
+    }
+
+    // ──────────────────────── Early (pre-approval) Candidates ────────────────────────
+
+    /// Stash a commit candidate that arrived before its proposal was locally
+    /// approved. Deduped by commit message and capped at `max`. Entries tagged
+    /// with a different epoch are dropped — the node has moved on.
+    pub fn stash_early_candidate(&mut self, epoch: u64, candidate: CommitCandidate, max: usize) {
+        self.early_candidates.retain(|(e, _)| *e == epoch);
+        let duplicate = self
+            .early_candidates
+            .iter()
+            .any(|(_, c)| c.commit_message == candidate.commit_message);
+        if duplicate || self.early_candidates.len() >= max {
+            return;
+        }
+        self.early_candidates.push((epoch, candidate));
+    }
+
+    /// Remove and return stashed candidates for `epoch`, discarding any tagged
+    /// with a different (stale) epoch. Clears the stash.
+    pub fn take_early_candidates(&mut self, epoch: u64) -> Vec<CommitCandidate> {
+        std::mem::take(&mut self.early_candidates)
+            .into_iter()
+            .filter(|(e, _)| *e == epoch)
+            .map(|(_, c)| c)
+            .collect()
     }
 
     /// Whether a freeze round is currently open.

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -168,7 +168,8 @@ fn apply_local_candidate<M: MlsService>(
 ) -> Result<CandidateOutcome, CoreError> {
     mls.merge_own_commit()?;
 
-    let committed_batch = finalize_committed_batch(conversation, chosen.commit_hash);
+    let committed_batch =
+        finalize_committed_batch(conversation, chosen.commit_hash, mls.current_epoch()?);
 
     // Build the welcome artifact only after merge.
     let joiner_identities = chosen.joiner_identities;
@@ -243,7 +244,8 @@ fn apply_incoming_candidate<M: MlsService, St: StewardListPlugin>(
     }
 
     mls.merge_staged_commit()?;
-    let committed_batch = finalize_committed_batch(conversation, chosen.commit_hash);
+    let committed_batch =
+        finalize_committed_batch(conversation, chosen.commit_hash, mls.current_epoch()?);
 
     // Remote candidates never carry welcome bytes — only the author sends those.
     let result = if self_removed {
@@ -437,6 +439,7 @@ fn check_commit_sender_authorized<St: StewardListPlugin>(
 fn finalize_committed_batch(
     conversation: &mut ConversationQueues,
     commit_hash: CommitHash,
+    current_epoch: u64,
 ) -> Vec<ConversationUpdateRequest> {
     conversation.insert_committed_hash(commit_hash);
     let snapshot = if let Some(target) = conversation.take_urgent_commit_target() {
@@ -446,6 +449,9 @@ fn finalize_committed_batch(
     } else {
         conversation.drain_approved_proposals()
     };
+    // Stamp join epochs for members this commit added, so the next reconcile
+    // doesn't count them toward an election they can't yet participate in.
+    conversation.note_member_joins(&snapshot, current_epoch);
     conversation.clear_freeze_round();
     snapshot
 }

--- a/src/core/freeze/apply.rs
+++ b/src/core/freeze/apply.rs
@@ -171,9 +171,11 @@ fn apply_local_candidate<M: MlsService>(
     let committed_batch = finalize_committed_batch(conversation, chosen.commit_hash);
 
     // Build the welcome artifact only after merge.
+    let joiner_identities = chosen.joiner_identities;
     let welcome = chosen.welcome_bytes.map(|welcome_bytes| MemberWelcome {
         welcome_bytes,
         conversation_sync_bytes: Vec::new(),
+        joiner_identities,
     });
 
     let result = if ctx.self_remove_pending {

--- a/src/core/freeze/mod.rs
+++ b/src/core/freeze/mod.rs
@@ -10,5 +10,5 @@ mod round;
 
 pub use round::{
     CommitHash, FreezeFinalizeResult, FreezeOutcome, buffer_commit_candidate, compute_commit_hash,
-    finalize_freeze_round,
+    finalize_freeze_round, replay_early_candidates,
 };

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -124,6 +124,7 @@ pub fn buffer_commit_candidate<M: MlsService>(
             commit_hash,
             is_local_candidate: false,
             welcome_bytes: None,
+            joiner_identities: Vec::new(),
         },
         epoch,
         max_candidates,
@@ -367,6 +368,7 @@ mod tests {
             commit_hash,
             is_local_candidate: false,
             welcome_bytes: None,
+            joiner_identities: Vec::new(),
         }
     }
 

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -106,18 +106,24 @@ pub fn buffer_commit_candidate<M: MlsService>(
     }
 
     let epoch = mls.current_epoch()?;
+    let max_candidates = mls.members()?.len();
 
     // Valid candidate — auto-start a round if there are approved proposals.
     if !conversation.has_freeze_round() {
         if conversation.approved_proposals_count() == 0 {
-            tracing::debug!(conversation = %conversation_id, "candidate ignored: no approved proposals");
-            return Ok(ProcessResult::Noop(NoopReason::NoApprovedProposals));
+            // The proposal isn't locally approved yet — the consensus outcome
+            // is still in flight (a peer steward can reach consensus and
+            // broadcast this commit before we apply our own vote). Stash for
+            // replay once approval lands rather than dropping; otherwise we'd
+            // never apply the commit and would fall an epoch behind.
+            tracing::debug!(conversation = %conversation_id, "candidate stashed: proposal not yet approved");
+            conversation.stash_early_candidate(epoch, candidate_msg, max_candidates);
+            return Ok(ProcessResult::Noop(NoopReason::CandidateStashedEarly));
         }
         conversation.start_freeze_round(epoch);
     }
 
     let steward = candidate_msg.steward_member_id.clone();
-    let max_candidates = mls.members()?.len();
     let outcome = conversation.add_freeze_candidate(
         BufferedCommitCandidate {
             candidate_msg,
@@ -150,6 +156,21 @@ pub fn buffer_commit_candidate<M: MlsService>(
             Ok(ProcessResult::Noop(NoopReason::CandidateBufferFull))
         }
     }
+}
+
+/// Re-buffer any commit candidates stashed before their proposal was locally
+/// approved. Call after a consensus outcome populates the approved queue: a
+/// candidate that lost the race against its own approval is now buffered into
+/// the freeze round and applied normally. No-op when nothing is stashed.
+pub fn replay_early_candidates<M: MlsService>(
+    conversation: &mut ConversationQueues,
+    mls: &mut M,
+) -> Result<(), CoreError> {
+    let epoch = mls.current_epoch()?;
+    for candidate in conversation.take_early_candidates(epoch) {
+        buffer_commit_candidate(conversation, mls, candidate)?;
+    }
+    Ok(())
 }
 
 /// Snapshot round state, rank the buffered candidates by RFC priority, and

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -72,7 +72,7 @@ pub use proposal_kind::ProposalKind;
 // ── Steward list ──
 pub use steward_list::{
     DEFAULT_MAX_RETRIES, DeterministicStewardList, ElectionDecision, StewardList,
-    StewardListConfig, StewardListEvent, StewardListPlugin,
+    StewardListConfig, StewardListPlugin,
 };
 
 // ── Consensus plug-in trait ──

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -38,6 +38,7 @@ mod steward_list;
 // ── Core conversation operations ──
 pub use freeze::{
     CommitHash, FreezeFinalizeResult, FreezeOutcome, compute_commit_hash, finalize_freeze_round,
+    replay_early_candidates,
 };
 pub use inbound::process_inbound;
 

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -84,6 +84,9 @@ pub enum NoopReason {
     DuplicateBufferedHash,
     /// Freeze-round buffer is full (one candidate per member already held).
     CandidateBufferFull,
+    /// Candidate arrived before its proposal was locally approved (consensus
+    /// outcome still in flight). Stashed for replay once approval lands.
+    CandidateStashedEarly,
 }
 
 // ── ViolationEvidence constructors ────────────────────────────────

--- a/src/core/steward_list/deterministic.rs
+++ b/src/core/steward_list/deterministic.rs
@@ -1,8 +1,8 @@
 //! [`DeterministicStewardList`] — SHA256-sorted [`super::StewardListPlugin`] impl.
 
 use crate::core::{
-    DEFAULT_MAX_RETRIES, ElectionDecision, StewardList, StewardListConfig, StewardListEvent,
-    StewardListPlugin, error::CoreError,
+    DEFAULT_MAX_RETRIES, ElectionDecision, StewardList, StewardListConfig, StewardListPlugin,
+    error::CoreError,
 };
 
 #[derive(Debug)]
@@ -130,7 +130,7 @@ impl StewardListPlugin for DeterministicStewardList {
         candidate_pool: &[Vec<u8>],
         sn: usize,
         retry_round: u32,
-    ) -> Result<Vec<StewardListEvent>, CoreError> {
+    ) -> Result<(), CoreError> {
         let list = StewardList::generate(
             epoch,
             &self.conversation_id,
@@ -139,13 +139,8 @@ impl StewardListPlugin for DeterministicStewardList {
             self.config.clone(),
             retry_round,
         )?;
-        let len = list.len();
         self.list = Some(list);
-        Ok(vec![StewardListEvent::ListInstalled {
-            epoch,
-            retry_round,
-            len,
-        }])
+        Ok(())
     }
 
     fn validate_proposed(
@@ -205,16 +200,8 @@ impl StewardListPlugin for DeterministicStewardList {
         })
     }
 
-    fn bump_retry(&mut self) -> Vec<StewardListEvent> {
+    fn bump_retry(&mut self) {
         self.next_retry_round = self.next_retry_round.saturating_add(1);
-        if self.next_retry_round > self.max_retries {
-            vec![StewardListEvent::RetryExhausted {
-                round: self.next_retry_round,
-                max: self.max_retries,
-            }]
-        } else {
-            Vec::new()
-        }
     }
 
     fn reset_retry(&mut self) {
@@ -259,18 +246,10 @@ mod tests {
     }
 
     #[test]
-    fn install_emits_list_installed_event() {
+    fn install_sets_current_list() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let events = p.install_list(0, &mems, 3, 0).unwrap();
-        assert_eq!(
-            events,
-            vec![StewardListEvent::ListInstalled {
-                epoch: 0,
-                retry_round: 0,
-                len: 3,
-            }]
-        );
+        p.install_list(0, &mems, 3, 0).unwrap();
         assert_eq!(p.current_list().unwrap().len(), 3);
         assert_eq!(p.election_epoch(), Some(0));
     }
@@ -279,7 +258,7 @@ mod tests {
     fn epoch_steward_filters_by_eligibility() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
 
         let nominal = p.epoch_steward(0, |_: &[u8]| true).unwrap().to_vec();
         let next = p
@@ -294,7 +273,7 @@ mod tests {
         let mut p =
             DeterministicStewardList::empty(b"g".to_vec(), StewardListConfig::new(3, 3).unwrap());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
 
         let (e, b) = p.epoch_and_backup(0, |_: &[u8]| true);
         assert!(e.is_some() && b.is_some());
@@ -305,7 +284,7 @@ mod tests {
     fn backup_is_none_when_only_one_eligible() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
 
         let survivor = mems[0].clone();
         let (e, b) = p.epoch_and_backup(0, |c: &[u8]| c == survivor.as_slice());
@@ -314,24 +293,27 @@ mod tests {
     }
 
     #[test]
-    fn bump_retry_emits_exhausted_after_max() {
+    fn bump_retry_increments_round_past_max() {
+        // Exhaustion is detected by the caller comparing next_retry_round()
+        // against max_retries() (config default = 1).
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
-        assert!(p.bump_retry().is_empty());
+        p.bump_retry();
         assert_eq!(p.next_retry_round(), 1);
+        assert!(p.next_retry_round() <= p.max_retries());
 
-        let events = p.bump_retry();
-        assert_eq!(
-            events,
-            vec![StewardListEvent::RetryExhausted { round: 2, max: 1 }]
-        );
+        p.bump_retry();
         assert_eq!(p.next_retry_round(), 2);
+        assert!(
+            p.next_retry_round() > p.max_retries(),
+            "round 2 exceeds max 1"
+        );
     }
 
     #[test]
     fn reset_retry_clears_round() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
-        let _ = p.bump_retry();
-        let _ = p.bump_retry();
+        p.bump_retry();
+        p.bump_retry();
         assert_eq!(p.next_retry_round(), 2);
         p.reset_retry();
         assert_eq!(p.next_retry_round(), 0);
@@ -341,7 +323,7 @@ mod tests {
     fn validate_proposed_against_self_derived_list() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
         let proposed = p.current_list().unwrap().members().to_vec();
         assert!(p.validate_proposed(&proposed, 0, &mems, 0).unwrap());
     }
@@ -350,7 +332,7 @@ mod tests {
     fn validate_proposed_rejects_tampered_order() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
         let mut tampered = p.current_list().unwrap().members().to_vec();
         tampered.swap(0, 1);
         assert!(!p.validate_proposed(&tampered, 0, &mems, 0).unwrap());
@@ -360,7 +342,7 @@ mod tests {
     fn steward_members_returns_filtered_roster() {
         let mut p = DeterministicStewardList::empty(b"g".to_vec(), config());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
         let dropped = mems[0].clone();
         let filtered = p.steward_members(|c: &[u8]| c != dropped.as_slice());
         assert_eq!(filtered.len(), 2);
@@ -374,12 +356,13 @@ mod tests {
         assert_eq!(p.max_retries(), 3);
 
         for _ in 0..3 {
-            assert!(p.bump_retry().is_empty());
+            p.bump_retry();
+            assert!(p.next_retry_round() <= p.max_retries());
         }
-        let events = p.bump_retry();
-        assert_eq!(
-            events,
-            vec![StewardListEvent::RetryExhausted { round: 4, max: 3 }]
+        p.bump_retry();
+        assert!(
+            p.next_retry_round() > p.max_retries(),
+            "round 4 exceeds max 3"
         );
     }
 
@@ -388,7 +371,7 @@ mod tests {
         let mut p =
             DeterministicStewardList::empty(b"g".to_vec(), StewardListConfig::new(3, 3).unwrap());
         let mems = members(&[1, 2, 3]);
-        let _ = p.install_list(0, &mems, 3, 0).unwrap();
+        p.install_list(0, &mems, 3, 0).unwrap();
 
         let proposer = p.election_proposer(|_: &[u8]| true).unwrap().to_vec();
         let next = p

--- a/src/core/steward_list/mod.rs
+++ b/src/core/steward_list/mod.rs
@@ -13,4 +13,4 @@ mod plugin;
 
 pub use deterministic::DeterministicStewardList;
 pub use list::{StewardList, StewardListConfig};
-pub use plugin::{DEFAULT_MAX_RETRIES, ElectionDecision, StewardListEvent, StewardListPlugin};
+pub use plugin::{DEFAULT_MAX_RETRIES, ElectionDecision, StewardListPlugin};

--- a/src/core/steward_list/plugin.rs
+++ b/src/core/steward_list/plugin.rs
@@ -1,4 +1,4 @@
-//! [`StewardListPlugin`] trait, events, and election vocabulary.
+//! [`StewardListPlugin`] trait and election vocabulary.
 
 use crate::core::error::CoreError;
 use crate::core::steward_list::list::{StewardList, StewardListConfig};
@@ -16,19 +16,6 @@ pub enum ElectionDecision {
         election_epoch: u64,
         retry_round: u32,
     },
-}
-
-/// Side effect from a plug-in mutator; drained by the coordinator.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StewardListEvent {
-    /// New list installed — broadcast `ConversationSync`.
-    ListInstalled {
-        epoch: u64,
-        retry_round: u32,
-        len: usize,
-    },
-    /// `bump_retry` exceeded [`StewardListPlugin::max_retries`] — escalate to `Deadlock` ECP.
-    RetryExhausted { round: u32, max: u32 },
 }
 
 /// Per-conversation steward roster. Eligibility flows in via `Fn(&[u8]) -> bool`
@@ -90,7 +77,7 @@ pub trait StewardListPlugin {
         candidate_pool: &[Vec<u8>],
         sn: usize,
         retry_round: u32,
-    ) -> Result<Vec<StewardListEvent>, CoreError>;
+    ) -> Result<(), CoreError>;
 
     /// `true` if `proposed` matches [`StewardList::validate`] for these parameters.
     fn validate_proposed(
@@ -111,8 +98,9 @@ pub trait StewardListPlugin {
         recovery: bool,
     ) -> Result<ElectionDecision, CoreError>;
 
-    /// Increment retry round; may emit [`StewardListEvent::RetryExhausted`].
-    fn bump_retry(&mut self) -> Vec<StewardListEvent>;
+    /// Increment the retry round. Exhaustion is detected by the caller via
+    /// [`Self::next_retry_round`] vs [`Self::max_retries`].
+    fn bump_retry(&mut self);
 
     fn reset_retry(&mut self);
 }

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -102,6 +102,10 @@ message RemoveMember {
 message MemberWelcome {
   bytes welcome_bytes = 1;
   bytes conversation_sync_bytes = 2;
+  // Member ids of the joiners this welcome admits (one per Add in the
+  // commit). Lets the committing steward — or any later holder — address
+  // delivery without out-of-band invite tracking.
+  repeated bytes joiner_identities = 3;
 }
 
 message ConversationSync {

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -19,7 +19,7 @@ use crate::{
     core::{
         ConsensusPlugin, ConsensusServiceFor, ConversationPluginsFactory, ElectionDecision,
         PeerScoringPlugin, ScoreOp, ScoreSnapshot, ScoringConfig, StewardList, StewardListConfig,
-        StewardListEvent, StewardListPlugin,
+        StewardListPlugin,
     },
     defaults::{DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage},
     ds::{OutboundPacket, SharedDeliveryService},

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -19,7 +19,7 @@ use crate::{
     core::{
         ConsensusPlugin, ConversationPluginsFactory, ElectionDecision, PeerScoringPlugin,
         PluginConsensus, ScoreOp, ScoreSnapshot, ScoringConfig, StewardList, StewardListConfig,
-        StewardListEvent, StewardListPlugin,
+        StewardListPlugin,
     },
     defaults::{DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage},
     ds::{OutboundPacket, SharedDeliveryService},
@@ -251,7 +251,7 @@ impl StewardListPlugin for StubStewardList {
         _: &[Vec<u8>],
         _: usize,
         _: u32,
-    ) -> Result<Vec<StewardListEvent>, crate::core::CoreError> {
+    ) -> Result<(), crate::core::CoreError> {
         unreachable!()
     }
     fn validate_proposed(
@@ -273,7 +273,7 @@ impl StewardListPlugin for StubStewardList {
     ) -> Result<ElectionDecision, crate::core::CoreError> {
         unreachable!()
     }
-    fn bump_retry(&mut self) -> Vec<StewardListEvent> {
+    fn bump_retry(&mut self) {
         unreachable!()
     }
     fn reset_retry(&mut self) {

--- a/tests/app_message_roundtrip.rs
+++ b/tests/app_message_roundtrip.rs
@@ -28,15 +28,13 @@ async fn chat_message_delivered_to_peer_as_app_message_event() {
     let alice_session = users[0].0.lookup_entry("chat").unwrap().unwrap();
     let bob_session = users[1].0.lookup_entry("chat").unwrap().unwrap();
 
-    SessionRunner::send_app_message(&alice_session, b"Hello from alice".to_vec())
-        .await
-        .unwrap();
+    SessionRunner::send_app_message(&alice_session, b"Hello from alice".to_vec()).unwrap();
 
     // Relay alice's outbound to bob.
     settle_for(Duration::from_millis(40)).await;
     let packets = users[0].1.lock().unwrap().drain_packets();
     for p in packets {
-        let _ = users[1].0.process_inbound_packet(to_inbound(&p)).await;
+        let _ = users[1].0.process_inbound_packet(to_inbound(&p));
     }
 
     let chat = bob_session

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -111,6 +111,7 @@ pub fn build_commit_candidate(
     let k_max = mls.commit_batch_max();
     let approved = group.approved_proposals();
     let mut updates = Vec::with_capacity(approved.len().min(k_max));
+    let mut joiner_identities = Vec::new();
     for (_pid, proposal) in approved.iter().take(k_max) {
         match proposal.payload.as_ref() {
             Some(conversation_update_request::Payload::MemberInvite(im)) => {
@@ -124,6 +125,7 @@ pub fn build_commit_candidate(
                     im.key_package_bytes.clone(),
                     im.member_id.clone(),
                 )));
+                joiner_identities.push(im.member_id.clone());
             }
             Some(conversation_update_request::Payload::RemoveMember(rm)) => {
                 if let Some(target) = urgent_target.as_deref()
@@ -166,6 +168,7 @@ pub fn build_commit_candidate(
             commit_hash,
             is_local_candidate: true,
             welcome_bytes: welcome,
+            joiner_identities,
         },
         epoch,
         max_candidates,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -303,7 +303,7 @@ pub fn setup_steward_with_config(
     let group = ConversationQueues::new(conversation_id);
     let mut steward_list =
         DeterministicStewardList::empty(conversation_id.as_bytes().to_vec(), config);
-    let _events = steward_list
+    steward_list
         .install_list(0, std::slice::from_ref(&member_id_bytes), 1, 0)
         .expect("bootstrap list install");
     StewardHandle {

--- a/tests/common/session_fixtures.rs
+++ b/tests/common/session_fixtures.rs
@@ -158,7 +158,7 @@ pub fn to_inbound(p: &OutboundPacket) -> InboundPacket {
     )
 }
 
-/// Sleep 100 ms — recovery_cascade.rs convention for letting an async
+/// Sleep 100 ms — recovery_cascade.rs convention for letting an
 /// poll loop catch up after a single round of state changes.
 pub async fn settle() {
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -171,17 +171,17 @@ pub async fn settle_for(d: Duration) {
 
 /// Deliver one packet to a single user. Returns the raw `process_inbound_packet`
 /// result so the caller can assert success or error.
-pub async fn deliver(user: &TestUser, p: &OutboundPacket) {
-    let _ = user.process_inbound_packet(to_inbound(p)).await;
+pub fn deliver(user: &TestUser, p: &OutboundPacket) {
+    let _ = user.process_inbound_packet(to_inbound(p));
 }
 
 /// Deliver each packet to every receiver. Errors are swallowed (mirrors
 /// pubsub-style relay where a delivery failure on one node doesn't stop
 /// the relay).
-pub async fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
+pub fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
     for p in packets {
         for r in receivers {
-            let _ = r.process_inbound_packet(to_inbound(p)).await;
+            let _ = r.process_inbound_packet(to_inbound(p));
         }
     }
 }
@@ -194,10 +194,7 @@ pub async fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
 /// once per polling round, BEFORE relaying packets — same-round
 /// app-msg packets (e.g. the post-commit steward election proposal)
 /// need the joiner's MLS attached first.
-pub async fn route_welcomes(
-    sessions: &[SessionArc],
-    users: &mut [(TestUser, TransportHandle)],
-) -> usize {
+pub fn route_welcomes(sessions: &[SessionArc], users: &mut [(TestUser, TransportHandle)]) -> usize {
     use de_mls::core::SessionEvent;
     use de_mls::protos::de_mls::messages::v1::MemberWelcome;
 
@@ -225,7 +222,7 @@ pub async fn route_welcomes(
             // `accept_welcome` surfaces as `Err(WelcomeNotForUs)`) for
             // anyone the welcome doesn't address. Only the targeted
             // joiner attaches MLS and gets the bundled sync replayed.
-            if u.accept_welcome(&welcome.welcome_bytes).await.is_ok() {
+            if u.accept_welcome(&welcome.welcome_bytes).is_ok() {
                 delivered += 1;
                 if !welcome.conversation_sync_bytes.is_empty() {
                     let sync_pkt = de_mls::ds::InboundPacket::new(
@@ -235,7 +232,7 @@ pub async fn route_welcomes(
                         welcomer_app_id.clone(),
                         0,
                     );
-                    let _ = u.process_inbound_packet(sync_pkt).await;
+                    let _ = u.process_inbound_packet(sync_pkt);
                 }
             }
         }
@@ -263,10 +260,10 @@ pub fn fast_test_config() -> ConversationConfig {
 /// One polling cycle on a session: drive freeze status, member-freeze
 /// check, and (for joiners) the pending-join tick. Mirrors the production
 /// `group_polling_loop` body in `de_mls_gateway::group`.
-pub async fn poll_once(session: &SessionArc) {
-    let _ = SessionRunner::tick_deadlines(session).await;
-    let _ = SessionRunner::poll_freeze_status(session).await;
-    let _ = SessionRunner::check_member_freeze(session).await;
+pub fn poll_once(session: &SessionArc) {
+    let _ = SessionRunner::tick_deadlines(session);
+    let _ = SessionRunner::poll_freeze_status(session);
+    let _ = SessionRunner::check_member_freeze(session);
     let _ = SessionRunner::check_pending_join(session);
 }
 
@@ -308,11 +305,9 @@ pub async fn bootstrap_joined_conversation(
     users[0]
         .0
         .start_conversation(conversation, true)
-        .await
         .expect("creator start");
     for (u, _) in users.iter_mut().skip(1) {
         u.start_conversation(conversation, false)
-            .await
             .expect("joiner start");
     }
 
@@ -328,16 +323,14 @@ pub async fn bootstrap_joined_conversation(
     // Joiners send KPs. Drain joiner transports, deliver to creator.
     for i in 1..users.len() {
         let kp = users[i].0.generate_key_package().expect("kp");
-        SessionRunner::send_key_package(&sessions[i], kp)
-            .await
-            .expect("send kp");
+        SessionRunner::send_key_package(&sessions[i], kp).expect("send kp");
     }
     let mut kp_packets = Vec::new();
     for (_, h) in users.iter().skip(1) {
         kp_packets.extend(h.lock().unwrap().drain_packets());
     }
     for p in &kp_packets {
-        let _ = users[0].0.process_inbound_packet(to_inbound(p)).await;
+        let _ = users[0].0.process_inbound_packet(to_inbound(p));
     }
 
     // Drive every session's polling and shuttle outbound packets until
@@ -353,7 +346,7 @@ pub async fn bootstrap_joined_conversation(
     for round in 0..MAX_ROUNDS {
         tokio::time::sleep(Duration::from_millis(60)).await;
         for s in &sessions {
-            poll_once(s).await;
+            poll_once(s);
         }
 
         // Welcomes never traverse the test transport: the steward emits
@@ -361,7 +354,7 @@ pub async fn bootstrap_joined_conversation(
         // its joiner BEFORE relaying packets — same-round app-msg
         // traffic (the post-commit steward election proposal) needs
         // the joiner's MLS attached first.
-        let delivered_welcome = route_welcomes(&sessions, &mut users).await > 0;
+        let delivered_welcome = route_welcomes(&sessions, &mut users) > 0;
 
         let mut packets = Vec::new();
         for (_, h) in &users {
@@ -371,7 +364,7 @@ pub async fn bootstrap_joined_conversation(
         // dedups echoes of our own messages via `app_id`.
         for p in &packets {
             for (u, _) in &users {
-                let _ = u.process_inbound_packet(to_inbound(p)).await;
+                let _ = u.process_inbound_packet(to_inbound(p));
             }
         }
 

--- a/tests/conversation_sync_idempotent.rs
+++ b/tests/conversation_sync_idempotent.rs
@@ -51,7 +51,7 @@ async fn second_conversation_sync_is_a_no_op() {
         .expect("steward must produce a sync packet");
 
     bob_tx.lock().unwrap().drain_packets();
-    deliver(&users[1].0, &sync_packet).await;
+    deliver(&users[1].0, &sync_packet);
     let bob_outbound_after = bob_tx.lock().unwrap().drain_packets();
     let roles_after = bob_session.read().unwrap().get_member_roles().unwrap();
     let scores_after = bob_session.read().unwrap().get_member_scores();

--- a/tests/freeze_coordinator_ordering.rs
+++ b/tests/freeze_coordinator_ordering.rs
@@ -56,9 +56,7 @@ async fn freeze_cycle_emits_phase_events_in_order() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&alice_session, remove_request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&alice_session, remove_request, CreatorVote::Yes).unwrap();
 
     // Drive polling + packet relay until both sessions are back in
     // Working (bob will actually exit the conversation, so we check
@@ -67,15 +65,15 @@ async fn freeze_cycle_emits_phase_events_in_order() {
     let mut saw_freezing = false;
     for _ in 0..40 {
         settle_for(Duration::from_millis(40)).await;
-        poll_once(&alice_session).await;
-        poll_once(&bob_session).await;
+        poll_once(&alice_session);
+        poll_once(&bob_session);
 
         let mut packets = Vec::new();
         packets.extend(alice_tx.lock().unwrap().drain_packets());
         packets.extend(bob_tx.lock().unwrap().drain_packets());
         for p in &packets {
-            let _ = users[0].0.process_inbound_packet(to_inbound(p)).await;
-            let _ = users[1].0.process_inbound_packet(to_inbound(p)).await;
+            let _ = users[0].0.process_inbound_packet(to_inbound(p));
+            let _ = users[1].0.process_inbound_packet(to_inbound(p));
         }
 
         alice_phases.extend(drain_phase_log(&alice_session));
@@ -87,7 +85,7 @@ async fn freeze_cycle_emits_phase_events_in_order() {
         if saw_freezing && alice_state == ConversationState::Working && packets.is_empty() {
             // Pump one more round to catch trailing events.
             settle_for(Duration::from_millis(40)).await;
-            poll_once(&alice_session).await;
+            poll_once(&alice_session);
             alice_phases.extend(drain_phase_log(&alice_session));
             break;
         }

--- a/tests/leave_after_removal.rs
+++ b/tests/leave_after_removal.rs
@@ -61,9 +61,7 @@ async fn removed_member_emits_leaving_and_is_evicted() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes).unwrap();
 
     // Drive packet relay + polling until the target is evicted from its
     // User registry. Mirrors the gateway's polling loop: when
@@ -74,17 +72,17 @@ async fn removed_member_emits_leaving_and_is_evicted() {
         settle_for(Duration::from_millis(40)).await;
         for (i, (u, _)) in users.iter().enumerate() {
             if let Some(s) = u.lookup_entry("leave").unwrap() {
-                let _ = SessionRunner::tick_deadlines(&s).await;
+                let _ = SessionRunner::tick_deadlines(&s);
                 if i == target_idx
                     && matches!(
-                        SessionRunner::poll_freeze_status(&s).await,
+                        SessionRunner::poll_freeze_status(&s),
                         Ok((_, DispatchOutcome::LeaveRequested))
                     )
                 {
-                    u.finalize_self_leave("leave").await.unwrap();
+                    u.finalize_self_leave("leave").unwrap();
                 } else {
-                    let _ = SessionRunner::poll_freeze_status(&s).await;
-                    let _ = SessionRunner::check_member_freeze(&s).await;
+                    let _ = SessionRunner::poll_freeze_status(&s);
+                    let _ = SessionRunner::check_member_freeze(&s);
                 }
             }
         }
@@ -94,7 +92,7 @@ async fn removed_member_emits_leaving_and_is_evicted() {
         }
         for p in &packets {
             for (u, _) in &users {
-                let _ = u.process_inbound_packet(to_inbound(p)).await;
+                let _ = u.process_inbound_packet(to_inbound(p));
             }
         }
         if users[target_idx].0.lookup_entry("leave").unwrap().is_none() {

--- a/tests/multi_conversation_isolation.rs
+++ b/tests/multi_conversation_isolation.rs
@@ -16,15 +16,14 @@ const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 // The whole point of this test is to hold one session's guard while
 // driving work on another — the await-holding-lock the lint flags is the
 // exact thing under assertion.
-#[allow(clippy::await_holding_lock)]
-#[tokio::test]
-async fn write_lock_on_one_session_does_not_block_others() {
+#[test]
+fn write_lock_on_one_session_does_not_block_others() {
     let cfg: ConversationConfig = fast_test_config();
     let steward_cfg = StewardListConfig::new(1, 5).unwrap();
     let (mut alice, _tx) = make_user(ALICE, cfg, steward_cfg);
 
-    alice.start_conversation("conv-a", true).await.unwrap();
-    alice.start_conversation("conv-b", true).await.unwrap();
+    alice.start_conversation("conv-a", true).unwrap();
+    alice.start_conversation("conv-b", true).unwrap();
 
     let session_a = alice.lookup_entry("conv-a").unwrap().unwrap();
     let session_b = alice.lookup_entry("conv-b").unwrap().unwrap();
@@ -61,7 +60,6 @@ async fn write_lock_on_one_session_does_not_block_others() {
     // composes with the outer isolation check without holding any guard
     // across an await.
     SessionRunner::check_member_freeze(&session_b)
-        .await
         .expect("check_member_freeze on conv-b must succeed");
 
     drop(a_guard);
@@ -69,6 +67,5 @@ async fn write_lock_on_one_session_does_not_block_others() {
     // After releasing, conv-a is also accessible — and the same static
     // entry point works against either Arc.
     SessionRunner::check_member_freeze(&session_a)
-        .await
         .expect("conv-a check_member_freeze must succeed");
 }

--- a/tests/operating_mode_transitions.rs
+++ b/tests/operating_mode_transitions.rs
@@ -53,23 +53,21 @@ async fn deadlock_ecp_opens_recovery_and_force_freezes() {
         .with_creator(b"alice-creator".to_vec())
         .into_update_request()
         .unwrap();
-    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes).unwrap();
 
     let mut alice_saw_freezing = false;
     let mut bob_saw_freezing = false;
     for _ in 0..30 {
         settle_for(Duration::from_millis(40)).await;
-        poll_once(&alice_session).await;
-        poll_once(&bob_session).await;
+        poll_once(&alice_session);
+        poll_once(&bob_session);
         let packets = alice_tx.lock().unwrap().drain_packets();
         for p in packets {
-            let _ = users[1].0.process_inbound_packet(to_inbound(&p)).await;
+            let _ = users[1].0.process_inbound_packet(to_inbound(&p));
         }
         let packets = bob_tx.lock().unwrap().drain_packets();
         for p in packets {
-            let _ = users[0].0.process_inbound_packet(to_inbound(&p)).await;
+            let _ = users[0].0.process_inbound_packet(to_inbound(&p));
         }
 
         alice_events.extend(alice_session.read().unwrap().drain_events());

--- a/tests/pending_join_eviction.rs
+++ b/tests/pending_join_eviction.rs
@@ -31,7 +31,7 @@ async fn pending_join_expires_evicts_entry_and_broadcasts_removal() {
 
     // Alice joins a conversation no one else is in — no welcome will ever
     // arrive. The session sits in PendingJoin.
-    alice.start_conversation(group, false).await.unwrap();
+    alice.start_conversation(group, false).unwrap();
     assert!(
         alice
             .list_conversations()
@@ -63,7 +63,7 @@ async fn pending_join_expires_evicts_entry_and_broadcasts_removal() {
     );
 
     // Cleanup pathway: caller follows up with finalize_self_leave.
-    alice.finalize_self_leave(group).await.unwrap();
+    alice.finalize_self_leave(group).unwrap();
 
     // Registry entry is gone.
     assert!(

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -101,10 +101,10 @@ async fn concurrent_joins_leave_joiners_with_empty_buffer() {
     let (mut dave, dh) = make(DAVE_KEY, cfg.clone(), steward_cfg.clone());
 
     // Step 1: alice creates the group. Bob/Charlie/Dave register as joiners.
-    alice.start_conversation(group, true).await.unwrap();
-    bob.start_conversation(group, false).await.unwrap();
-    charlie.start_conversation(group, false).await.unwrap();
-    dave.start_conversation(group, false).await.unwrap();
+    alice.start_conversation(group, true).unwrap();
+    bob.start_conversation(group, false).unwrap();
+    charlie.start_conversation(group, false).unwrap();
+    dave.start_conversation(group, false).unwrap();
 
     // Step 2: All three joiners send KPs nearly simultaneously. Before the
     // buffer-hygiene fix, each joiner would buffer the others' KPs observed
@@ -112,7 +112,7 @@ async fn concurrent_joins_leave_joiners_with_empty_buffer() {
     for u in [&bob, &charlie, &dave] {
         let kp = u.generate_key_package().unwrap();
         let session = u.lookup_entry(group).unwrap().unwrap();
-        SessionRunner::send_key_package(&session, kp).await.unwrap();
+        SessionRunner::send_key_package(&session, kp).unwrap();
     }
 
     // Step 3: Broadcast every KP packet to every participant (mocks pubsub).
@@ -122,10 +122,10 @@ async fn concurrent_joins_leave_joiners_with_empty_buffer() {
         all_kp_packets.extend(h.lock().unwrap().drain_packets());
     }
     for p in &all_kp_packets {
-        let _ = alice.process_inbound_packet(to_in(p)).await;
-        let _ = bob.process_inbound_packet(to_in(p)).await;
-        let _ = charlie.process_inbound_packet(to_in(p)).await;
-        let _ = dave.process_inbound_packet(to_in(p)).await;
+        let _ = alice.process_inbound_packet(to_in(p));
+        let _ = bob.process_inbound_packet(to_in(p));
+        let _ = charlie.process_inbound_packet(to_in(p));
+        let _ = dave.process_inbound_packet(to_in(p));
     }
     settle().await;
 

--- a/tests/recovery_inactivity_reelection.rs
+++ b/tests/recovery_inactivity_reelection.rs
@@ -65,23 +65,21 @@ async fn silent_steward_drives_observer_to_reelection() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&observer_session, request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&observer_session, request, CreatorVote::Yes).unwrap();
 
     // Phase 1: pump packets normally until both sides have approved=1.
     let mut consensus_reached = false;
     for _ in 0..20 {
         settle_for(Duration::from_millis(40)).await;
-        poll_once(&alice_session).await;
-        poll_once(&bob_session).await;
+        poll_once(&alice_session);
+        poll_once(&bob_session);
         let packets = users[0].1.lock().unwrap().drain_packets();
         for p in packets {
-            let _ = users[1].0.process_inbound_packet(to_inbound(&p)).await;
+            let _ = users[1].0.process_inbound_packet(to_inbound(&p));
         }
         let packets = users[1].1.lock().unwrap().drain_packets();
         for p in packets {
-            let _ = users[0].0.process_inbound_packet(to_inbound(&p)).await;
+            let _ = users[0].0.process_inbound_packet(to_inbound(&p));
         }
         let observer_approved = observer_session
             .read()
@@ -102,18 +100,15 @@ async fn silent_steward_drives_observer_to_reelection() {
     let mut entered_reelection = false;
     for _ in 0..20 {
         settle_for(Duration::from_millis(40)).await;
-        poll_once(&observer_session).await;
-        poll_once(&alice_session).await; // keep the steward polling, just discard its packets
-        poll_once(&bob_session).await;
+        poll_once(&observer_session);
+        poll_once(&alice_session); // keep the steward polling, just discard its packets
+        poll_once(&bob_session);
 
         // Discard everything the steward emits, deliver everything else.
         let _ = steward_tx.lock().unwrap().drain_packets();
         let packets = observer_tx.lock().unwrap().drain_packets();
         for p in packets {
-            let _ = users[steward_idx]
-                .0
-                .process_inbound_packet(to_inbound(&p))
-                .await;
+            let _ = users[steward_idx].0.process_inbound_packet(to_inbound(&p));
         }
 
         let observer_state = observer_session.read().unwrap().get_conversation_state();

--- a/tests/rejoin_after_eviction.rs
+++ b/tests/rejoin_after_eviction.rs
@@ -69,9 +69,7 @@ async fn evicted_member_can_rejoin_at_higher_epoch() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes).unwrap();
 
     let mut target_evicted = false;
     for _ in 0..30 {
@@ -94,14 +92,11 @@ async fn evicted_member_can_rejoin_at_higher_epoch() {
     users[target_idx]
         .0
         .start_conversation("rejoin", false)
-        .await
         .unwrap();
 
     let new_session = users[target_idx].0.lookup_entry("rejoin").unwrap().unwrap();
     let kp = users[target_idx].0.generate_key_package().unwrap();
-    SessionRunner::send_key_package(&new_session, kp)
-        .await
-        .unwrap();
+    SessionRunner::send_key_package(&new_session, kp).unwrap();
 
     let mut rejoined = false;
     for _ in 0..30 {
@@ -152,13 +147,13 @@ async fn drive_one_round(
     let mut sessions = Vec::with_capacity(users.len());
     for (i, (u, _)) in users.iter().enumerate() {
         if let Some(s) = u.lookup_entry("rejoin").unwrap() {
-            let _ = SessionRunner::tick_deadlines(&s).await;
-            let pfs = SessionRunner::poll_freeze_status(&s).await;
+            let _ = SessionRunner::tick_deadlines(&s);
+            let pfs = SessionRunner::poll_freeze_status(&s);
             if i == target_idx && matches!(pfs, Ok((_, DispatchOutcome::LeaveRequested))) {
-                u.finalize_self_leave("rejoin").await.unwrap();
+                u.finalize_self_leave("rejoin").unwrap();
                 continue;
             }
-            let _ = SessionRunner::check_member_freeze(&s).await;
+            let _ = SessionRunner::check_member_freeze(&s);
             let _ = SessionRunner::check_pending_join(&s).unwrap();
             sessions.push(s);
         }
@@ -166,14 +161,14 @@ async fn drive_one_round(
     // Route the steward's WelcomeReady event to the rejoining target
     // before relaying packets — ConversationSync emitted in the same
     // round needs the target's MLS attached first.
-    route_welcomes(&sessions, users).await;
+    route_welcomes(&sessions, users);
     let mut packets = Vec::new();
     for (_, h) in users.iter() {
         packets.extend(h.lock().unwrap().drain_packets());
     }
     for p in &packets {
         for (u, _) in users.iter() {
-            let _ = u.process_inbound_packet(to_inbound(p)).await;
+            let _ = u.process_inbound_packet(to_inbound(p));
         }
     }
 }

--- a/tests/self_leave_dedup.rs
+++ b/tests/self_leave_dedup.rs
@@ -19,17 +19,17 @@ async fn double_leave_does_not_re_propose() {
     let steward_cfg = StewardListConfig::new(1, 5).unwrap();
     let (mut alice, h) = make_user(ALICE_KEY, cfg, steward_cfg);
 
-    alice.start_conversation("c4", true).await.unwrap();
+    alice.start_conversation("c4", true).unwrap();
     h.lock().unwrap().drain_packets();
 
-    alice.leave_conversation("c4").await.unwrap();
+    alice.leave_conversation("c4").unwrap();
     let after_first = h.lock().unwrap().snapshot().len();
     assert!(
         after_first > 0,
         "first leave must file a self-leave proposal"
     );
 
-    alice.leave_conversation("c4").await.unwrap();
+    alice.leave_conversation("c4").unwrap();
     let after_second = h.lock().unwrap().snapshot().len();
 
     assert_eq!(

--- a/tests/steward_inactivity_commit.rs
+++ b/tests/steward_inactivity_commit.rs
@@ -54,9 +54,7 @@ async fn steward_inactivity_fires_commit_candidate() {
             RemoveMember { member_id: bob_id },
         )),
     };
-    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes)
-        .await
-        .unwrap();
+    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes).unwrap();
 
     // Drive polling + packet relay. Accumulate alice's outbound so we can
     // verify a `CommitCandidate` packet appears — without any explicit
@@ -64,16 +62,16 @@ async fn steward_inactivity_fires_commit_candidate() {
     let mut alice_outbound: Vec<OutboundPacket> = Vec::new();
     for _ in 0..30 {
         settle_for(Duration::from_millis(40)).await;
-        poll_once(&alice_session).await;
-        poll_once(&bob_session).await;
+        poll_once(&alice_session);
+        poll_once(&bob_session);
 
         let new_alice = alice_tx.lock().unwrap().drain_packets();
         let new_bob = bob_tx.lock().unwrap().drain_packets();
         for p in &new_alice {
-            let _ = users[1].0.process_inbound_packet(to_inbound(p)).await;
+            let _ = users[1].0.process_inbound_packet(to_inbound(p));
         }
         for p in &new_bob {
-            let _ = users[0].0.process_inbound_packet(to_inbound(p)).await;
+            let _ = users[0].0.process_inbound_packet(to_inbound(p));
         }
         alice_outbound.extend(new_alice);
 

--- a/tests/steward_small_group_rotation.rs
+++ b/tests/steward_small_group_rotation.rs
@@ -1,22 +1,13 @@
-//! Steward-list rotation reconciles by group size.
-//!
-//! `members <= sn_max`: every member is a steward, so the list is the full
-//! membership — each node regenerates it deterministically on commit-merge,
-//! no consensus round. `members > sn_max`: the list is a genuine subset, so
-//! peers run a voted election to agree which members serve.
-//!
-//! The small-group path is the fix for the doomed-election storm: a 2-member
-//! group used to open a steward election that could never reach quorum, time
-//! out, and escalate to a `Deadlock` ECP. These tests pin both branches.
+//! Steward-list reconcile under the settled-member rule: a just-bootstrapped
+//! group (every joiner added this epoch) keeps the creator as sole steward and
+//! fires no election. These tests pin the behavior — stays `Working`, a
+//! committer always exists, `retry_round` never leaves 0 (no election storm).
 
 use std::time::Duration;
 
-use de_mls::app::MemberRole;
 use de_mls::core::{ConversationState, StewardListConfig};
-use de_mls::member_id::MemberId;
 
 mod common;
-use common::WalletMemberId;
 use common::session_fixtures::{
     SessionArc, TestUser, TransportHandle, bootstrap_joined_conversation, fast_test_config,
     poll_once, settle_for, to_inbound,
@@ -25,28 +16,6 @@ use common::session_fixtures::{
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
-
-/// Sorted member ids carrying any steward role.
-fn steward_set(roles: &[(Vec<u8>, MemberRole)]) -> Vec<Vec<u8>> {
-    let mut ids: Vec<Vec<u8>> = roles
-        .iter()
-        .filter(|(_, role)| {
-            matches!(
-                role,
-                MemberRole::EpochSteward | MemberRole::BackupSteward | MemberRole::Steward
-            )
-        })
-        .map(|(id, _)| id.clone())
-        .collect();
-    ids.sort();
-    ids
-}
-
-fn member_id(users: &[(TestUser, TransportHandle)], idx: usize) -> Vec<u8> {
-    WalletMemberId::from_hex(&users[idx].0.member_id_string())
-        .member_id_bytes()
-        .to_vec()
-}
 
 /// Drain every transport and feed each packet to every user, mirroring the
 /// gateway relay. Echo-dedup drops a user's own packets.
@@ -62,10 +31,43 @@ async fn relay_all(users: &[(TestUser, TransportHandle)]) {
     }
 }
 
+/// Poll past every deadline, then assert stability: a committer exists, no
+/// election fired (`retry_round == 0`), every member stays `Working`.
+async fn assert_stable_no_election(
+    users: &[(TestUser, TransportHandle)],
+    conversation: &str,
+    sessions: &[(&str, &SessionArc)],
+) {
+    assert!(
+        sessions[0].1.read().unwrap().is_steward_for_self(),
+        "creator must be a steward (a committer must always exist)"
+    );
+
+    for _ in 0..20 {
+        settle_for(Duration::from_millis(40)).await;
+        for (_, s) in sessions {
+            poll_once(s);
+        }
+        relay_all(users).await;
+    }
+
+    for (label, s) in sessions {
+        let (_, retry) = s.read().unwrap().get_epoch_and_retry().unwrap();
+        assert_eq!(
+            retry, 0,
+            "{label} retry_round must stay 0 — no election fires for unsettled members ({conversation})"
+        );
+        assert_eq!(
+            s.read().unwrap().get_conversation_state(),
+            ConversationState::Working,
+            "{label} must stay Working ({conversation})"
+        );
+    }
+}
+
 #[tokio::test]
-async fn small_group_regenerates_locally_no_election() {
-    // n = 2, sn_max = 3 → every member is a steward; the list is the full
-    // membership, installed locally with no vote.
+async fn small_group_reconciles_locally_no_election() {
+    // n = 2, sn_max = 3 → list fits; reconciled locally, no vote.
     let users = bootstrap_joined_conversation(
         &[ALICE, BOB],
         "sg",
@@ -73,58 +75,15 @@ async fn small_group_regenerates_locally_no_election() {
         StewardListConfig::new(1, 3).unwrap(),
     )
     .await;
-
-    let alice_session = users[0].0.lookup_entry("sg").unwrap().unwrap();
-    let bob_session = users[1].0.lookup_entry("sg").unwrap().unwrap();
-
-    let mut both = vec![member_id(&users, 0), member_id(&users, 1)];
-    both.sort();
-
-    // Both nodes installed the identical full-membership list: every member
-    // is a steward, no plain `Member`.
-    let alice_roles = alice_session.read().unwrap().get_member_roles().unwrap();
-    let bob_roles = bob_session.read().unwrap().get_member_roles().unwrap();
-    assert_eq!(
-        steward_set(&alice_roles),
-        both,
-        "alice's steward list must be the full membership"
-    );
-    assert_eq!(
-        steward_set(&bob_roles),
-        both,
-        "bob's steward list must match alice's exactly"
-    );
-
-    // No election ever ran: a doomed steward election would bump retry_round
-    // off zero and (after retries) escalate to a Deadlock ECP, flipping state
-    // out of Working. Poll well past every inactivity/consensus deadline and
-    // assert sustained stability.
-    for _ in 0..20 {
-        settle_for(Duration::from_millis(40)).await;
-        for s in [&alice_session, &bob_session] {
-            poll_once(s);
-        }
-        relay_all(&users).await;
-    }
-
-    for (label, s) in [("alice", &alice_session), ("bob", &bob_session)] {
-        let (_, retry) = s.read().unwrap().get_epoch_and_retry().unwrap();
-        assert_eq!(
-            retry, 0,
-            "{label} retry_round must stay 0 (no election fired)"
-        );
-        assert_eq!(
-            s.read().unwrap().get_conversation_state(),
-            ConversationState::Working,
-            "{label} must stay Working (no Deadlock ECP storm)"
-        );
-    }
+    let alice = users[0].0.lookup_entry("sg").unwrap().unwrap();
+    let bob = users[1].0.lookup_entry("sg").unwrap().unwrap();
+    assert_stable_no_election(&users, "sg", &[("alice", &alice), ("bob", &bob)]).await;
 }
 
 #[tokio::test]
-async fn large_group_elects_proper_subset() {
-    // n = 3, sn_max = 2 → the list is a genuine subset; a voted election
-    // picks exactly two stewards, agreed by every node.
+async fn members_over_sn_max_do_not_elect_until_settled() {
+    // n = 3, sn_max = 2 → more members than sn_max, but the joiners aren't
+    // settled yet, so settled members still fit: no premature election.
     let users = bootstrap_joined_conversation(
         &[ALICE, BOB, CHARLIE],
         "lg",
@@ -132,23 +91,13 @@ async fn large_group_elects_proper_subset() {
         StewardListConfig::new(1, 2).unwrap(),
     )
     .await;
-
-    let sessions: Vec<SessionArc> = (0..3)
+    let s: Vec<SessionArc> = (0..3)
         .map(|i| users[i].0.lookup_entry("lg").unwrap().unwrap())
         .collect();
-
-    let reference = steward_set(&sessions[0].read().unwrap().get_member_roles().unwrap());
-    assert_eq!(
-        reference.len(),
-        2,
-        "sn_max=2 with 3 members must elect a 2-steward subset, got {reference:?}"
-    );
-    for (i, s) in sessions.iter().enumerate() {
-        let roles = s.read().unwrap().get_member_roles().unwrap();
-        assert_eq!(
-            steward_set(&roles),
-            reference,
-            "node {i} must agree on the elected steward subset"
-        );
-    }
+    assert_stable_no_election(
+        &users,
+        "lg",
+        &[("alice", &s[0]), ("bob", &s[1]), ("charlie", &s[2])],
+    )
+    .await;
 }

--- a/tests/steward_small_group_rotation.rs
+++ b/tests/steward_small_group_rotation.rs
@@ -57,7 +57,7 @@ async fn relay_all(users: &[(TestUser, TransportHandle)]) {
     }
     for p in &packets {
         for (u, _) in users {
-            let _ = u.process_inbound_packet(to_inbound(p)).await;
+            let _ = u.process_inbound_packet(to_inbound(p));
         }
     }
 }
@@ -102,7 +102,7 @@ async fn small_group_regenerates_locally_no_election() {
     for _ in 0..20 {
         settle_for(Duration::from_millis(40)).await;
         for s in [&alice_session, &bob_session] {
-            poll_once(s).await;
+            poll_once(s);
         }
         relay_all(&users).await;
     }


### PR DESCRIPTION
Fixes two bugs that surface when a member who is not the conversation steward adds a new participant.

The MLS welcome is created only by the steward that commits the Add, but it previously carried no joiner identity, forcing integrators to guess the recipient from their own `add_member` call. When the proposer was not the steward, the welcome landed on a node with no invite record and was dropped, so the new member never joined. `MemberWelcome` now carries `joiner_identities`, so the committing node can address delivery itself, and batch Adds naming multiple joiners route correctly.

Separately, a peer steward can reach consensus and broadcast the commit candidate before the proposer applies its own vote. The proposer dropped the candidate as having no approved proposal and fell an epoch behind, ending in a needless reelection. Such candidates are now stashed and replayed once the consensus outcome lands, so the freeze round applies the commit normally. Stashed candidates still go through full MLS staging, steward-authorization, and approved-action validation at finalize — nothing is bypassed.
