### PR TITLE
chore: bump prost version to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1.41"
 indexmap = "2.14.0"
 
 libc = { version = "0.2", optional = true }
-prost = "0.13.5"
+prost = "0.14"
 hashgraph-like-consensus = "0.5.0"
 
 [dev-dependencies]
@@ -63,7 +63,7 @@ alloy = { version = "1.0.37", default-features = false, features = [
 ] }
 
 [build-dependencies]
-prost-build = "0.13.5"
+prost-build = "0.14"
 
 [profile]
 


### PR DESCRIPTION


This PR updates the prost library version to 0.14 to avoid conflicts with `libchat`

As the library exposes Protobuf messages outside of the library, a mismatch in versions causes conflicts. 

## Notes

- This repo depends on Message types from `hash_graph_consensus` library. This [PR](https://github.com/vacp2p/hashgraph-like-consensus/pull/20) bumps the `prost` version there.
   - Tests will continue to fail until it is merged