### PR TITLE
refactor(session): take &mut self instead of Arc<RwLock<Self>>

### DIFF
--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use alloy::primitives::Address;
 
 use de_mls::{
-    app::{DispatchOutcome, FreezeTimeoutStatus, PendingJoinTick, SessionRunner, UserError},
+    app::{DispatchOutcome, FreezeTimeoutStatus, PendingJoinTick, UserError},
     ds::WakuDeliveryService,
     protos::de_mls::messages::v1::BanRequest,
 };
@@ -73,7 +73,10 @@ impl Gateway<WakuDeliveryService> {
         core.topics.add_many(&conversation_id)?;
         let key_package = user_ref.read().await.generate_key_package()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::send_key_package(&session, key_package)?;
+        session
+            .read()
+            .map_err(|_| UserError::LockPoisoned("session"))?
+            .send_key_package(key_package)?;
         tracing::info!(group = %conversation_id, "key package sent");
 
         // Phase 1 (PendingJoin): Poll every 5s until joined or timed out
@@ -88,10 +91,14 @@ impl Gateway<WakuDeliveryService> {
                 let Ok(session) = lookup_session(&user_clone, &group_name_clone).await else {
                     break false;
                 };
-                let tick = match SessionRunner::check_pending_join(&session) {
-                    Ok(t) => t,
-                    Err(e) => {
+                let tick = match session.read().map(|s| s.check_pending_join()) {
+                    Ok(Ok(t)) => t,
+                    Ok(Err(e)) => {
                         tracing::warn!(group = %group_name_clone, error = %e, "check_pending_join failed");
+                        break false;
+                    }
+                    Err(_) => {
+                        tracing::warn!(group = %group_name_clone, "check_pending_join skipped: session lock poisoned");
                         break false;
                     }
                 };
@@ -155,14 +162,22 @@ impl Gateway<WakuDeliveryService> {
                 tracing::warn!(group = %conversation_id, "polling loop: session gone");
                 break;
             };
-            if let Err(e) = SessionRunner::tick_deadlines(&session) {
+            let tick_result = session
+                .write()
+                .map_err(|_| UserError::LockPoisoned("session"))
+                .and_then(|mut s| s.tick_deadlines());
+            if let Err(e) = tick_result {
                 if is_polling_fatal(&e) {
                     tracing::warn!(group = %conversation_id, error = %e, "polling loop exiting (tick_deadlines)");
                     break;
                 }
                 tracing::warn!(group = %conversation_id, error = %e, "tick_deadlines failed");
             }
-            let freeze_outcome = match SessionRunner::poll_freeze_status(&session) {
+            let freeze_outcome = match session
+                .write()
+                .map_err(|_| UserError::LockPoisoned("session"))
+                .and_then(|mut s| s.poll_freeze_status())
+            {
                 Ok(o) => o,
                 Err(e) => {
                     if is_polling_fatal(&e) {
@@ -181,7 +196,11 @@ impl Gateway<WakuDeliveryService> {
             }
             match freeze_status {
                 FreezeTimeoutStatus::NotFreezing => {
-                    match SessionRunner::check_member_freeze(&session) {
+                    match session
+                        .write()
+                        .map_err(|_| UserError::LockPoisoned("session"))
+                        .and_then(|mut s| s.check_member_freeze())
+                    {
                         Ok(true) => { /* entered Freezing (+ created candidate if steward) */ }
                         Ok(false) => {}
                         Err(e) => {
@@ -233,7 +252,10 @@ impl Gateway<WakuDeliveryService> {
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::send_app_message(&session, message.into_bytes())?;
+        session
+            .write()
+            .map_err(|_| UserError::LockPoisoned("session"))?
+            .send_app_message(message.into_bytes())?;
         tracing::debug!(group = %conversation_id, "app message sent");
         Ok(())
     }
@@ -253,7 +275,10 @@ impl Gateway<WakuDeliveryService> {
             conversation_id: conversation_id.clone(),
         };
 
-        SessionRunner::process_ban_request(&session, ban_request)?;
+        session
+            .write()
+            .map_err(|_| UserError::LockPoisoned("session"))?
+            .process_ban_request(ban_request)?;
 
         Ok(())
     }
@@ -266,7 +291,10 @@ impl Gateway<WakuDeliveryService> {
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
         let session = lookup_session(&user_ref, &conversation_id).await?;
-        SessionRunner::process_user_vote(&session, proposal_id, vote)?;
+        session
+            .write()
+            .map_err(|_| UserError::LockPoisoned("session"))?
+            .process_user_vote(proposal_id, vote)?;
         Ok(())
     }
 

--- a/src/app/session/consensus.rs
+++ b/src/app/session/consensus.rs
@@ -1,20 +1,17 @@
 //! Proposal submission + voting on `SessionRunner`.
 //!
 //! Outgoing proposals submit to consensus, register ownership, broadcast
-//! (bundled or unbundled per `creator_vote`), and resolve on timeout. The
-//! methods take `Arc<RwLock<SessionRunner>>` so the body can release the
-//! runner lock across `` points rather than holding it through a
-//! consensus call.
+//! (bundled or unbundled per `creator_vote`), and resolve on timeout.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use hashgraph_like_consensus::{error::ConsensusError, storage::ConsensusStorage};
 use prost::Message;
-use tracing::{error, info};
+use tracing::info;
 
 use crate::{
     app::{
-        ConversationState, LockExt, SessionRunner, SessionTick, UserError,
+        ConversationState, SessionRunner, SessionTick, UserError,
         session::{
             consensus_bridge::{
                 ProposalParams, cast_vote, submit_proposal, submit_self_leave_proposal,
@@ -49,7 +46,7 @@ pub enum CreatorVote {
     Deferred,
 }
 
-/// Typed payload for the spawned proposal lifecycle.
+/// Typed payload for the proposal lifecycle.
 struct NewProposal {
     request: ConversationUpdateRequest,
     expected_voters: u32,
@@ -93,21 +90,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     ///
     /// `creator_vote` — see [`CreatorVote`] for wire shape and local UI behavior.
     pub fn initiate_proposal(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         request: ConversationUpdateRequest,
         creator_vote: CreatorVote,
     ) -> Result<(), UserError> {
         let kind = ProposalKind::of(&request);
-        let expected_voters = arc.read_or_err("session")?.check_proposal_allowed(kind)?;
-        Self::register_new_proposal(
-            arc,
-            NewProposal {
-                request,
-                expected_voters,
-                kind,
-                creator_vote,
-            },
-        )?;
+        let expected_voters = self.check_proposal_allowed(kind)?;
+        self.register_new_proposal(NewProposal {
+            request,
+            expected_voters,
+            kind,
+            creator_vote,
+        })?;
         Ok(())
     }
 
@@ -116,13 +110,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// promote it to a voting proposal if this node is the current epoch
     /// steward and the conversation accepts new proposals.
     pub fn handle_incoming_update_request(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         request: ConversationUpdateRequest,
     ) -> Result<(), UserError> {
         let (pending_join, members_for_rotation, current_epoch) = {
-            let s = arc.read_or_err("session")?;
-            let pending = s.conversation.current_state() == ConversationState::PendingJoin;
-            match (pending, s.conversation.mls()) {
+            let pending = self.conversation.current_state() == ConversationState::PendingJoin;
+            match (pending, self.conversation.mls()) {
                 (true, _) | (false, None) => (pending, Vec::new(), 0u64),
                 (false, Some(mls)) => (false, mls.members()?, mls.current_epoch()?),
             }
@@ -131,37 +124,33 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             return Ok(());
         }
 
-        let (inserted, is_epoch_steward, state, buffer_total, should_propose, conversation_id) = {
-            let mut s = arc.write_or_err("session")?;
+        // Defensive — core only emits membership changes here.
+        if target_member_id_of(&request).is_none() {
+            return Ok(());
+        }
 
-            // Defensive — core only emits membership changes here.
-            if target_member_id_of(&request).is_none() {
-                return Ok(());
-            }
+        let inserted = self
+            .conversation
+            .queues
+            .insert_pending_update(request.clone(), current_epoch);
 
-            let inserted = s
-                .conversation
-                .queues
-                .insert_pending_update(request.clone(), current_epoch);
-
-            // Only the epoch steward proposes immediately. The buffer
-            // survives freeze rounds so a later steward can retry.
-            let self_member_id = Arc::clone(&s.self_member_id);
-            let eligible = s
+        // Only the epoch steward proposes immediately. The buffer
+        // survives freeze rounds so a later steward can retry.
+        let self_member_id = Arc::clone(&self.self_member_id);
+        let is_epoch_steward = {
+            let eligible = self
                 .conversation
                 .queues
                 .steward_eligibility(&members_for_rotation);
-            let is_es = s
-                .conversation
+            self.conversation
                 .steward_list
                 .epoch_steward(current_epoch, &eligible)
-                .is_some_and(|es| es == &*self_member_id);
-            let state = s.conversation.current_state();
-            let total = s.conversation.queues.pending_update_count();
-            let should = is_es && state == ConversationState::Working;
-            let name = s.conversation_id.clone();
-            (inserted, is_es, state, total, should, name)
+                .is_some_and(|es| es == &*self_member_id)
         };
+        let state = self.conversation.current_state();
+        let buffer_total = self.conversation.queues.pending_update_count();
+        let should_propose = is_epoch_steward && state == ConversationState::Working;
+        let conversation_id = self.conversation_id.clone();
 
         info!(
             conversation = %conversation_id,
@@ -180,7 +169,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // let the banner drive the steward's vote like any other member.
             // `check_proposal_allowed` may still reject (active emergency
             // etc.) — leave the entry in the buffer for next rotation.
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred) {
+            if let Err(e) = self.initiate_proposal(request, CreatorVote::Deferred) {
                 info!(conversation = %conversation_id, error = %e, "proposal deferred");
             }
         }
@@ -190,67 +179,53 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Cast a manual vote on behalf of the local member. Blocked in
     /// `Freezing` and `Selection`; cancels any pending auto-vote so the
     /// manual choice wins.
-    pub fn process_user_vote(
-        arc: &Arc<RwLock<Self>>,
-        proposal_id: u32,
-        vote: bool,
-    ) -> Result<(), UserError> {
-        let (consensus, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            let state = s.conversation.current_state();
-            if state == ConversationState::Freezing || state == ConversationState::Selection {
-                return Err(UserError::ConversationBlocked(state.to_string()));
-            }
-            (s.consensus.clone(), s.conversation_id.clone())
-        };
+    pub fn process_user_vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), UserError> {
+        let state = self.conversation.current_state();
+        if state == ConversationState::Freezing || state == ConversationState::Selection {
+            return Err(UserError::ConversationBlocked(state.to_string()));
+        }
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
 
         // Manual vote takes precedence over the pending auto-vote timer.
-        arc.write_or_err("session")?.cancel_auto_vote(proposal_id);
+        self.cancel_auto_vote(proposal_id);
 
         let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus)?;
-        let packet = {
-            let mut s = arc.write_or_err("session")?;
-            let app_id = Arc::clone(&s.app_id);
-            s.conversation
-                .expect_mls_mut()?
-                .build_message(&app_message, &app_id)?
-        };
-        let transport = Arc::clone(arc.read_or_err("session")?.transport());
-        send_packet(&transport, packet)?;
+        let app_id = Arc::clone(&self.app_id);
+        let packet = self
+            .conversation
+            .expect_mls_mut()?
+            .build_message(&app_message, &app_id)?;
+        send_packet(self.transport(), packet)?;
         Ok(())
     }
 
     /// Walk pending deadlines, fire any whose `fire_at` has elapsed, then
     /// drain the consensus event bus and dispatch each event through
-    /// `apply_consensus_outcome`. Call from the caller's polling
-    /// loop.
-    pub fn tick_deadlines(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
+    /// `apply_consensus_outcome`. Call from the caller's polling loop.
+    pub fn tick_deadlines(&mut self) -> Result<SessionTick, UserError> {
         let now = std::time::Instant::now();
-        let (auto_votes_due, timeouts_due) = {
-            let mut s = arc.write_or_err("session")?;
-            let auto_votes: Vec<(u32, bool)> = s
-                .pending_auto_votes
-                .iter()
-                .filter(|(_, e)| e.fire_at <= now)
-                .map(|(id, e)| (*id, e.vote))
-                .collect();
-            for (id, _) in &auto_votes {
-                s.pending_auto_votes.remove(id);
-            }
-            let timeouts: Vec<u32> = s
-                .pending_consensus_timeouts
-                .iter()
-                .filter(|(_, fire_at)| **fire_at <= now)
-                .map(|(id, _)| *id)
-                .collect();
-            for id in &timeouts {
-                s.pending_consensus_timeouts.remove(id);
-            }
-            (auto_votes, timeouts)
-        };
+        let auto_votes_due: Vec<(u32, bool)> = self
+            .pending_auto_votes
+            .iter()
+            .filter(|(_, e)| e.fire_at <= now)
+            .map(|(id, e)| (*id, e.vote))
+            .collect();
+        for (id, _) in &auto_votes_due {
+            self.pending_auto_votes.remove(id);
+        }
+        let timeouts_due: Vec<u32> = self
+            .pending_consensus_timeouts
+            .iter()
+            .filter(|(_, fire_at)| **fire_at <= now)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &timeouts_due {
+            self.pending_consensus_timeouts.remove(id);
+        }
 
         for (proposal_id, vote) in auto_votes_due {
-            if let Err(e) = Self::cast_auto_vote(arc, proposal_id, vote) {
+            if let Err(e) = self.cast_auto_vote(proposal_id, vote) {
                 tracing::debug!(
                     proposal_id,
                     error = %e,
@@ -259,28 +234,27 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
         }
         for proposal_id in timeouts_due {
-            Self::resolve_on_timeout(arc, proposal_id);
+            self.resolve_on_timeout(proposal_id);
         }
 
         loop {
             // The bus is per-session and single-scope, so the scope on each
             // event is always this conversation's — drained, not matched.
-            let next = {
-                let mut s = arc.write_or_err("session")?;
-                <_ as SyncConsensusReceiver<_>>::try_recv(&mut s.consensus_rx)
+            let Some((_scope, event)) =
+                <_ as SyncConsensusReceiver<_>>::try_recv(&mut self.consensus_rx)
+            else {
+                break;
             };
-            let Some((_scope, event)) = next else { break };
-            if let Err(e) = Self::apply_consensus_outcome(arc, event) {
-                let conversation_id = arc.read_or_err("session")?.conversation_id.clone();
+            if let Err(e) = self.apply_consensus_outcome(event) {
                 tracing::warn!(
-                    conversation = %conversation_id,
+                    conversation = %self.conversation_id,
                     error = %e,
                     "apply_consensus_outcome failed"
                 );
             }
         }
 
-        Ok(arc.read_or_err("session")?.tick())
+        Ok(self.tick())
     }
 
     // ── Crate-internal ───────────────────────────────────────────────
@@ -292,17 +266,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// after a successful submit short-circuits on the local pending-leave
     /// check, and a retransmit dedupes inside the consensus library via
     /// the deterministic [`self_leave_proposal_id`].
-    pub fn initiate_self_leave(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let self_member_id = Arc::clone(&arc.read_or_err("session")?.self_member_id);
+    pub fn initiate_self_leave(&mut self) -> Result<(), UserError> {
+        let self_member_id = Arc::clone(&self.self_member_id);
+        let conversation_id = self.conversation_id.clone();
 
-        let (already_pending, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            (
-                s.conversation.queues.is_pending_self_leave(&self_member_id),
-                s.conversation_id.clone(),
-            )
-        };
-        if already_pending {
+        if self
+            .conversation
+            .queues
+            .is_pending_self_leave(&self_member_id)
+        {
             info!(
                 conversation = %conversation_id,
                 "self-leave already in flight, ignoring duplicate"
@@ -323,17 +295,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // fires `ConsensusReached` synchronously, and
         // `apply_consensus_outcome` needs `is_owner_of_proposal` to be true
         // by then.
-        let (consensus, proposal_expiration, consensus_timeout) = {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation
-                .queues
-                .insert_voting_proposal(proposal_id, request);
-            (
-                s.consensus.clone(),
-                s.conversation.config.proposal_expiration,
-                s.conversation.config.consensus_timeout,
-            )
-        };
+        self.conversation
+            .queues
+            .insert_voting_proposal(proposal_id, request.clone());
+        let consensus = self.consensus.clone();
+        let proposal_expiration = self.conversation.config.proposal_expiration;
+        let consensus_timeout = self.conversation.config.consensus_timeout;
 
         let submitted = submit_self_leave_proposal::<P>(
             &conversation_id,
@@ -353,15 +320,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             return Ok(());
         };
 
-        let packet = {
-            let mut s = arc.write_or_err("session")?;
-            let app_id = Arc::clone(&s.app_id);
-            s.conversation
-                .expect_mls_mut()?
-                .build_message(&app_msg, &app_id)?
-        };
-        let transport = Arc::clone(arc.read_or_err("session")?.transport());
-        send_packet(&transport, packet)?;
+        let app_id = Arc::clone(&self.app_id);
+        let packet = self
+            .conversation
+            .expect_mls_mut()?
+            .build_message(&app_msg, &app_id)?;
+        send_packet(self.transport(), packet)?;
         Ok(())
     }
 
@@ -405,7 +369,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Ownership is stored *before* the vote is cast, so a single-voter
     /// consensus transition can't race `is_owner=false` when the drain
     /// loop in `tick_deadlines` picks it up.
-    fn register_new_proposal(arc: &Arc<RwLock<Self>>, np: NewProposal) -> Result<u32, UserError> {
+    fn register_new_proposal(&mut self, np: NewProposal) -> Result<u32, UserError> {
         let NewProposal {
             request,
             expected_voters,
@@ -413,26 +377,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             creator_vote,
         } = np;
 
-        let (
-            proposal_expiration,
-            consensus_timeout,
-            liveness_criteria_yes,
-            voting_delay,
-            consensus,
-            conversation_id,
-            self_member_id,
-        ) = {
-            let s = arc.read_or_err("session")?;
-            (
-                s.conversation.config.proposal_expiration,
-                s.conversation.config.consensus_timeout,
-                s.conversation.config.liveness_criteria_yes,
-                s.conversation.config.voting_delay_for(kind),
-                s.consensus.clone(),
-                s.conversation_id.clone(),
-                Arc::clone(&s.self_member_id),
-            )
-        };
+        let proposal_expiration = self.conversation.config.proposal_expiration;
+        let consensus_timeout = self.conversation.config.consensus_timeout;
+        let liveness_criteria_yes = self.conversation.config.liveness_criteria_yes;
+        let voting_delay = self.conversation.config.voting_delay_for(kind);
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
+        let self_member_id = Arc::clone(&self.self_member_id);
 
         let (proposal_id, unbundled) = submit_proposal::<P>(
             &conversation_id,
@@ -447,20 +398,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             },
         )?;
 
-        {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation
-                .queues
-                .insert_voting_proposal(proposal_id, request.clone());
-            if kind.is_emergency() {
-                s.conversation.queues.insert_emergency(proposal_id);
-            }
-            // Register the consensus timeout deadline. The caller's polling
-            // loop fires `resolve_on_timeout` via `tick_deadlines` once the
-            // deadline elapses; the entry is removed naturally on
-            // `apply_consensus_outcome` if consensus resolves first.
-            s.register_consensus_timeout(proposal_id, consensus_timeout);
+        self.conversation
+            .queues
+            .insert_voting_proposal(proposal_id, request.clone());
+        if kind.is_emergency() {
+            self.conversation.queues.insert_emergency(proposal_id);
         }
+        // Register the consensus timeout deadline. The caller's polling
+        // loop fires `resolve_on_timeout` via `tick_deadlines` once the
+        // deadline elapses; the entry is removed naturally on
+        // `apply_consensus_outcome` if consensus resolves first.
+        self.register_consensus_timeout(proposal_id, consensus_timeout);
 
         match creator_vote {
             CreatorVote::Yes => {
@@ -478,44 +426,32 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     "YES vote cast (bundled at submit)"
                 );
                 let outbound: AppMessage = proposal.into();
-                let packet = {
-                    let mut s = arc.write_or_err("session")?;
-                    let app_id = Arc::clone(&s.app_id);
-                    s.conversation
-                        .expect_mls_mut()?
-                        .build_message(&outbound, &app_id)?
-                };
-                let transport = Arc::clone(arc.read_or_err("session")?.transport());
-                send_packet(&transport, packet)?;
+                let app_id = Arc::clone(&self.app_id);
+                let packet = self
+                    .conversation
+                    .expect_mls_mut()?
+                    .build_message(&outbound, &app_id)?;
+                send_packet(self.transport(), packet)?;
                 // Creator already voted — populate history cache, no banner.
-                arc.read_or_err("session")?
-                    .emit_event(SessionEvent::OwnProposalSubmitted {
-                        proposal_id,
-                        request,
-                    });
+                self.emit_event(SessionEvent::OwnProposalSubmitted {
+                    proposal_id,
+                    request,
+                });
             }
             CreatorVote::Deferred => {
                 // Unbundled path: broadcast the proposal alone. Show the
                 // creator the banner like peers and start their own
                 // auto-vote timer; peers run their own timers locally.
-                let packet = {
-                    let mut s = arc.write_or_err("session")?;
-                    let app_id = Arc::clone(&s.app_id);
-                    s.conversation
-                        .expect_mls_mut()?
-                        .build_message(&unbundled, &app_id)?
-                };
-                let transport = Arc::clone(arc.read_or_err("session")?.transport());
-                send_packet(&transport, packet)?;
+                let app_id = Arc::clone(&self.app_id);
+                let packet = self
+                    .conversation
+                    .expect_mls_mut()?
+                    .build_message(&unbundled, &app_id)?;
+                send_packet(self.transport(), packet)?;
                 let banner =
                     build_vote_banner_event(&conversation_id, proposal_id, request.encode_to_vec());
-                arc.read_or_err("session")?
-                    .emit_event(SessionEvent::AppMessage(banner));
-                arc.write_or_err("session")?.register_auto_vote(
-                    proposal_id,
-                    voting_delay,
-                    liveness_criteria_yes,
-                );
+                self.emit_event(SessionEvent::AppMessage(banner));
+                self.register_auto_vote(proposal_id, voting_delay, liveness_criteria_yes);
             }
         }
 
@@ -532,14 +468,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// as the proposal is in our resolved-proposals cache — we downgrade the
     /// log accordingly and warn only for truly unknown IDs (indicates a logic
     /// bug, not a race).
-    fn resolve_on_timeout(arc: &Arc<RwLock<Self>>, proposal_id: u32) {
-        let (consensus, conversation_id) = match arc.read_or_err("session") {
-            Ok(s) => (s.consensus.clone(), s.conversation_id.clone()),
-            Err(e) => {
-                error!(proposal_id, error = %e, "timeout resolution aborted: session lock poisoned");
-                return;
-            }
-        };
+    fn resolve_on_timeout(&self, proposal_id: u32) {
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
         let scope = P::Scope::from(conversation_id.clone());
         let still_active = consensus
             .storage()
@@ -552,14 +483,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         match consensus.handle_consensus_timeout(&scope, proposal_id) {
             Ok(_) => {}
             Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
-                let resolved_locally = arc
-                    .read_or_err("session")
-                    .map(|s| {
-                        s.conversation
-                            .queues
-                            .is_consensus_outcome_applied(proposal_id)
-                    })
-                    .unwrap_or(false);
+                let resolved_locally = self
+                    .conversation
+                    .queues
+                    .is_consensus_outcome_applied(proposal_id);
                 if resolved_locally {
                     tracing::debug!(
                         conversation = %conversation_id,
@@ -582,25 +509,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Cast the auto-vote on behalf of the local member. Same broadcast
     /// path as a manual vote — the library sees the two identically.
-    fn cast_auto_vote(
-        arc: &Arc<RwLock<Self>>,
-        proposal_id: u32,
-        vote: bool,
-    ) -> Result<(), UserError> {
-        let (consensus, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            (s.consensus.clone(), s.conversation_id.clone())
-        };
+    fn cast_auto_vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), UserError> {
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
         let app_message = cast_vote::<P>(&conversation_id, proposal_id, vote, &consensus)?;
-        let packet = {
-            let mut s = arc.write_or_err("session")?;
-            let app_id = Arc::clone(&s.app_id);
-            s.conversation
-                .expect_mls_mut()?
-                .build_message(&app_message, &app_id)?
-        };
-        let transport = Arc::clone(arc.read_or_err("session")?.transport());
-        send_packet(&transport, packet)?;
+        let app_id = Arc::clone(&self.app_id);
+        let packet = self
+            .conversation
+            .expect_mls_mut()?
+            .build_message(&app_message, &app_id)?;
+        send_packet(self.transport(), packet)?;
         Ok(())
     }
 }

--- a/src/app/session/consensus_events.rs
+++ b/src/app/session/consensus_events.rs
@@ -2,20 +2,16 @@
 //! hashgraph-like-consensus service reaches or fails consensus on a
 //! proposal; compare with `inbound.rs` (transport-delivered packets).
 //!
-//! All five handlers are associated functions taking
-//! `Arc<RwLock<SessionRunner>>` because they fan out into steward
-//! initiations (election, deadlock ECP, score removals, buffered-update
-//! drains), each of which opens a follow-up proposal that releases the
-//! runner lock across its `` points.
-
-use std::sync::{Arc, RwLock};
+//! The handlers fan out into steward initiations (election, deadlock ECP,
+//! score removals, buffered-update drains), each of which opens a follow-up
+//! proposal.
 
 use hashgraph_like_consensus::{storage::ConsensusStorage, types::ConsensusEvent};
 use prost::Message;
 use tracing::{error, info};
 
 use crate::{
-    app::{ConversationState, LockExt, SessionRunner, SessionTick, UserError},
+    app::{ConversationState, SessionRunner, SessionTick, UserError},
     core::{
         ConsensusApplyResult, ConsensusPlugin, ConversationPluginsFactory, PeerScoringPlugin,
         ScoreOp, SessionEvent, StewardListPlugin, apply_consensus_result, emergency_score_ops,
@@ -31,7 +27,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// follow-up handler (election-accepted / election-rejected /
     /// emergency-scored).
     pub(crate) fn apply_consensus_outcome(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         event: ConsensusEvent,
     ) -> Result<SessionTick, UserError> {
         let (proposal_id, approved, timestamp) = match &event {
@@ -46,38 +42,32 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             } => (*proposal_id, false, *timestamp),
         };
 
-        let already_applied = {
-            let mut s = arc.write_or_err("session")?;
-            // Proposal resolved — any pending auto-vote timer is now moot.
-            s.cancel_auto_vote(proposal_id);
-            // Drop re-emissions from the consensus library (timeout-path
-            // race) so we don't re-apply state or double-fire UI events.
-            s.conversation
-                .queues
-                .is_consensus_outcome_applied(proposal_id)
-        };
+        // Proposal resolved — any pending auto-vote timer is now moot.
+        self.cancel_auto_vote(proposal_id);
+        // Drop re-emissions from the consensus library (timeout-path
+        // race) so we don't re-apply state or double-fire UI events.
+        let already_applied = self
+            .conversation
+            .queues
+            .is_consensus_outcome_applied(proposal_id);
         if already_applied {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             tracing::debug!(
-                conversation = %conv_name,
+                conversation = %self.conversation_id,
                 proposal_id,
                 "duplicate consensus outcome dropped"
             );
-            return Self::current_tick(arc);
+            return self.current_tick();
         }
 
         // Surface the decision before any effects so UI fanout sees it in
-        // the same polling cycle as the state change that follows; grab the
-        // payload-fetch handles under the same read guard.
-        let (consensus, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            s.emit_event(SessionEvent::ConsensusReached {
-                proposal_id,
-                approved,
-                timestamp,
-            });
-            (s.consensus.clone(), s.conversation_id.clone())
-        };
+        // the same polling cycle as the state change that follows.
+        self.emit_event(SessionEvent::ConsensusReached {
+            proposal_id,
+            approved,
+            timestamp,
+        });
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
         let scope = P::Scope::from(conversation_id.clone());
         let proposal = consensus.storage().get_proposal(&scope, proposal_id)?;
         // Decode once and thread the request through every downstream step.
@@ -85,85 +75,75 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // The inactivity timer is self-started by `check_steward_inactivity`
         // on the next poll — no explicit notification needed here.
-        let consensus_apply = {
-            let mut s = arc.write_or_err("session")?;
-            info!(
-                conversation = %s.conversation_id,
-                proposal_id, approved, "consensus reached"
-            );
-            s.conversation
-                .queues
-                .mark_consensus_outcome_applied(proposal_id);
-            apply_consensus_result(&mut s.conversation.queues, proposal_id, approved, &request)?
-        };
+        info!(
+            conversation = %conversation_id,
+            proposal_id, approved, "consensus reached"
+        );
+        self.conversation
+            .queues
+            .mark_consensus_outcome_applied(proposal_id);
+        let consensus_apply = apply_consensus_result(
+            &mut self.conversation.queues,
+            proposal_id,
+            approved,
+            &request,
+        )?;
 
         // A commit candidate may have arrived before this approval landed (a
         // peer steward can reach consensus and broadcast the commit before we
         // apply our own vote). Now that the approved queue is populated, replay
         // any stashed candidate so the freeze round picks it up instead of
         // starting empty and forcing a needless reelection.
-        arc.write_or_err("session")?
-            .conversation
-            .replay_early_candidates()?;
+        self.conversation.replay_early_candidates()?;
 
         match consensus_apply {
             ConsensusApplyResult::NoAction => {}
             ConsensusApplyResult::ElectionAccepted(election) => {
-                Self::handle_election_accepted(arc, election)?;
-                return Self::current_tick(arc);
+                self.handle_election_accepted(election)?;
+                return self.current_tick();
             }
             ConsensusApplyResult::ElectionRejected => {
-                Self::handle_election_rejected(arc)?;
+                self.handle_election_rejected()?;
             }
             ConsensusApplyResult::RecoveryModeOpened => {
-                arc.write_or_err("session")?
-                    .conversation
-                    .enter_recovery_mode();
-                Self::start_freezing_and_emit(arc)?;
+                self.conversation.enter_recovery_mode();
+                self.start_freezing_and_emit()?;
             }
             ConsensusApplyResult::UrgentRemoval { target } => {
-                Self::start_freezing_and_emit(arc)?;
-                Self::refresh_stewards_after_removal(arc, &target)?;
+                self.start_freezing_and_emit()?;
+                self.refresh_stewards_after_removal(&target)?;
             }
             ConsensusApplyResult::QueuedRemoval { target } => {
-                Self::refresh_stewards_after_removal(arc, &target)?;
+                self.refresh_stewards_after_removal(&target)?;
             }
             ConsensusApplyResult::RejectedMembership { target } => {
-                arc.write_or_err("session")?
-                    .conversation
-                    .queues
-                    .remove_pending_update(&target);
+                self.conversation.queues.remove_pending_update(&target);
             }
         }
 
         // Consensus has settled — drop the deadline so tick_deadlines
         // doesn't fire a stale handle_consensus_timeout.
-        arc.write_or_err("session")?
-            .unregister_consensus_timeout(proposal_id);
+        self.unregister_consensus_timeout(proposal_id);
 
         let score_ops = emergency_score_ops(&request, approved);
         if !score_ops.is_empty() {
-            Self::handle_emergency_scored(arc, proposal_id, &request, &score_ops)?;
+            self.handle_emergency_scored(proposal_id, &request, &score_ops)?;
         }
 
-        Self::current_tick(arc)
+        self.current_tick()
     }
 
-    /// Latest [`SessionTick`] under a brief read guard. Terminal value of
-    /// every `apply_consensus_outcome` exit path.
-    fn current_tick(arc: &Arc<RwLock<Self>>) -> Result<SessionTick, UserError> {
-        Ok(arc.read_or_err("session")?.tick())
+    /// Latest [`SessionTick`]. Terminal value of every
+    /// `apply_consensus_outcome` exit path.
+    fn current_tick(&self) -> Result<SessionTick, UserError> {
+        Ok(self.tick())
     }
 
     /// Emit a [`SessionEvent::PhaseChange`] for `transition`, if a state
     /// change occurred. Shared by the freeze / election / emergency paths.
-    fn emit_phase_change(
-        arc: &Arc<RwLock<Self>>,
-        transition: Option<ConversationState>,
-    ) -> Result<(), UserError> {
+    fn emit_phase_change(&self, transition: Option<ConversationState>) -> Result<(), UserError> {
         if let Some(state) = transition {
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::PhaseChange(state));
+            self.emit_event(SessionEvent::PhaseChange(state));
         }
         Ok(())
     }
@@ -172,29 +152,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// the resulting phase change. Called by `apply_consensus_outcome` for
     /// `UrgentRemoval` and `RecoveryModeOpened` outcomes that need an
     /// immediate commit.
-    fn start_freezing_and_emit(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let transition = arc.write_or_err("session")?.start_freezing();
-        Self::emit_phase_change(arc, transition)
+    fn start_freezing_and_emit(&mut self) -> Result<(), UserError> {
+        let transition = self.start_freezing();
+        self.emit_phase_change(transition)
     }
 
     /// When the removal target is a current steward, fire a fresh election
     /// in parallel so the next epoch keeps a healthy ES + BS.
-    fn refresh_stewards_after_removal(
-        arc: &Arc<RwLock<Self>>,
-        target: &[u8],
-    ) -> Result<(), UserError> {
-        let target_was_steward = arc
-            .read_or_err("session")?
-            .conversation
-            .steward_list
-            .is_steward(target);
-        if !target_was_steward {
+    fn refresh_stewards_after_removal(&mut self, target: &[u8]) -> Result<(), UserError> {
+        if !self.conversation.steward_list.is_steward(target) {
             return Ok(());
         }
-        if let Err(e) = Self::initiate_steward_election(arc, true) {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
+        if let Err(e) = self.initiate_steward_election(true) {
             info!(
-                conversation = %conv_name,
+                conversation = %self.conversation_id,
                 error = %e,
                 "post-removal steward-list refresh deferred"
             );
@@ -206,84 +177,70 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// if we were in it, close any open recovery window, and drain
     /// buffered updates so the fresh epoch steward picks them up.
     fn handle_election_accepted(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         election: StewardElectionProposal,
     ) -> Result<(), UserError> {
-        let is_valid = {
-            let s = arc.read_or_err("session")?;
-            s.conversation.expect_mls()?;
-            // Election proposals carry the candidate pool implicitly:
-            // `proposed_stewards` is the full set the proposer sorted, so
-            // `candidate_pool == proposed_stewards` for validation.
-            s.conversation.steward_list.validate_proposed(
-                &election.proposed_stewards,
-                election.election_epoch,
-                &election.proposed_stewards,
-                election.retry_round,
-            )?
-        };
+        self.conversation.expect_mls()?;
+        // Election proposals carry the candidate pool implicitly:
+        // `proposed_stewards` is the full set the proposer sorted, so
+        // `candidate_pool == proposed_stewards` for validation.
+        let is_valid = self.conversation.steward_list.validate_proposed(
+            &election.proposed_stewards,
+            election.election_epoch,
+            &election.proposed_stewards,
+            election.retry_round,
+        )?;
         if !is_valid {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
             info!(
-                conversation = %conv_name,
+                conversation = %self.conversation_id,
                 "steward election rejected: invalid list"
             );
             return Ok(());
         }
 
-        let resumed_from_reelection = {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation.steward_list.install_list(
-                election.election_epoch,
-                &election.proposed_stewards,
-                election.proposed_stewards.len(),
-                election.retry_round,
-            )?;
-            // `retry_round` stays > 0 until the next successful commit so
-            // the immediate post-election inactivity check uses the
-            // short retry window.
-            s.conversation.exit_recovery_mode();
-            if s.conversation.current_state() == ConversationState::Reelection {
-                Some(s.start_working())
+        self.conversation.steward_list.install_list(
+            election.election_epoch,
+            &election.proposed_stewards,
+            election.proposed_stewards.len(),
+            election.retry_round,
+        )?;
+        // `retry_round` stays > 0 until the next successful commit so
+        // the immediate post-election inactivity check uses the
+        // short retry window.
+        self.conversation.exit_recovery_mode();
+        let resumed_from_reelection =
+            if self.conversation.current_state() == ConversationState::Reelection {
+                Some(self.start_working())
             } else {
                 None
-            }
-        };
-        Self::emit_phase_change(arc, resumed_from_reelection)?;
-        {
-            let s = arc.read_or_err("session")?;
-            info!(
-                conversation = %s.conversation_id,
-                epoch = election.election_epoch,
-                stewards = election.proposed_stewards.len(),
-                retry_round = election.retry_round,
-                "steward election applied"
-            );
-        }
+            };
+        self.emit_phase_change(resumed_from_reelection)?;
+        info!(
+            conversation = %self.conversation_id,
+            epoch = election.election_epoch,
+            stewards = election.proposed_stewards.len(),
+            retry_round = election.retry_round,
+            "steward election applied"
+        );
 
-        Self::process_buffered_updates(arc)
+        self.process_buffered_updates()
     }
 
     /// Rejected election: bump the retry round and retry under the max
     /// (idempotent), or escalate to a `Deadlock` ECP once exhausted.
-    fn handle_election_rejected(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let (round, max) = {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation.steward_list.bump_retry();
-            (
-                s.conversation.steward_list.next_retry_round(),
-                s.conversation.steward_list.max_retries(),
-            )
-        };
-        let conversation_id = arc.read_or_err("session")?.conversation_id.clone();
+    fn handle_election_rejected(&mut self) -> Result<(), UserError> {
+        self.conversation.steward_list.bump_retry();
+        let round = self.conversation.steward_list.next_retry_round();
+        let max = self.conversation.steward_list.max_retries();
+        let conversation_id = self.conversation_id.clone();
         if round > max {
             info!(
                 conversation = %conversation_id,
                 round, max, "election retries exhausted; escalating to Layer 3"
             );
-            if let Err(e) = Self::initiate_deadlock_ecp(arc) {
+            if let Err(e) = self.initiate_deadlock_ecp() {
                 error!(conversation = %conversation_id, error = %e, "Deadlock ECP filing failed");
-                arc.read_or_err("session")?.emit_event(SessionEvent::Error {
+                self.emit_event(SessionEvent::Error {
                     operation: "Reelection stuck".to_string(),
                     message: e.to_string(),
                 });
@@ -294,7 +251,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             conversation = %conversation_id,
             round, max, "steward election rejected, retrying"
         );
-        if let Err(e) = Self::initiate_steward_election(arc, true) {
+        if let Err(e) = self.initiate_steward_election(true) {
             info!(conversation = %conversation_id, error = %e, "election retry deferred");
         }
         Ok(())
@@ -305,42 +262,33 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// exit Reelection if we landed there), then check for new
     /// below-threshold removals.
     fn handle_emergency_scored(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         proposal_id: u32,
         request: &ConversationUpdateRequest,
         score_ops: &[ScoreOp],
     ) -> Result<(), UserError> {
+        // Events from this apply chain into the score-removal pass
+        // below. The terminal `check_and_initiate_score_removals`
+        // call covers it, so we drop the result here.
+        let _ = self.conversation.scoring.apply_ops(score_ops);
+        if let Some(conversation_update_request::Payload::EmergencyCriteria(ec)) = &request.payload
+            && let Some(ev) = &ec.evidence
         {
-            let mut s = arc.write_or_err("session")?;
-            // Events from this apply chain into the score-removal pass
-            // below (after `handle_emergency_scored` returns into its
-            // caller). The terminal `check_and_initiate_score_removals`
-            // call covers it, so we drop the result here.
-            let _ = s.conversation.scoring.apply_ops(score_ops);
-            if let Some(conversation_update_request::Payload::EmergencyCriteria(ec)) =
-                &request.payload
-                && let Some(ev) = &ec.evidence
-            {
-                s.conversation
-                    .queues
-                    .remove_pending_removal(&ev.target_member_id);
-            }
+            self.conversation
+                .queues
+                .remove_pending_removal(&ev.target_member_id);
         }
 
-        let resumed_event = {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation.queues.remove_emergency(proposal_id);
-            if s.conversation.current_state() == ConversationState::Reelection {
-                Some(s.start_working())
-            } else {
-                None
-            }
+        self.conversation.queues.remove_emergency(proposal_id);
+        let resumed_event = if self.conversation.current_state() == ConversationState::Reelection {
+            Some(self.start_working())
+        } else {
+            None
         };
-        Self::emit_phase_change(arc, resumed_event)?;
+        self.emit_phase_change(resumed_event)?;
 
-        if let Err(e) = Self::check_and_initiate_score_removals(arc) {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
-            error!(conversation = %conv_name, error = %e, "score-removal check failed");
+        if let Err(e) = self.check_and_initiate_score_removals() {
+            error!(conversation = %self.conversation_id, error = %e, "score-removal check failed");
         }
         Ok(())
     }

--- a/src/app/session/freeze.rs
+++ b/src/app/session/freeze.rs
@@ -10,13 +10,13 @@
 //! the freeze fires `LeaveConversation`. Same handshake as
 //! [`SessionRunner::dispatch_inbound_result`].
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use tracing::{error, info};
 
 use crate::{
     app::{
-        ConversationState, DispatchOutcome, FreezeTimeoutStatus, LockExt, SessionRunner, UserError,
+        ConversationState, DispatchOutcome, FreezeTimeoutStatus, SessionRunner, UserError,
         session::runner::send_packet,
     },
     core::{
@@ -45,24 +45,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Polling check for `PendingJoin`. Returns [`PendingJoinTick::Expired`]
     /// after emitting `SessionEvent::Leaving` once the pending-join window
     /// elapses; the caller handles registry-side cleanup.
-    pub fn check_pending_join(arc: &Arc<RwLock<Self>>) -> Result<PendingJoinTick, UserError> {
-        let (state, expired, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            (
-                s.conversation.current_state(),
-                s.is_pending_join_expired(),
-                s.conversation_id.clone(),
-            )
-        };
+    pub fn check_pending_join(&self) -> Result<PendingJoinTick, UserError> {
+        let state = self.conversation.current_state();
         if state != ConversationState::PendingJoin {
             return Ok(PendingJoinTick::NotPending);
         }
-        if !expired {
+        if !self.is_pending_join_expired() {
             return Ok(PendingJoinTick::StillPending);
         }
-        info!(conversation = %conversation_id, "pending join timed out");
-        arc.read_or_err("session")?
-            .emit_event(SessionEvent::Leaving);
+        info!(conversation = %self.conversation_id, "pending join timed out");
+        self.emit_event(SessionEvent::Leaving);
         Ok(PendingJoinTick::Expired)
     }
 
@@ -73,79 +65,71 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// applied commit ejected the local member — the caller drives the
     /// User-side registry teardown.
     pub fn poll_freeze_status(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
     ) -> Result<(FreezeTimeoutStatus, DispatchOutcome), UserError> {
-        let (has_proposals, selection_event) = {
-            let mut s = arc.write_or_err("session")?;
+        let state = self.conversation.current_state();
+        if state != ConversationState::Freezing {
+            return Ok((FreezeTimeoutStatus::NotFreezing, DispatchOutcome::Done));
+        }
 
-            let state = s.conversation.current_state();
-            if state != ConversationState::Freezing {
-                return Ok((FreezeTimeoutStatus::NotFreezing, DispatchOutcome::Done));
-            }
+        // Early selection: skip remaining freeze time if all expected
+        // stewards have submitted candidates.
+        let all_candidates_in = self
+            .conversation
+            .steward_list
+            .current_list()
+            .is_some_and(|list| self.conversation.queues.freeze_candidate_count() >= list.len());
 
-            // Early selection: skip remaining freeze time if all expected
-            // stewards have submitted candidates.
-            let all_candidates_in = s
+        if !all_candidates_in && !self.is_freeze_timed_out() {
+            return Ok((FreezeTimeoutStatus::StillFreezing, DispatchOutcome::Done));
+        }
+
+        let selection_event = self.start_selection();
+        let has_proposals = self.conversation.queues.approved_proposals_count() > 0;
+        self.emit_event(SessionEvent::PhaseChange(selection_event));
+
+        let conversation_id = self.conversation_id.clone();
+        let allow_subset = self
+            .conversation
+            .steward_list
+            .config()
+            .allow_subset_candidates;
+        let self_member_id = Arc::clone(&self.self_member_id);
+        let mut finalize_result = if self.conversation.mls().is_some() {
+            match self
                 .conversation
-                .steward_list
-                .current_list()
-                .is_some_and(|list| s.conversation.queues.freeze_candidate_count() >= list.len());
-
-            if !all_candidates_in && !s.is_freeze_timed_out() {
-                return Ok((FreezeTimeoutStatus::StillFreezing, DispatchOutcome::Done));
-            }
-
-            let event = s.start_selection();
-            (s.conversation.queues.approved_proposals_count() > 0, event)
-        };
-
-        arc.read_or_err("session")?
-            .emit_event(SessionEvent::PhaseChange(selection_event));
-
-        let (mut finalize_result, downward_cross, conversation_id) = {
-            let mut s = arc.write_or_err("session")?;
-            let allow_subset = s.conversation.steward_list.config().allow_subset_candidates;
-            let self_member_id = Arc::clone(&s.self_member_id);
-            let result = if s.conversation.mls().is_some() {
-                match s
-                    .conversation
-                    .finalize_freeze_round(allow_subset, &self_member_id)
-                {
-                    Ok(result) => result,
-                    Err(e) => {
-                        error!(conversation = %s.conversation_id, error = %e, "freeze finalize failed");
-                        FreezeFinalizeResult::default()
-                    }
+                .finalize_freeze_round(allow_subset, &self_member_id)
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    error!(conversation = %conversation_id, error = %e, "freeze finalize failed");
+                    FreezeFinalizeResult::default()
                 }
-            } else {
-                FreezeFinalizeResult::default()
-            };
-            // Apply locally-observed score events before releasing the
-            // runner lock. These come from dropped candidates in the
-            // phase-3 loop (RFC §Peer Scoring: direct local observation,
-            // no ECP needed). A downward threshold cross schedules a
-            // removal-init pass below, after the lock drops.
-            let cross = if !result.score_ops.is_empty() {
-                s.conversation.scoring.apply_ops(&result.score_ops)
-            } else {
-                false
-            };
-            (result, cross, s.conversation_id.clone())
+            }
+        } else {
+            FreezeFinalizeResult::default()
+        };
+        // Apply locally-observed score events. These come from dropped
+        // candidates in the phase-3 loop (RFC §Peer Scoring: direct local
+        // observation, no ECP needed). A downward threshold cross schedules
+        // a removal-init pass below.
+        let downward_cross = if !finalize_result.score_ops.is_empty() {
+            self.conversation
+                .scoring
+                .apply_ops(&finalize_result.score_ops)
+        } else {
+            false
         };
 
         if !finalize_result.committed_batch.is_empty() {
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::CommitApplied(std::mem::take(
-                    &mut finalize_result.committed_batch,
-                )));
+            self.emit_event(SessionEvent::CommitApplied(std::mem::take(
+                &mut finalize_result.committed_batch,
+            )));
         }
 
-        // Lock split is intentional: `check_and_initiate_score_removals`
-        // re-acquires the runner write lock and calls `initiate_proposal`,
-        // which ``s on the consensus service. Holding the runner
-        // lock across that await would block other operations on this
-        // conversation, so we drop the lock above before chaining.
-        if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc) {
+        // `check_and_initiate_score_removals` calls `initiate_proposal`. A
+        // downward threshold cross during finalize schedules a removal pass.
+        if downward_cross && let Err(e) = self.check_and_initiate_score_removals() {
             error!(conversation = %conversation_id, error = %e, "score-removal check failed (freeze finalize)");
         }
 
@@ -163,17 +147,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     // inclusive list rather than the pre-commit one. A large
                     // group leaves the list for the post-commit election.
                     welcome.conversation_sync_bytes = {
-                        let mut s = arc.write_or_err("session")?;
-                        let _ = s.reconcile_steward_list()?;
-                        s.build_conversation_sync_packet()?
+                        let _ = self.reconcile_steward_list()?;
+                        self.build_conversation_sync_packet()?
                             .map(|p| p.payload)
                             .unwrap_or_default()
                     };
-                    arc.read_or_err("session")?
-                        .emit_event(SessionEvent::WelcomeReady(welcome));
+                    self.emit_event(SessionEvent::WelcomeReady(welcome));
                 }
 
-                let outcome = match Self::dispatch_inbound_result(arc, result) {
+                let outcome = match self.dispatch_inbound_result(result) {
                     Ok(o) => o,
                     Err(e) => {
                         error!(conversation = %conversation_id, error = %e, "finalize result dispatch failed");
@@ -188,62 +170,57 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 // other than ourselves. Self-penalties are skipped — the
                 // node that failed to commit observes its own state directly
                 // and doesn't need to record a ScoreOp against itself.
-                let (transition_event, downward_cross) = {
-                    let mut s = arc.write_or_err("session")?;
+                let (transition_event, downward_cross) = if has_proposals {
+                    // Approved batch (and in-flight votes) survive so
+                    // the recovered steward commits the same proposals
+                    // once the next election lands.
+                    let event = self.start_reelection();
 
-                    if has_proposals {
-                        // Approved batch (and in-flight votes) survive so
-                        // the recovered steward commits the same proposals
-                        // once the next election lands.
-                        let event = s.start_reelection();
-
-                        // Local observation → direct peer-score penalty,
-                        // no ECP round-trip. Each honest member records
-                        // the same event independently; threshold-crossing
-                        // removal still goes through SCORE_BELOW_THRESHOLD
-                        // consensus in steward.rs.
-                        let accuse_target = match s.conversation.mls() {
-                            Some(mls) => {
-                                let violation_epoch = mls.current_epoch()?;
-                                let members = mls.members()?;
-                                let self_member_id: &[u8] = &s.self_member_id;
-                                let eligible = s.conversation.queues.steward_eligibility(&members);
-                                s.conversation
-                                    .steward_list
-                                    .epoch_steward(violation_epoch, &eligible)
-                                    .filter(|id| !id.is_empty() && *id != self_member_id)
-                                    .map(|id| id.to_vec())
-                            }
-                            None => None,
-                        };
-                        let cross = if let Some(steward_id) = accuse_target {
-                            s.conversation.scoring.apply_op(&ScoreOp {
-                                member_id: steward_id,
-                                event: ScoreEvent::CensorshipInactivity,
-                            })
-                        } else {
-                            false
-                        };
-
-                        (event, cross)
+                    // Local observation → direct peer-score penalty,
+                    // no ECP round-trip. Each honest member records
+                    // the same event independently; threshold-crossing
+                    // removal still goes through SCORE_BELOW_THRESHOLD
+                    // consensus in steward.rs.
+                    let accuse_target = match self.conversation.mls() {
+                        Some(mls) => {
+                            let violation_epoch = mls.current_epoch()?;
+                            let members = mls.members()?;
+                            let self_member_id: &[u8] = &self.self_member_id;
+                            let eligible = self.conversation.queues.steward_eligibility(&members);
+                            self.conversation
+                                .steward_list
+                                .epoch_steward(violation_epoch, &eligible)
+                                .filter(|id| !id.is_empty() && *id != self_member_id)
+                                .map(|id| id.to_vec())
+                        }
+                        None => None,
+                    };
+                    let cross = if let Some(steward_id) = accuse_target {
+                        self.conversation.scoring.apply_op(&ScoreOp {
+                            member_id: steward_id,
+                            event: ScoreEvent::CensorshipInactivity,
+                        })
                     } else {
-                        s.conversation.queues.clear_freeze_round();
-                        let event = s.start_working();
-                        (event, false)
-                    }
+                        false
+                    };
+
+                    (event, cross)
+                } else {
+                    self.conversation.queues.clear_freeze_round();
+                    let event = self.start_working();
+                    (event, false)
                 };
 
-                if downward_cross && let Err(e) = Self::check_and_initiate_score_removals(arc) {
+                if downward_cross && let Err(e) = self.check_and_initiate_score_removals() {
                     error!(conversation = %conversation_id, error = %e, "score-removal check failed (freeze timeout)");
                 }
 
                 let entered_reelection = transition_event == ConversationState::Reelection;
-                arc.read_or_err("session")?
-                    .emit_event(SessionEvent::PhaseChange(transition_event));
+                self.emit_event(SessionEvent::PhaseChange(transition_event));
 
                 // Layer 2 recovery: regenerate the steward list. Only the
                 // responsible proposer's call actually submits.
-                if entered_reelection && let Err(e) = Self::initiate_steward_election(arc, true) {
+                if entered_reelection && let Err(e) = self.initiate_steward_election(true) {
                     info!(conversation = %conversation_id, error = %e, "recovery election deferred");
                 }
             }
@@ -258,80 +235,70 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Drive the steward-inactivity check. Returns `true` exactly on the
     /// tick that transitions into Freezing; `false` while still waiting,
     /// outside Working, or when there's no approved work. Stewards build
-    /// their own commit candidate under the same lock; candidate-build
-    /// failure is logged and the freeze transition proceeds (peers'
-    /// candidates still get processed).
-    ///
-    /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
-    /// awaiting on the transport for the steward's own candidate send.
-    pub fn check_member_freeze(arc: &Arc<RwLock<Self>>) -> Result<bool, UserError> {
-        // Sync phase: under the runner write lock, run the inactivity
-        // check and (for stewards) build the outbound candidate.
-        let (transitioned, transport, outbound) = {
-            let mut s = arc.write_or_err("session")?;
-            let state = s.conversation.current_state();
-            if state == ConversationState::PendingJoin {
-                return Ok(false);
-            }
-
-            let proposal_count = s.conversation.queues.approved_proposals_count();
-            // Hold the freeze while an election is in flight — committing on
-            // the known-stale list would just produce a NoCandidate.
-            if s.conversation.queues.has_election_in_flight() {
-                return Ok(false);
-            }
-            // Recovery uses the shorter retry inactivity window so we don't
-            // burn another full epoch waiting for a steward to commit.
-            let in_recovery = s.conversation.is_in_recovery_mode()
-                || s.conversation.steward_list.next_retry_round() > 0;
-            let inactivity = if in_recovery {
-                s.conversation.config.recovery_inactivity_duration
-            } else {
-                s.conversation.config.commit_inactivity_duration
-            };
-            let freeze_event = s.check_steward_inactivity(proposal_count, inactivity);
-            let Some(event) = freeze_event else {
-                return Ok(false);
-            };
-            let epoch = s.conversation.expect_mls()?.current_epoch()?;
-            s.conversation.queues.start_freeze_round(epoch);
-
-            let self_member_id = Arc::clone(&s.self_member_id);
-            let app_id = Arc::clone(&s.app_id);
-            let outbound = if s.conversation.steward_list.is_steward(&self_member_id) {
-                match s
-                    .conversation
-                    .create_commit_candidate(&self_member_id, &app_id)
-                {
-                    Ok(packets) => packets,
-                    Err(e) => {
-                        error!(
-                            conversation = %s.conversation_id,
-                            error = %e,
-                            "commit candidate build failed"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            info!(
-                conversation = %s.conversation_id,
-                approved = proposal_count,
-                "steward inactivity transition"
-            );
-
-            s.emit_event(SessionEvent::PhaseChange(event));
-            (true, Arc::clone(s.transport()), outbound)
-        };
-
-        // Async phase: release the lock before awaiting the transport.
-        if let Some(message) = outbound {
-            send_packet(&transport, message)?;
+    /// their own commit candidate too; candidate-build failure is logged
+    /// and the freeze transition proceeds (peers' candidates still get
+    /// processed).
+    pub fn check_member_freeze(&mut self) -> Result<bool, UserError> {
+        let state = self.conversation.current_state();
+        if state == ConversationState::PendingJoin {
+            return Ok(false);
         }
 
-        Ok(transitioned)
+        let proposal_count = self.conversation.queues.approved_proposals_count();
+        // Hold the freeze while an election is in flight — committing on
+        // the known-stale list would just produce a NoCandidate.
+        if self.conversation.queues.has_election_in_flight() {
+            return Ok(false);
+        }
+        // Recovery uses the shorter retry inactivity window so we don't
+        // burn another full epoch waiting for a steward to commit.
+        let in_recovery = self.conversation.is_in_recovery_mode()
+            || self.conversation.steward_list.next_retry_round() > 0;
+        let inactivity = if in_recovery {
+            self.conversation.config.recovery_inactivity_duration
+        } else {
+            self.conversation.config.commit_inactivity_duration
+        };
+        let freeze_event = self.check_steward_inactivity(proposal_count, inactivity);
+        let Some(event) = freeze_event else {
+            return Ok(false);
+        };
+        let epoch = self.conversation.expect_mls()?.current_epoch()?;
+        self.conversation.queues.start_freeze_round(epoch);
+
+        let self_member_id = Arc::clone(&self.self_member_id);
+        let app_id = Arc::clone(&self.app_id);
+        let outbound = if self.conversation.steward_list.is_steward(&self_member_id) {
+            match self
+                .conversation
+                .create_commit_candidate(&self_member_id, &app_id)
+            {
+                Ok(packets) => packets,
+                Err(e) => {
+                    error!(
+                        conversation = %self.conversation_id,
+                        error = %e,
+                        "commit candidate build failed"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        info!(
+            conversation = %self.conversation_id,
+            approved = proposal_count,
+            "steward inactivity transition"
+        );
+
+        self.emit_event(SessionEvent::PhaseChange(event));
+
+        if let Some(message) = outbound {
+            send_packet(self.transport(), message)?;
+        }
+
+        Ok(true)
     }
 }

--- a/src/app/session/inbound.rs
+++ b/src/app/session/inbound.rs
@@ -1,9 +1,8 @@
 //! Session-side inbound dispatch.
 //!
-//! `dispatch_inbound_result` and every `ProcessResult` branch handler live
-//! on `SessionRunner` as associated functions taking `Arc<RwLock<Self>>` so
-//! they can release the runner lock across `` points without holding
-//! it during proposal lifecycles.
+//! `dispatch_inbound_result` and every `ProcessResult` branch handler are
+//! `&mut self` methods on `SessionRunner`; compare with `consensus_events.rs`
+//! (consensus-bus-delivered outcomes).
 //!
 //! `LeaveConversation` is split: the session-side helper `prepare_self_leave`
 //! does the protocol work (emit `Leaving`, take and delete the MLS service);
@@ -12,7 +11,7 @@
 //! session method returns [`DispatchOutcome::LeaveRequested`] so the caller
 //! knows to finish the lifecycle on the User side.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use hashgraph_like_consensus::protos::consensus::v1::Proposal;
 use prost::Message;
@@ -20,7 +19,7 @@ use tracing::{error, info};
 
 use crate::{
     app::{
-        ConversationState, LockExt, SessionRunner, UserError,
+        ConversationState, SessionRunner, UserError,
         session::{
             consensus::build_vote_banner_event,
             consensus_bridge::{forward_incoming_proposal, forward_incoming_vote},
@@ -60,67 +59,61 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// produce a `ProcessResult` (e.g. the welcome-side
     /// `JoinedConversation`).
     pub(crate) fn dispatch_inbound_result(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         result: ProcessResult,
     ) -> Result<DispatchOutcome, UserError> {
         match result {
             ProcessResult::AppMessage(msg) => {
-                arc.read_or_err("session")?
-                    .emit_event(SessionEvent::AppMessage(*msg));
+                self.emit_event(SessionEvent::AppMessage(*msg));
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Proposal(proposal) => {
-                Self::on_incoming_proposal(arc, *proposal)?;
+                self.on_incoming_proposal(*proposal)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Vote(vote) => {
                 let proposal_id = vote.proposal_id;
-                let (consensus, conversation_id, outcome_applied) = {
-                    let s = arc.read_or_err("session")?;
-                    (
-                        s.consensus.clone(),
-                        s.conversation_id.clone(),
-                        s.conversation
-                            .queues
-                            .is_consensus_outcome_applied(proposal_id),
-                    )
-                };
+                let consensus = self.consensus.clone();
+                let conversation_id = self.conversation_id.clone();
+                let outcome_applied = self
+                    .conversation
+                    .queues
+                    .is_consensus_outcome_applied(proposal_id);
                 forward_incoming_vote::<P>(&conversation_id, *vote, &consensus, outcome_applied)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::MembershipChangeReceived(request) => {
-                Self::handle_incoming_update_request(arc, *request)?;
+                self.handle_incoming_update_request(*request)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::JoinedConversation(_name) => {
                 // `name` is always this conversation's name — `process_inbound`
                 // emits it via the local MLS service. Use the session's own
                 // `conversation_id` rather than the parameter.
-                Self::on_joined_conversation(arc)?;
+                self.on_joined_conversation()?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::ConversationUpdated => {
-                Self::on_conversation_updated(arc)?;
+                self.on_conversation_updated()?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::LeaveConversation => {
-                Self::prepare_self_leave(arc)?;
+                self.prepare_self_leave()?;
                 Ok(DispatchOutcome::LeaveRequested)
             }
             ProcessResult::CommitCandidateReceived {
                 steward_id: steward,
             } => {
-                Self::on_commit_candidate_received(arc, &steward)?;
+                self.on_commit_candidate_received(&steward)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::ConversationSyncReceived(sync) => {
-                Self::on_conversation_sync(arc, *sync)?;
+                self.on_conversation_sync(*sync)?;
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Noop(reason) => {
-                let conv_name = arc.read_or_err("session")?.conversation_id.clone();
                 tracing::debug!(
-                    conversation = %conv_name,
+                    conversation = %self.conversation_id,
                     ?reason,
                     "inbound dispatched as noop"
                 );
@@ -140,7 +133,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// blocked. We don't drop today — the RFC's Δ-synchrony assumption keeps
     /// divergence windows small. Consensus-service-level priority gating is
     /// tracked as a backlog item in `docs/ROADMAP.md`.
-    fn on_incoming_proposal(arc: &Arc<RwLock<Self>>, proposal: Proposal) -> Result<(), UserError> {
+    fn on_incoming_proposal(&mut self, proposal: Proposal) -> Result<(), UserError> {
         let decoded = match ConversationUpdateRequest::decode(proposal.payload.as_slice()) {
             Ok(req) => Some(req),
             Err(e) => {
@@ -153,18 +146,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
         };
         if let Some(req) = decoded.as_ref() {
-            let mut s = arc.write_or_err("session")?;
-            let current_epoch = match s.conversation.mls() {
+            let current_epoch = match self.conversation.mls() {
                 Some(mls) => mls.current_epoch()?,
                 None => 0,
             };
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
-                    s.conversation.queues.insert_emergency(proposal.proposal_id);
+                    self.conversation
+                        .queues
+                        .insert_emergency(proposal.proposal_id);
                 }
                 Some(conversation_update_request::Payload::MemberInvite(_))
                 | Some(conversation_update_request::Payload::RemoveMember(_)) => {
-                    s.conversation
+                    self.conversation
                         .queues
                         .insert_pending_update(req.clone(), current_epoch);
                 }
@@ -178,27 +172,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             .as_ref()
             .map(ProposalKind::of)
             .unwrap_or(ProposalKind::Commit);
-        let (consensus, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            (s.consensus.clone(), s.conversation_id.clone())
-        };
+        let consensus = self.consensus.clone();
+        let conversation_id = self.conversation_id.clone();
         forward_incoming_proposal::<P>(&conversation_id, proposal, &consensus)?;
         // Skip the banner + auto-vote for fast-path proposals: the
         // creator's bundled YES already resolved the session, so peers have
         // nothing to vote on.
         if expected_voters > 1 {
             let banner = build_vote_banner_event(&conversation_id, proposal_id, payload);
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::AppMessage(banner));
-            let (delay, vote) = {
-                let s = arc.read_or_err("session")?;
-                (
-                    s.conversation.config.voting_delay_for(kind),
-                    s.conversation.config.liveness_criteria_yes,
-                )
-            };
-            arc.write_or_err("session")?
-                .register_auto_vote(proposal_id, delay, vote);
+            self.emit_event(SessionEvent::AppMessage(banner));
+            let delay = self.conversation.config.voting_delay_for(kind);
+            let vote = self.conversation.config.liveness_criteria_yes;
+            self.register_auto_vote(proposal_id, delay, vote);
         }
         Ok(())
     }
@@ -206,31 +191,24 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// We just joined via welcome. Broadcast a system "joined" chat
     /// message, seed scoring with the current member set, and
     /// transition to Working.
-    fn on_joined_conversation(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let (packet, mls_members, conversation_id) = {
-            let mut s = arc.write_or_err("session")?;
-            let msg: AppMessage = ConversationMessage {
-                message: format!("User {} joined the conversation", s.member_id_display)
-                    .into_bytes(),
-                sender: "SYSTEM".to_string(),
-                conversation_id: s.conversation_id.clone(),
-            }
-            .into();
-            let app_id = Arc::clone(&s.app_id);
-            let conversation_id = s.conversation_id.clone();
-            let mls = s.conversation.expect_mls_mut()?;
-            let members = mls.members().unwrap_or_default();
-            let packet = mls.build_message(&msg, &app_id)?;
-            (packet, members, conversation_id)
-        };
-        let transport = Arc::clone(arc.read_or_err("session")?.transport());
-        send_packet(&transport, packet)?;
-        arc.write_or_err("session")?
-            .sync_scoring_members(&mls_members);
+    fn on_joined_conversation(&mut self) -> Result<(), UserError> {
+        let msg: AppMessage = ConversationMessage {
+            message: format!("User {} joined the conversation", self.member_id_display)
+                .into_bytes(),
+            sender: "SYSTEM".to_string(),
+            conversation_id: self.conversation_id.clone(),
+        }
+        .into();
+        let app_id = Arc::clone(&self.app_id);
+        let conversation_id = self.conversation_id.clone();
+        let mls = self.conversation.expect_mls_mut()?;
+        let mls_members = mls.members().unwrap_or_default();
+        let packet = mls.build_message(&msg, &app_id)?;
+        send_packet(self.transport(), packet)?;
+        self.sync_scoring_members(&mls_members);
 
-        let event = arc.write_or_err("session")?.start_working();
-        arc.read_or_err("session")?
-            .emit_event(SessionEvent::PhaseChange(event));
+        let event = self.start_working();
+        self.emit_event(SessionEvent::PhaseChange(event));
         info!(conversation = %conversation_id, "joined conversation");
         Ok(())
     }
@@ -239,70 +217,50 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Working, and run steward housekeeping (list reconcile, election
     /// kick-off, buffered-update drain). The commit author's `SuccessfulCommit`
     /// reward is emitted by `finalize_freeze_round`, not here.
-    fn on_conversation_updated(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let mls_members = {
-            let s = arc.read_or_err("session")?;
-            match s.conversation.mls() {
-                Some(mls) => mls.members().unwrap_or_default(),
-                None => Vec::new(),
-            }
+    fn on_conversation_updated(&mut self) -> Result<(), UserError> {
+        let mls_members = match self.conversation.mls() {
+            Some(mls) => mls.members().unwrap_or_default(),
+            None => Vec::new(),
         };
-        arc.write_or_err("session")?
-            .sync_scoring_members(&mls_members);
-        arc.write_or_err("session")?
-            .prune_pending_updates_after_commit()?;
+        self.sync_scoring_members(&mls_members);
+        self.prune_pending_updates_after_commit()?;
 
         // Transition to Working BEFORE steward checks (election needs Working
         // state). Reset reelection_round: this commit advanced the epoch,
         // so whatever retry cycle we were in belongs to the previous epoch.
-        let working_event = {
-            let mut s = arc.write_or_err("session")?;
-            s.conversation.steward_list.reset_retry();
-            let state = s.conversation.current_state();
-            if matches!(
-                state,
-                ConversationState::Working
-                    | ConversationState::Freezing
-                    | ConversationState::Selection
-                    | ConversationState::Reelection
-            ) {
-                Some(s.start_working())
-            } else {
-                None
-            }
+        self.conversation.steward_list.reset_retry();
+        let state = self.conversation.current_state();
+        let working_event = if matches!(
+            state,
+            ConversationState::Working
+                | ConversationState::Freezing
+                | ConversationState::Selection
+                | ConversationState::Reelection
+        ) {
+            Some(self.start_working())
+        } else {
+            None
         };
 
-        Self::steward_list_housekeeping(arc)?;
-        Self::process_buffered_updates(arc)?;
-        Self::maybe_close_recovery_window(arc);
+        self.steward_list_housekeeping()?;
+        self.process_buffered_updates()?;
+        self.maybe_close_recovery_window();
 
         if let Some(event) = working_event {
-            arc.read_or_err("session")?
-                .emit_event(SessionEvent::PhaseChange(event));
+            self.emit_event(SessionEvent::PhaseChange(event));
         }
         Ok(())
     }
 
     /// Fire a steward election while `recovery_mode` is set so the next
     /// list installs and closes the window.
-    fn maybe_close_recovery_window(arc: &Arc<RwLock<Self>>) {
-        let in_recovery_mode = match arc.read_or_err("session") {
-            Ok(s) => s.conversation.is_in_recovery_mode(),
-            Err(e) => {
-                tracing::warn!(error = %e, "recovery window check skipped: session lock poisoned");
-                return;
-            }
-        };
-        if !in_recovery_mode {
+    fn maybe_close_recovery_window(&mut self) {
+        if !self.conversation.is_in_recovery_mode() {
             return;
         }
-        if let Err(e) = Self::initiate_steward_election(arc, true) {
-            let conv_name = arc
-                .read_or_err("session")
-                .map(|s| s.conversation_id.clone())
-                .unwrap_or_else(|_| "<poisoned>".to_string());
+        if let Err(e) = self.initiate_steward_election(true) {
             info!(
-                conversation = %conv_name,
+                conversation = %self.conversation_id,
                 error = %e,
                 "post-recovery election deferred"
             );
@@ -313,14 +271,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// the session's bus and delete the local MLS state. The User-side
     /// caller drops the entry from the registry and broadcasts
     /// `ConversationLifecycle::Removed`.
-    fn prepare_self_leave(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        arc.read_or_err("session")?
-            .emit_event(SessionEvent::Leaving);
-        // Bind to a let so the write guard is dropped before `mls.delete()`
-        // runs the storage I/O — otherwise the guard's `if let` scrutinee
-        // lifetime would keep every other task on this session blocked
-        // throughout the delete.
-        let taken_mls = arc.write_or_err("session")?.conversation.take_mls();
+    fn prepare_self_leave(&mut self) -> Result<(), UserError> {
+        self.emit_event(SessionEvent::Leaving);
+        let taken_mls = self.conversation.take_mls();
         if let Some(mut mls) = taken_mls {
             // The leave is already committed (`Leaving` emitted, MLS
             // detached); a delete failure must log and continue, else the
@@ -334,59 +287,47 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Peer broadcast a commit candidate. If we were in Working, enter
     /// Freezing and — if we're a steward — build our own candidate too.
-    fn on_commit_candidate_received(
-        arc: &Arc<RwLock<Self>>,
-        steward: &[u8],
-    ) -> Result<(), UserError> {
-        {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
-            tracing::debug!(
-                conversation = %conv_name,
-                steward = ?steward,
-                "candidate received from peer steward"
-            );
+    fn on_commit_candidate_received(&mut self, steward: &[u8]) -> Result<(), UserError> {
+        tracing::debug!(
+            conversation = %self.conversation_id,
+            steward = ?steward,
+            "candidate received from peer steward"
+        );
+        let state = self.conversation.current_state();
+        if state != ConversationState::Working && state != ConversationState::Reelection {
+            return Ok(());
         }
-        let (event, outbound) = {
-            let mut s = arc.write_or_err("session")?;
-            let state = s.conversation.current_state();
-            if state != ConversationState::Working && state != ConversationState::Reelection {
-                return Ok(());
-            }
 
-            let Some(event) = s.start_freezing() else {
-                return Ok(());
-            };
-            let epoch = s.conversation.expect_mls()?.current_epoch()?;
-            s.conversation.queues.start_freeze_round(epoch);
+        let Some(event) = self.start_freezing() else {
+            return Ok(());
+        };
+        let epoch = self.conversation.expect_mls()?.current_epoch()?;
+        self.conversation.queues.start_freeze_round(epoch);
 
-            let self_member_id = Arc::clone(&s.self_member_id);
-            let app_id = Arc::clone(&s.app_id);
-            let outbound = if s.conversation.steward_list.is_steward(&self_member_id) {
-                match s
-                    .conversation
-                    .create_commit_candidate(&self_member_id, &app_id)
-                {
-                    Ok(packets) => packets,
-                    Err(e) => {
-                        error!(
-                            conversation = %s.conversation_id,
-                            error = %e,
-                            "own commit candidate build failed"
-                        );
-                        None
-                    }
+        let self_member_id = Arc::clone(&self.self_member_id);
+        let app_id = Arc::clone(&self.app_id);
+        let outbound = if self.conversation.steward_list.is_steward(&self_member_id) {
+            match self
+                .conversation
+                .create_commit_candidate(&self_member_id, &app_id)
+            {
+                Ok(packets) => packets,
+                Err(e) => {
+                    error!(
+                        conversation = %self.conversation_id,
+                        error = %e,
+                        "own commit candidate build failed"
+                    );
+                    None
                 }
-            } else {
-                None
-            };
-            (event, outbound)
+            }
+        } else {
+            None
         };
 
-        arc.read_or_err("session")?
-            .emit_event(SessionEvent::PhaseChange(event));
+        self.emit_event(SessionEvent::PhaseChange(event));
         if let Some(message) = outbound {
-            let transport = Arc::clone(arc.read_or_err("session")?.transport());
-            send_packet(&transport, message)?;
+            send_packet(self.transport(), message)?;
         }
         Ok(())
     }
@@ -395,23 +336,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// list. Validates the proposed list against the members it carries
     /// (not the full MLS set — the list may have been generated before we
     /// existed), then applies list + protocol flags + timing + peer scores.
-    fn on_conversation_sync(
-        arc: &Arc<RwLock<Self>>,
-        sync: ConversationSync,
-    ) -> Result<(), UserError> {
-        let (members, current_epoch, local_default_peer_score, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            if s.conversation.steward_list.current_list().is_some() {
-                return Ok(());
-            }
-            let mls = s.conversation.expect_mls()?;
-            (
-                mls.members()?,
-                mls.current_epoch()?,
-                s.conversation.scoring.default_score(),
-                s.conversation_id.clone(),
-            )
+    fn on_conversation_sync(&mut self, sync: ConversationSync) -> Result<(), UserError> {
+        if self.conversation.steward_list.current_list().is_some() {
+            return Ok(());
+        }
+        let conversation_id = self.conversation_id.clone();
+        let (members, current_epoch) = {
+            let mls = self.conversation.expect_mls()?;
+            (mls.members()?, mls.current_epoch()?)
         };
+        let local_default_peer_score = self.conversation.scoring.default_score();
         if !validate_conversation_sync(
             &conversation_id,
             &sync,
@@ -423,8 +357,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
 
         let sn = sync.steward_members.len();
-        arc.write_or_err("session")?
-            .apply_conversation_sync_to_entry(&sync)?;
+        self.apply_conversation_sync_to_entry(&sync)?;
 
         info!(
             conversation = %conversation_id,

--- a/src/app/session/messaging.rs
+++ b/src/app/session/messaging.rs
@@ -1,13 +1,13 @@
 //! Send operations on `SessionRunner`: key packages, app messages, and
 //! ban requests.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use prost::Message;
 
 use crate::{
     app::{
-        ConversationState, CreatorVote, LockExt, SessionRunner, SessionTick, UserError,
+        ConversationState, CreatorVote, SessionRunner, SessionTick, UserError,
         session::runner::send_packet,
     },
     core::{ConsensusPlugin, ConversationPluginsFactory},
@@ -42,61 +42,40 @@ pub fn build_key_package_packet(
 impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Broadcast `key_package` on this conversation's welcome subtopic so
     /// the steward can invite us.
-    ///
-    /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
-    /// awaiting on the transport.
-    pub fn send_key_package(
-        arc: &Arc<RwLock<Self>>,
-        key_package: KeyPackageBytes,
-    ) -> Result<SessionTick, UserError> {
-        let (transport, packet) = {
-            let s = arc.read_or_err("session")?;
-            let packet = build_key_package_packet(&s.conversation_id, key_package, &s.app_id);
-            (Arc::clone(s.transport()), packet)
-        };
-        send_packet(&transport, packet)?;
-        Ok(arc.read_or_err("session")?.tick())
+    pub fn send_key_package(&self, key_package: KeyPackageBytes) -> Result<SessionTick, UserError> {
+        let packet = build_key_package_packet(&self.conversation_id, key_package, &self.app_id);
+        send_packet(self.transport(), packet)?;
+        Ok(self.tick())
     }
 
     /// Send a chat message. Blocked in `PendingJoin` (no keys yet),
     /// `Freezing`, and `Selection` (epoch rotation in flight — the message
     /// might not decrypt on peers who have already merged the next commit).
     /// Governance traffic has its own gate (`check_proposal_allowed`).
-    ///
-    /// Takes `&Arc<RwLock<Self>>` so the runner lock is released before
-    /// awaiting on the transport.
-    pub fn send_app_message(
-        arc: &Arc<RwLock<Self>>,
-        message: Vec<u8>,
-    ) -> Result<SessionTick, UserError> {
-        let (transport, packet) = {
-            let mut s = arc.write_or_err("session")?;
-            let state = s.conversation.current_state();
-            if matches!(
-                state,
-                ConversationState::PendingJoin
-                    | ConversationState::Freezing
-                    | ConversationState::Selection
-            ) {
-                return Err(UserError::ConversationBlocked(state.to_string()));
-            }
+    pub fn send_app_message(&mut self, message: Vec<u8>) -> Result<SessionTick, UserError> {
+        let state = self.conversation.current_state();
+        if matches!(
+            state,
+            ConversationState::PendingJoin
+                | ConversationState::Freezing
+                | ConversationState::Selection
+        ) {
+            return Err(UserError::ConversationBlocked(state.to_string()));
+        }
 
-            let app_msg: AppMessage = ConversationMessage {
-                message,
-                sender: s.member_id_display.to_string(),
-                conversation_id: s.conversation_id.clone(),
-            }
-            .into();
-            let app_id = Arc::clone(&s.app_id);
-            let transport = Arc::clone(s.transport());
-            let packet = s
-                .conversation
-                .expect_mls_mut()?
-                .build_message(&app_msg, &app_id)?;
-            (transport, packet)
-        };
-        send_packet(&transport, packet)?;
-        Ok(arc.read_or_err("session")?.tick())
+        let app_msg: AppMessage = ConversationMessage {
+            message,
+            sender: self.member_id_display.to_string(),
+            conversation_id: self.conversation_id.clone(),
+        }
+        .into();
+        let app_id = Arc::clone(&self.app_id);
+        let packet = self
+            .conversation
+            .expect_mls_mut()?
+            .build_message(&app_msg, &app_id)?;
+        send_packet(self.transport(), packet)?;
+        Ok(self.tick())
     }
 
     /// Start a `RemoveMember` consensus round targeting `ban_request.user_to_ban`.
@@ -104,19 +83,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// creator's vote is bundled as YES at submit; no banner is shown to
     /// the requester.
     pub fn process_ban_request(
-        arc: &Arc<RwLock<Self>>,
+        &mut self,
         ban_request: BanRequest,
     ) -> Result<SessionTick, UserError> {
-        {
-            let s = arc.read_or_err("session")?;
-            let state = s.conversation.current_state();
-            if state != ConversationState::Working {
-                return Err(UserError::ConversationBlocked(state.to_string()));
-            }
+        let state = self.conversation.current_state();
+        if state != ConversationState::Working {
+            return Err(UserError::ConversationBlocked(state.to_string()));
         }
 
-        Self::initiate_proposal(
-            arc,
+        self.initiate_proposal(
             ConversationUpdateRequest {
                 payload: Some(conversation_update_request::Payload::RemoveMember(
                     RemoveMember {
@@ -127,6 +102,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             CreatorVote::Yes,
         )?;
 
-        Ok(arc.read_or_err("session")?.tick())
+        Ok(self.tick())
     }
 }

--- a/src/app/session/steward.rs
+++ b/src/app/session/steward.rs
@@ -1,20 +1,13 @@
 //! Post-epoch-advance steward housekeeping on `SessionRunner`: list
 //! generation/election, pending-update drain, scoring sync, conversation-sync
 //! broadcast.
-//!
-//! Methods that file new proposals (`initiate_steward_election`,
-//! `initiate_deadlock_ecp`, `process_buffered_updates`,
-//! `check_and_initiate_score_removals`) are associated functions taking
-//! `Arc<RwLock<SessionRunner>>` so they can call
-//! [`SessionRunner::initiate_proposal`] which itself spawns a background
-//! task. The rest are `&self` / `&mut self` methods on the runner.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use tracing::{error, info};
 
 use crate::{
-    app::{CreatorVote, LockExt, SessionRunner, UserError},
+    app::{CreatorVote, SessionRunner, UserError},
     core::{
         ConsensusPlugin, ConversationPluginsFactory, ElectionDecision, PeerScoringPlugin,
         StewardListPlugin, member_set, scoring_member_diff, target_member_id_of,
@@ -68,13 +61,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Reconcile the list after an epoch advance, opening a voted election when
     /// it's needed. Election-init failures are logged, not surfaced — the
     /// conversation may legitimately reject a new proposal right now.
-    pub fn steward_list_housekeeping(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
-        let reconcile = arc.write_or_err("session")?.reconcile_steward_list()?;
+    pub fn steward_list_housekeeping(&mut self) -> Result<(), UserError> {
+        let reconcile = self.reconcile_steward_list()?;
         if reconcile == StewardListReconcile::NeedsElection
-            && let Err(e) = Self::initiate_steward_election(arc, false)
+            && let Err(e) = self.initiate_steward_election(false)
         {
-            let conv_name = arc.read_or_err("session")?.conversation_id.clone();
-            info!(conversation = %conv_name, error = %e, "election initiation deferred");
+            info!(conversation = %self.conversation_id, error = %e, "election initiation deferred");
         }
         Ok(())
     }
@@ -155,21 +147,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// On epoch advance, the new live epoch steward drains the pending-update
     /// buffer into voting proposals. Skips entries already covered by the
     /// current voting/approved queues so we don't double-propose.
-    pub fn process_buffered_updates(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn process_buffered_updates(&mut self) -> Result<(), UserError> {
         let (current_epoch, to_propose, conversation_id): (
             u64,
             Vec<ConversationUpdateRequest>,
             String,
         ) = {
-            let s = arc.read_or_err("session")?;
-
-            let (current_epoch, members) = match s.conversation.mls() {
+            let (current_epoch, members) = match self.conversation.mls() {
                 Some(mls) => (mls.current_epoch()?, mls.members()?),
                 None => (0, Vec::new()),
             };
-            let self_member_id: &[u8] = &s.self_member_id;
-            let eligible = s.conversation.queues.steward_eligibility(&members);
-            let is_live = s
+            let self_member_id: &[u8] = &self.self_member_id;
+            let eligible = self.conversation.queues.steward_eligibility(&members);
+            let is_live = self
                 .conversation
                 .steward_list
                 .epoch_steward(current_epoch, &eligible)
@@ -181,12 +171,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // Collect buffered updates whose target isn't already in an
             // active proposal queue. Both the voting and approved queues
             // live on `ConversationQueues`.
-            let approved = s.conversation.queues.approved_proposals();
+            let approved = self.conversation.queues.approved_proposals();
             let approved_targets: std::collections::HashSet<&[u8]> =
                 approved.values().filter_map(target_member_id_of).collect();
             let members_set = member_set(&members);
 
-            let to_propose: Vec<ConversationUpdateRequest> = s
+            let to_propose: Vec<ConversationUpdateRequest> = self
                 .conversation
                 .queues
                 .pending_updates()
@@ -203,7 +193,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 })
                 .map(|(_, p)| p.request.clone())
                 .collect();
-            (current_epoch, to_propose, s.conversation_id.clone())
+            (current_epoch, to_propose, self.conversation_id.clone())
         };
 
         if to_propose.is_empty() {
@@ -220,7 +210,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Buffered updates inherit the same banner path as fresh
         // steward-auto-propose — the steward still decides per proposal.
         for request in to_propose {
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Deferred) {
+            if let Err(e) = self.initiate_proposal(request, CreatorVote::Deferred) {
                 info!(
                     conversation = %conversation_id,
                     error = %e,
@@ -309,16 +299,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Steward-only: file `ScoreBelowThreshold` ECPs for any member whose
     /// score fell at or below the removal threshold. Skips self and any
     /// target already covered by a pending removal.
-    pub fn check_and_initiate_score_removals(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn check_and_initiate_score_removals(&mut self) -> Result<(), UserError> {
         // Reactive entry: callers chain into this after a scoring apply
         // emitted a downward cross, so we expect at least one tracked
         // member to be at-or-below threshold. The scan is the source of
         // truth — events just trigger the look.
         let (epoch, to_remove, self_id_arc, conversation_id) = {
-            let mut s = arc.write_or_err("session")?;
-            let epoch = s.conversation.expect_mls()?.current_epoch()?;
-            let self_id_arc = Arc::clone(&s.self_member_id);
-            let is_steward = s.conversation.steward_list.is_steward(&self_id_arc);
+            let epoch = self.conversation.expect_mls()?.current_epoch()?;
+            let self_id_arc = Arc::clone(&self.self_member_id);
+            let is_steward = self.conversation.steward_list.is_steward(&self_id_arc);
             if !is_steward {
                 return Ok(());
             }
@@ -334,26 +323,25 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             //     ≤ threshold) would re-fire a duplicate ECP for the
             //     same target before the RemoveMember commits.
             let self_id: &[u8] = &self_id_arc;
-            let to_remove: Vec<(Vec<u8>, i64)> = s
+            let to_remove: Vec<(Vec<u8>, i64)> = self
                 .conversation
                 .scoring
                 .members_below_threshold()
                 .into_iter()
                 .filter(|id| id.as_slice() != self_id)
-                .filter(|id| !s.conversation.queues.has_pending_removal(id))
-                .filter(|id| !s.conversation.queues.has_approved_removal(id))
+                .filter(|id| !self.conversation.queues.has_pending_removal(id))
+                .filter(|id| !self.conversation.queues.has_approved_removal(id))
                 .filter_map(|id| {
-                    let score = s.conversation.scoring.score_for(&id)?;
+                    let score = self.conversation.scoring.score_for(&id)?;
                     Some((id, score))
                 })
                 .collect();
             for (id, _) in &to_remove {
-                s.conversation.queues.insert_pending_removal(id.clone());
+                self.conversation.queues.insert_pending_removal(id.clone());
             }
-            (epoch, to_remove, self_id_arc, s.conversation_id.clone())
+            (epoch, to_remove, self_id_arc, self.conversation_id.clone())
         };
 
-        // Submit proposals without holding the lock.
         for (target_id, current_score) in to_remove {
             let evidence =
                 ViolationEvidence::score_below_threshold(target_id.clone(), epoch, current_score)
@@ -369,11 +357,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // SCORE_BELOW_THRESHOLD is self-executing: threshold crossed ⇒
             // member must be removed. The steward's vote is YES by
             // protocol, so we bundle it at submit and skip the banner.
-            if let Err(e) = Self::initiate_proposal(arc, request, CreatorVote::Yes) {
-                arc.write_or_err("session")?
-                    .conversation
-                    .queues
-                    .remove_pending_removal(&target_id);
+            if let Err(e) = self.initiate_proposal(request, CreatorVote::Yes) {
+                self.conversation.queues.remove_pending_removal(&target_id);
                 error!(
                     conversation = %conversation_id,
                     target = ?target_id,
@@ -397,20 +382,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// already in `approved_proposals` thanks to
     /// [`crate::core::apply_consensus_result`], so `has_approved_removal`
     /// catches them without an explicit exclude.
-    pub fn initiate_steward_election(
-        arc: &Arc<RwLock<Self>>,
-        recovery: bool,
-    ) -> Result<(), UserError> {
+    pub fn initiate_steward_election(&mut self, recovery: bool) -> Result<(), UserError> {
         let (proposed_stewards, election_epoch, retry_round, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            let mls = s.conversation.expect_mls()?;
+            let mls = self.conversation.expect_mls()?;
             let epoch = mls.current_epoch()?;
             let mls_members = mls.members()?;
-            let self_member_id: &[u8] = &s.self_member_id;
+            let self_member_id: &[u8] = &self.self_member_id;
 
             // `has_election_in_flight` is a proposal-queue check, not a
             // steward-list one — gated here, before the plug-in call.
-            if s.conversation.queues.has_election_in_flight() {
+            if self.conversation.queues.has_election_in_flight() {
                 return Ok(());
             }
 
@@ -420,15 +401,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // — they may not have attached MLS and can't serve as stewards yet.
             let candidate_pool: Vec<Vec<u8>> = mls_members
                 .iter()
-                .filter(|m| s.conversation.queues.is_settled(m, epoch))
-                .filter(|m| !(recovery && s.conversation.queues.has_approved_removal(m)))
+                .filter(|m| self.conversation.queues.is_settled(m, epoch))
+                .filter(|m| !(recovery && self.conversation.queues.has_approved_removal(m)))
                 .cloned()
                 .collect();
             let pool_set: std::collections::HashSet<&[u8]> =
                 candidate_pool.iter().map(Vec::as_slice).collect();
             let eligible = |c: &[u8]| pool_set.contains(c);
 
-            match s.conversation.steward_list.propose_election(
+            match self.conversation.steward_list.propose_election(
                 epoch,
                 &candidate_pool,
                 self_member_id,
@@ -438,7 +419,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 ElectionDecision::Skip(reason) => {
                     if matches!(reason, "no eligible candidates after filter") {
                         info!(
-                            conversation = %s.conversation_id,
+                            conversation = %self.conversation_id,
                             "skipping election: {reason}"
                         );
                     }
@@ -452,7 +433,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     proposed_stewards,
                     election_epoch,
                     retry_round,
-                    s.conversation_id.clone(),
+                    self.conversation_id.clone(),
                 ),
             }
         };
@@ -479,7 +460,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Elections are conversation-wide decisions — broadcast unbundled
         // so the responsible proposer still votes via the banner.
-        Self::initiate_proposal(arc, request, CreatorVote::Deferred)?;
+        self.initiate_proposal(request, CreatorVote::Deferred)?;
 
         Ok(())
     }
@@ -487,19 +468,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Layer 3 escalation: file a `Deadlock` ECP after re-election retries
     /// exhaust. Only the deterministic responsible proposer submits;
     /// others no-op. On YES the ECP opens `recovery_mode`.
-    pub fn initiate_deadlock_ecp(arc: &Arc<RwLock<Self>>) -> Result<(), UserError> {
+    pub fn initiate_deadlock_ecp(&mut self) -> Result<(), UserError> {
         let (is_authorized, self_id, epoch, conversation_id) = {
-            let s = arc.read_or_err("session")?;
-            let mls = s.conversation.expect_mls()?;
+            let mls = self.conversation.expect_mls()?;
             let mls_members = mls.members()?;
             let epoch = mls.current_epoch()?;
-            let self_id: &[u8] = &s.self_member_id;
+            let self_id: &[u8] = &self.self_member_id;
             // Deadlock proposer = election proposer with the stricter
             // predicate (MLS-present and not queued for removal).
             let mls_set: std::collections::HashSet<&[u8]> =
                 mls_members.iter().map(Vec::as_slice).collect();
-            let conversation_ref = &s.conversation.queues;
-            let authorized = s
+            let conversation_ref = &self.conversation.queues;
+            let authorized = self
                 .conversation
                 .steward_list
                 .election_proposer(|c: &[u8]| {
@@ -508,9 +488,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 .is_some_and(|proposer| proposer == self_id);
             (
                 authorized,
-                Arc::clone(&s.self_member_id),
+                Arc::clone(&self.self_member_id),
                 epoch,
-                s.conversation_id.clone(),
+                self.conversation_id.clone(),
             )
         };
 
@@ -529,7 +509,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Bundle YES — the proposer's observation that the deadlock is
         // real is their vote.
-        Self::initiate_proposal(arc, request, CreatorVote::Yes)?;
+        self.initiate_proposal(request, CreatorVote::Yes)?;
         Ok(())
     }
 }

--- a/src/app/user/inbound.rs
+++ b/src/app/user/inbound.rs
@@ -136,7 +136,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let gur = ConversationUpdateRequest {
             payload: Some(conversation_update_request::Payload::MemberInvite(invite)),
         };
-        SessionRunner::handle_incoming_update_request(entry_arc, gur)
+        entry_arc
+            .write_or_err("session")?
+            .handle_incoming_update_request(gur)
     }
 
     /// Drive the session-side dispatcher and finish lifecycle work on the
@@ -147,7 +149,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         entry_arc: &Arc<RwLock<SessionRunner<P, CP>>>,
         result: ProcessResult,
     ) -> Result<(), UserError> {
-        let outcome = SessionRunner::dispatch_inbound_result(entry_arc, result)?;
+        let outcome = entry_arc
+            .write_or_err("session")?
+            .dispatch_inbound_result(result)?;
         if matches!(outcome, DispatchOutcome::LeaveRequested) {
             self.finalize_self_leave(conversation_id)?;
         }

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -165,6 +165,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             return Ok(());
         }
 
-        SessionRunner::initiate_self_leave(&entry_arc)
+        entry_arc.write_or_err("session")?.initiate_self_leave()
     }
 }

--- a/src/app/user/state.rs
+++ b/src/app/user/state.rs
@@ -126,7 +126,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::send_app_message(&entry, message)
+        entry.write_or_err("session")?.send_app_message(message)
     }
 
     /// Broadcast `key_package` on `conversation_id`'s welcome subtopic
@@ -140,7 +140,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::send_key_package(&entry, key_package)
+        entry.read_or_err("session")?.send_key_package(key_package)
     }
 
     /// Walk pending deadlines on `conversation_id`. Thin wrapper over
@@ -149,7 +149,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::tick_deadlines(&entry)
+        entry.write_or_err("session")?.tick_deadlines()
     }
 
     /// Advance every per-conversation polling path: deadlines (auto-votes
@@ -165,10 +165,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::tick_deadlines(&entry)?;
-        SessionRunner::poll_freeze_status(&entry)?;
-        SessionRunner::check_member_freeze(&entry)?;
-        SessionRunner::check_pending_join(&entry)?;
+        entry.write_or_err("session")?.tick_deadlines()?;
+        entry.write_or_err("session")?.poll_freeze_status()?;
+        entry.write_or_err("session")?.check_member_freeze()?;
+        entry.read_or_err("session")?.check_pending_join()?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -215,7 +215,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 },
             )),
         };
-        SessionRunner::initiate_proposal(&entry, request, CreatorVote::Yes)?;
+        entry
+            .write_or_err("session")?
+            .initiate_proposal(request, CreatorVote::Yes)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -279,7 +281,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::process_user_vote(&entry, proposal_id, vote)?;
+        entry
+            .write_or_err("session")?
+            .process_user_vote(proposal_id, vote)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -294,7 +298,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::process_ban_request(&entry, ban_request)
+        entry
+            .write_or_err("session")?
+            .process_ban_request(ban_request)
     }
 
     /// Submit `request` as a fresh consensus proposal with
@@ -311,7 +317,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::initiate_proposal(&entry, request, creator_vote)?;
+        entry
+            .write_or_err("session")?
+            .initiate_proposal(request, creator_vote)?;
         Ok(entry.read_or_err("session")?.tick())
     }
 
@@ -324,7 +332,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        SessionRunner::initiate_self_leave(&entry)?;
+        entry.write_or_err("session")?.initiate_self_leave()?;
         Ok(entry.read_or_err("session")?.tick())
     }
 

--- a/tests/app_message_roundtrip.rs
+++ b/tests/app_message_roundtrip.rs
@@ -3,7 +3,6 @@
 
 use std::time::Duration;
 
-use de_mls::app::SessionRunner;
 use de_mls::core::{SessionEvent, StewardListConfig};
 use de_mls::protos::de_mls::messages::v1::app_message;
 
@@ -27,7 +26,11 @@ fn chat_message_delivered_to_peer_as_app_message_event() {
     let alice_session = users[0].0.lookup_entry("chat").unwrap().unwrap();
     let bob_session = users[1].0.lookup_entry("chat").unwrap().unwrap();
 
-    SessionRunner::send_app_message(&alice_session, b"Hello from alice".to_vec()).unwrap();
+    alice_session
+        .write()
+        .unwrap()
+        .send_app_message(b"Hello from alice".to_vec())
+        .unwrap();
 
     // Relay alice's outbound to bob.
     settle_for(Duration::from_millis(40));

--- a/tests/common/session_fixtures.rs
+++ b/tests/common/session_fixtures.rs
@@ -262,10 +262,10 @@ pub fn fast_test_config() -> ConversationConfig {
 /// check, and (for joiners) the pending-join tick. Mirrors the production
 /// `group_polling_loop` body in `de_mls_gateway::group`.
 pub fn poll_once(session: &SessionArc) {
-    let _ = SessionRunner::tick_deadlines(session);
-    let _ = SessionRunner::poll_freeze_status(session);
-    let _ = SessionRunner::check_member_freeze(session);
-    let _ = SessionRunner::check_pending_join(session);
+    let _ = session.write().unwrap().tick_deadlines();
+    let _ = session.write().unwrap().poll_freeze_status();
+    let _ = session.write().unwrap().check_member_freeze();
+    let _ = session.read().unwrap().check_pending_join();
 }
 
 /// Bring up a conversation with `keys[0]` as the creator and the rest as
@@ -324,7 +324,11 @@ pub fn bootstrap_joined_conversation(
     // Joiners send KPs. Drain joiner transports, deliver to creator.
     for i in 1..users.len() {
         let kp = users[i].0.generate_key_package().expect("kp");
-        SessionRunner::send_key_package(&sessions[i], kp).expect("send kp");
+        sessions[i]
+            .read()
+            .unwrap()
+            .send_key_package(kp)
+            .expect("send kp");
     }
     let mut kp_packets = Vec::new();
     for (_, h) in users.iter().skip(1) {

--- a/tests/freeze_coordinator_ordering.rs
+++ b/tests/freeze_coordinator_ordering.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, SessionRunner};
+use de_mls::app::CreatorVote;
 use de_mls::core::{ConversationState, SessionEvent, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::{
@@ -55,7 +55,11 @@ fn freeze_cycle_emits_phase_events_in_order() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&alice_session, remove_request, CreatorVote::Yes).unwrap();
+    alice_session
+        .write()
+        .unwrap()
+        .initiate_proposal(remove_request, CreatorVote::Yes)
+        .unwrap();
 
     // Drive polling + packet relay until both sessions are back in
     // Working (bob will actually exit the conversation, so we check

--- a/tests/leave_after_removal.rs
+++ b/tests/leave_after_removal.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, DispatchOutcome, SessionRunner};
+use de_mls::app::{CreatorVote, DispatchOutcome};
 use de_mls::core::{SessionEvent, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::{
@@ -60,7 +60,11 @@ fn removed_member_emits_leaving_and_is_evicted() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes).unwrap();
+    steward_session
+        .write()
+        .unwrap()
+        .initiate_proposal(request, CreatorVote::Yes)
+        .unwrap();
 
     // Drive packet relay + polling until the target is evicted from its
     // User registry. Mirrors the gateway's polling loop: when
@@ -71,17 +75,17 @@ fn removed_member_emits_leaving_and_is_evicted() {
         settle_for(Duration::from_millis(40));
         for (i, (u, _)) in users.iter().enumerate() {
             if let Some(s) = u.lookup_entry("leave").unwrap() {
-                let _ = SessionRunner::tick_deadlines(&s);
+                let _ = s.write().unwrap().tick_deadlines();
                 if i == target_idx
                     && matches!(
-                        SessionRunner::poll_freeze_status(&s),
+                        s.write().unwrap().poll_freeze_status(),
                         Ok((_, DispatchOutcome::LeaveRequested))
                     )
                 {
                     u.finalize_self_leave("leave").unwrap();
                 } else {
-                    let _ = SessionRunner::poll_freeze_status(&s);
-                    let _ = SessionRunner::check_member_freeze(&s);
+                    let _ = s.write().unwrap().poll_freeze_status();
+                    let _ = s.write().unwrap().check_member_freeze();
                 }
             }
         }

--- a/tests/multi_conversation_isolation.rs
+++ b/tests/multi_conversation_isolation.rs
@@ -5,7 +5,7 @@
 //! block reads or writes on any other session, nor block the outer
 //! registry read path that `lookup_entry` walks.
 
-use de_mls::app::{ConversationConfig, SessionRunner};
+use de_mls::app::ConversationConfig;
 use de_mls::core::StewardListConfig;
 
 mod common;
@@ -14,8 +14,8 @@ use common::session_fixtures::{fast_test_config, make_user};
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
 // The whole point of this test is to hold one session's guard while
-// driving work on another — the await-holding-lock the lint flags is the
-// exact thing under assertion.
+// driving work on another — per-conversation lock isolation is the exact
+// thing under assertion.
 #[test]
 fn write_lock_on_one_session_does_not_block_others() {
     let cfg: ConversationConfig = fast_test_config();
@@ -50,22 +50,27 @@ fn write_lock_on_one_session_does_not_block_others() {
         let _b_guard = session_b
             .try_write()
             .expect("write on conv-b must not wait on conv-a's lock");
-        // Guard is dropped at the end of this block, before the await
-        // below — `check_member_freeze` takes the Arc and locks itself.
+        // Guard is dropped at the end of this block, before the
+        // `check_member_freeze` call below acquires its own write guard.
     }
 
     // Drive a session-level operation to prove the lock is actually
     // usable for real work, not just acquirable. `check_member_freeze`
-    // is a static method that takes the Arc and locks internally, so it
-    // composes with the outer isolation check without holding any guard
-    // across an await.
-    SessionRunner::check_member_freeze(&session_b)
+    // takes `&mut self`, so the caller holds the conv-b write guard for
+    // the call — independent of conv-a's still-held guard.
+    session_b
+        .write()
+        .unwrap()
+        .check_member_freeze()
         .expect("check_member_freeze on conv-b must succeed");
 
     drop(a_guard);
 
-    // After releasing, conv-a is also accessible — and the same static
-    // entry point works against either Arc.
-    SessionRunner::check_member_freeze(&session_a)
+    // After releasing, conv-a is also accessible — the same entry point
+    // works against either session.
+    session_a
+        .write()
+        .unwrap()
+        .check_member_freeze()
         .expect("conv-a check_member_freeze must succeed");
 }

--- a/tests/operating_mode_transitions.rs
+++ b/tests/operating_mode_transitions.rs
@@ -11,7 +11,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, SessionRunner};
+use de_mls::app::CreatorVote;
 use de_mls::core::{ConversationState, SessionEvent, StewardListConfig};
 use de_mls::protos::de_mls::messages::v1::ViolationEvidence;
 
@@ -52,7 +52,11 @@ fn deadlock_ecp_opens_recovery_and_force_freezes() {
         .with_creator(b"alice-creator".to_vec())
         .into_update_request()
         .unwrap();
-    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes).unwrap();
+    alice_session
+        .write()
+        .unwrap()
+        .initiate_proposal(request, CreatorVote::Yes)
+        .unwrap();
 
     let mut alice_saw_freezing = false;
     let mut bob_saw_freezing = false;

--- a/tests/pending_join_eviction.rs
+++ b/tests/pending_join_eviction.rs
@@ -9,7 +9,7 @@
 
 use std::time::{Duration, Instant};
 
-use de_mls::app::{ConversationConfig, PendingJoinTick, SessionRunner};
+use de_mls::app::{ConversationConfig, PendingJoinTick};
 use de_mls::core::{ConversationLifecycle, SessionEvent, StewardListConfig};
 
 mod common;
@@ -92,7 +92,7 @@ fn await_pending_join_outcome(session: &SessionArc, inactivity: Duration) -> Pen
     // Allow up to 6× inactivity so the test isn't fragile on slow CI.
     let deadline = Instant::now() + inactivity * 6;
     loop {
-        let tick = SessionRunner::check_pending_join(session).unwrap();
+        let tick = session.read().unwrap().check_pending_join().unwrap();
         if tick != PendingJoinTick::StillPending {
             return tick;
         }

--- a/tests/recovery_cascade.rs
+++ b/tests/recovery_cascade.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
-use de_mls::app::{ConversationConfig, SessionRunner, User};
+use de_mls::app::{ConversationConfig, User};
 use de_mls::core::StewardListConfig;
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultConversationPluginsFactory};
 use de_mls::ds::{
@@ -113,7 +113,7 @@ fn concurrent_joins_leave_joiners_with_empty_buffer() {
     for u in [&bob, &charlie, &dave] {
         let kp = u.generate_key_package().unwrap();
         let session = u.lookup_entry(group).unwrap().unwrap();
-        SessionRunner::send_key_package(&session, kp).unwrap();
+        session.read().unwrap().send_key_package(kp).unwrap();
     }
 
     // Step 3: Broadcast every KP packet to every participant (mocks pubsub).

--- a/tests/recovery_inactivity_reelection.rs
+++ b/tests/recovery_inactivity_reelection.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, SessionRunner};
+use de_mls::app::CreatorVote;
 use de_mls::core::{ConversationState, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::{
@@ -64,7 +64,11 @@ fn silent_steward_drives_observer_to_reelection() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&observer_session, request, CreatorVote::Yes).unwrap();
+    observer_session
+        .write()
+        .unwrap()
+        .initiate_proposal(request, CreatorVote::Yes)
+        .unwrap();
 
     // Phase 1: pump packets normally until both sides have approved=1.
     let mut consensus_reached = false;

--- a/tests/rejoin_after_eviction.rs
+++ b/tests/rejoin_after_eviction.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, DispatchOutcome, SessionRunner};
+use de_mls::app::{CreatorVote, DispatchOutcome};
 use de_mls::core::{ConversationState, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::{
@@ -68,7 +68,11 @@ fn evicted_member_can_rejoin_at_higher_epoch() {
             },
         )),
     };
-    SessionRunner::initiate_proposal(&steward_session, request, CreatorVote::Yes).unwrap();
+    steward_session
+        .write()
+        .unwrap()
+        .initiate_proposal(request, CreatorVote::Yes)
+        .unwrap();
 
     let mut target_evicted = false;
     for _ in 0..30 {
@@ -95,7 +99,7 @@ fn evicted_member_can_rejoin_at_higher_epoch() {
 
     let new_session = users[target_idx].0.lookup_entry("rejoin").unwrap().unwrap();
     let kp = users[target_idx].0.generate_key_package().unwrap();
-    SessionRunner::send_key_package(&new_session, kp).unwrap();
+    new_session.read().unwrap().send_key_package(kp).unwrap();
 
     let mut rejoined = false;
     for _ in 0..30 {
@@ -146,14 +150,14 @@ fn drive_one_round(
     let mut sessions = Vec::with_capacity(users.len());
     for (i, (u, _)) in users.iter().enumerate() {
         if let Some(s) = u.lookup_entry("rejoin").unwrap() {
-            let _ = SessionRunner::tick_deadlines(&s);
-            let pfs = SessionRunner::poll_freeze_status(&s);
+            let _ = s.write().unwrap().tick_deadlines();
+            let pfs = s.write().unwrap().poll_freeze_status();
             if i == target_idx && matches!(pfs, Ok((_, DispatchOutcome::LeaveRequested))) {
                 u.finalize_self_leave("rejoin").unwrap();
                 continue;
             }
-            let _ = SessionRunner::check_member_freeze(&s);
-            let _ = SessionRunner::check_pending_join(&s).unwrap();
+            let _ = s.write().unwrap().check_member_freeze();
+            let _ = s.read().unwrap().check_pending_join().unwrap();
             sessions.push(s);
         }
     }

--- a/tests/steward_inactivity_commit.rs
+++ b/tests/steward_inactivity_commit.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use de_mls::app::{CreatorVote, SessionRunner};
+use de_mls::app::CreatorVote;
 use de_mls::core::StewardListConfig;
 use de_mls::ds::OutboundPacket;
 use de_mls::member_id::MemberId;
@@ -53,7 +53,11 @@ fn steward_inactivity_fires_commit_candidate() {
             RemoveMember { member_id: bob_id },
         )),
     };
-    SessionRunner::initiate_proposal(&alice_session, request, CreatorVote::Yes).unwrap();
+    alice_session
+        .write()
+        .unwrap()
+        .initiate_proposal(request, CreatorVote::Yes)
+        .unwrap();
 
     // Drive polling + packet relay. Accumulate alice's outbound so we can
     // verify a `CommitCandidate` packet appears — without any explicit


### PR DESCRIPTION
The per-conversation `SessionRunner` methods used to take `&Arc<RwLock<Self>>` and re-acquire the runner lock internally, so they could drop it across the `.await` points that proposal and transport calls used to have. The sync migration removed those await points, leaving the lock-juggling as dead ceremony.