### PR TITLE
refactor(session): build conversations via ConversationDeps

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -37,7 +37,7 @@ pub use error::UserError;
 pub use phase_timer::{FreezeTimeoutStatus, PhaseTimer};
 pub(crate) use session::LockExt;
 pub use session::{
-    CreatorVote, DispatchOutcome, PendingJoinTick, SessionRunner, SessionTick,
+    ConversationDeps, CreatorVote, DispatchOutcome, PendingJoinTick, SessionRunner, SessionTick,
     build_key_package_packet,
 };
 pub use user::{ConsensusContext, SessionEntry, User, UserPlugins};

--- a/src/app/session/construct.rs
+++ b/src/app/session/construct.rs
@@ -1,0 +1,149 @@
+//! Standalone construction of a [`SessionRunner`] from a [`ConversationDeps`]
+//! bundle — no `User` required.
+//!
+//! [`ConversationDeps`] gathers everything a single conversation needs:
+//! the shared plug-in factory and consensus context (borrowed — one set
+//! serves every conversation an integrator runs), the identity, the
+//! transport, and the per-conversation config. [`SessionRunner::create`]
+//! and [`SessionRunner::join`] consume one bundle and return a runner ready
+//! to drop into a registry. `User` is now a thin caller of these; an
+//! integrator can build conversations the same way without it.
+
+use std::sync::Arc;
+
+use hashgraph_like_consensus::events::ConsensusEventBus;
+use tracing::info;
+
+use crate::{
+    app::{ConsensusContext, ConversationState, PhaseTimer, SessionRunner, UserError},
+    core::{
+        ConsensusPlugin, ConversationConfig, ConversationPluginsFactory, ConversationQueues,
+        ConversationStateMachine, PeerScoringPlugin, ScoringConfig, SessionEvent,
+        StewardListConfig, StewardListPlugin,
+    },
+    ds::SharedDeliveryService,
+    member_id::MemberId,
+};
+
+/// Everything one conversation needs to come into being.
+///
+/// The plug-in factory and consensus context are borrowed: an integrator
+/// holds one of each and serves every conversation from them. The identity
+/// is borrowed too — the constructor snapshots its bytes/display. The rest
+/// is owned and cheap (Arc handles + small configs), built fresh per
+/// conversation since `config` varies.
+pub struct ConversationDeps<'a, P: ConsensusPlugin, CP: ConversationPluginsFactory> {
+    /// Builds the per-conversation MLS / scoring / steward plug-ins.
+    pub plugins: &'a CP,
+    /// Mints this conversation's consensus service from shared storage.
+    pub consensus: &'a ConsensusContext<P>,
+    /// Local participant identity; the constructor snapshots its bytes
+    /// and display form onto the runner.
+    pub identity: &'a dyn MemberId,
+    /// Outbound transport, shared with the integrator's other conversations.
+    pub transport: SharedDeliveryService,
+    /// Per-instance UUID stamped on every outbound packet for echo dedup.
+    pub app_id: Arc<[u8]>,
+    /// Durable per-conversation protocol config.
+    pub config: ConversationConfig,
+    /// Seed config for the peer-scoring plug-in.
+    pub scoring_config: ScoringConfig,
+    /// Seed config for the steward-list plug-in.
+    pub steward_list_config: StewardListConfig,
+}
+
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+    /// Build a runner for a brand-new conversation we create and steward.
+    /// Starts in `Working` with the local member installed as sole steward
+    /// at epoch 0.
+    pub fn create(conversation_id: &str, deps: ConversationDeps<P, CP>) -> Result<Self, UserError> {
+        Self::build(conversation_id, deps, true)
+    }
+
+    /// Build a runner that joins an existing conversation. Starts in
+    /// `PendingJoin` with no MLS state; the steward list and scoring fill in
+    /// once the welcome and `ConversationSync` arrive.
+    pub fn join(conversation_id: &str, deps: ConversationDeps<P, CP>) -> Result<Self, UserError> {
+        Self::build(conversation_id, deps, false)
+    }
+
+    /// Shared construction body for [`Self::create`] / [`Self::join`].
+    fn build(
+        conversation_id: &str,
+        deps: ConversationDeps<P, CP>,
+        is_creation: bool,
+    ) -> Result<Self, UserError> {
+        let self_member_id_bytes = deps.identity.member_id_bytes().to_vec();
+
+        let (queues, mls_opt, state_machine, phase_timer) = if is_creation {
+            let mls = deps.plugins.create_mls(conversation_id.to_string())?;
+            (
+                ConversationQueues::new(conversation_id),
+                Some(mls),
+                ConversationStateMachine::new_as_member(),
+                PhaseTimer::new(),
+            )
+        } else {
+            // Anchor the timer at "now" so `is_pending_join_expired` can
+            // detect the 3× commit-inactivity timeout.
+            let mut phase_timer = PhaseTimer::new();
+            phase_timer.start();
+            (
+                ConversationQueues::new(conversation_id),
+                None,
+                ConversationStateMachine::new_as_pending_join(),
+                phase_timer,
+            )
+        };
+
+        let mut steward_list = deps
+            .plugins
+            .make_steward_list(conversation_id.as_bytes(), deps.steward_list_config);
+        steward_list.set_max_retries(deps.config.max_reelection_attempts);
+        // Creator path: bootstrap the list with self as sole steward at
+        // epoch 0. Joiner path leaves the plug-in empty until `ConversationSync`.
+        if is_creation {
+            steward_list.install_list(0, std::slice::from_ref(&self_member_id_bytes), 1, 0)?;
+        }
+
+        let mut scoring = deps.plugins.make_scoring(&deps.scoring_config);
+        // Joiners get tracked at `JoinedConversation` time, once members are known.
+        if is_creation {
+            // Creator is self at `default_score`; under standard config
+            // (`default > threshold`) no cross fires, so we drop the result.
+            let _ = scoring.add_member(&self_member_id_bytes);
+        }
+
+        let initial_state = state_machine.current_state();
+        if initial_state == ConversationState::PendingJoin {
+            info!(
+                conversation = conversation_id,
+                timeout_s = deps.config.commit_inactivity_duration.as_secs() * 3,
+                "pending join, awaiting welcome"
+            );
+        }
+
+        let consensus = deps.consensus.build_service();
+        let consensus_rx = consensus.event_bus().subscribe();
+        let runner = SessionRunner::new(
+            conversation_id.to_string(),
+            queues,
+            mls_opt,
+            state_machine,
+            phase_timer,
+            deps.config,
+            scoring,
+            steward_list,
+            consensus,
+            consensus_rx,
+            deps.transport,
+            Arc::from(deps.identity.member_id_bytes()),
+            Arc::from(deps.identity.member_id_display()),
+            deps.app_id,
+        );
+        // Surface the opening phase so a caller draining session events sees
+        // the conversation's starting state without a separate query.
+        runner.emit_event(SessionEvent::PhaseChange(initial_state));
+        Ok(runner)
+    }
+}

--- a/src/app/session/mod.rs
+++ b/src/app/session/mod.rs
@@ -11,6 +11,7 @@
 mod consensus;
 mod consensus_bridge;
 mod consensus_events;
+mod construct;
 mod freeze;
 mod inbound;
 mod lock;
@@ -21,6 +22,7 @@ mod steward;
 mod tick;
 
 pub use consensus::CreatorVote;
+pub use construct::ConversationDeps;
 pub use freeze::PendingJoinTick;
 pub use inbound::DispatchOutcome;
 pub(crate) use lock::LockExt;

--- a/src/app/session/runner.rs
+++ b/src/app/session/runner.rs
@@ -62,14 +62,13 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     pub conversation_id: String,
     pub(crate) conversation: Conversation<CP>,
     /// Per-conversation consensus service. Owns this conversation's scope
-    /// in the shared storage and a private event bus. Constructed at
-    /// conversation creation by `User::build_consensus_service`.
+    /// in the shared storage and a private event bus. Minted from the
+    /// [`crate::app::ConversationDeps`] consensus context at construction.
     pub consensus: ConsensusServiceFor<P>,
     /// Subscriber on `consensus.event_bus()`. Drained by
     /// [`Self::tick_deadlines`], which dispatches each event through
-    /// `apply_consensus_outcome`. Subscribed in
-    /// [`crate::app::User::start_conversation`] before the runner is
-    /// registered.
+    /// `apply_consensus_outcome`. Subscribed when the runner is built in
+    /// [`SessionRunner::create`] / [`SessionRunner::join`].
     pub(crate) consensus_rx: ConsensusReceiver<P>,
     /// Wall-clock anchor combined with `conversation.state_machine` by
     /// coordinator methods.

--- a/src/app/user/lifecycle.rs
+++ b/src/app/user/lifecycle.rs
@@ -2,15 +2,13 @@
 
 use std::sync::{Arc, RwLock};
 
-use hashgraph_like_consensus::events::ConsensusEventBus;
 use tracing::info;
 
 use crate::{
-    app::{ConversationState, LockExt, PhaseTimer, SessionRunner, User, UserError},
+    app::{ConversationDeps, ConversationState, LockExt, SessionRunner, User, UserError},
     core::{
         ConsensusPlugin, ConversationConfig, ConversationLifecycle, ConversationPluginsFactory,
-        ConversationQueues, ConversationStateMachine, PeerScoringPlugin, SessionEvent,
-        StewardListPlugin,
+        SessionEvent,
     },
 };
 
@@ -43,73 +41,22 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             return Err(UserError::ConversationAlreadyExists);
         }
 
-        let self_member_id_bytes = self.self_member_id().to_vec();
-        let (conversation, mls_opt, state_machine, phase_timer) = if is_creation {
-            let mls = self
-                .plugins
-                .conversation_plugins
-                .create_mls(conversation_id.to_string())?;
-            let conversation = ConversationQueues::new(conversation_id);
-            let state_machine = ConversationStateMachine::new_as_member();
-            (conversation, Some(mls), state_machine, PhaseTimer::new())
-        } else {
-            let conversation = ConversationQueues::new(conversation_id);
-            let state_machine = ConversationStateMachine::new_as_pending_join();
-            // Anchor the timer at "now" so `is_pending_join_expired` can
-            // detect the 3× commit-inactivity timeout.
-            let mut phase_timer = PhaseTimer::new();
-            phase_timer.start();
-            (conversation, None, state_machine, phase_timer)
-        };
-
-        let mut steward_list = self.plugins.conversation_plugins.make_steward_list(
-            conversation_id.as_bytes(),
-            self.plugins.default_steward_list_config.clone(),
-        );
-        steward_list.set_max_retries(config.max_reelection_attempts);
-        // Creator path: bootstrap the list with self as sole steward at
-        // epoch 0. Joiner path leaves the plug-in empty until `ConversationSync`.
-        if is_creation {
-            steward_list.install_list(0, std::slice::from_ref(&self_member_id_bytes), 1, 0)?;
-        }
-
-        let mut scoring = self
-            .plugins
-            .conversation_plugins
-            .make_scoring(&self.plugins.default_scoring_config);
-        // Joiners get tracked at `JoinedConversation` time, once members are known.
-        if is_creation {
-            // Creator is self at `default_score`; under standard config
-            // (`default > threshold`) no cross fires, so we drop the result.
-            let _ = scoring.add_member(&self_member_id_bytes);
-        }
-
-        let initial_state = state_machine.current_state();
-        if initial_state == ConversationState::PendingJoin {
-            info!(
-                conversation = conversation_id,
-                timeout_s = config.commit_inactivity_duration.as_secs() * 3,
-                "pending join, awaiting welcome"
-            );
-        }
-        let consensus = self.build_consensus_service();
-        let consensus_rx = consensus.event_bus().subscribe();
-        let session = Arc::new(RwLock::new(SessionRunner::new(
-            conversation_id.to_string(),
-            conversation,
-            mls_opt,
-            state_machine,
-            phase_timer,
+        let deps = ConversationDeps {
+            plugins: &self.plugins.conversation_plugins,
+            consensus: &self.plugins.consensus,
+            identity: self.member_id.as_ref(),
+            transport: Arc::clone(&self.transport),
+            app_id: Arc::from(self.app_id.as_slice()),
             config,
-            scoring,
-            steward_list,
-            consensus,
-            consensus_rx,
-            Arc::clone(&self.transport),
-            Arc::from(self.member_id.member_id_bytes()),
-            Arc::from(self.member_id.member_id_display()),
-            Arc::from(self.app_id.as_slice()),
-        )));
+            scoring_config: self.plugins.default_scoring_config.clone(),
+            steward_list_config: self.plugins.default_steward_list_config.clone(),
+        };
+        let runner = if is_creation {
+            SessionRunner::create(conversation_id, deps)?
+        } else {
+            SessionRunner::join(conversation_id, deps)?
+        };
+        let session = Arc::new(RwLock::new(runner));
         {
             let mut conversations = self
                 .conversations
@@ -118,16 +65,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             if conversations.contains_key(conversation_id) {
                 return Err(UserError::ConversationAlreadyExists);
             }
-            conversations.insert(conversation_id.to_string(), Arc::clone(&session));
+            conversations.insert(conversation_id.to_string(), session);
         }
 
-        // Record the lifecycle event first so integrators draining
-        // [`User::drain_lifecycle_events`] see `Created` before any
-        // per-session event emitted below.
+        // The runner already buffered its opening `PhaseChange`; record the
+        // lifecycle event so integrators draining
+        // [`User::drain_lifecycle_events`] discover the session.
         self.emit_lifecycle(ConversationLifecycle::Created(conversation_id.to_string()));
-        session
-            .read_or_err("session")?
-            .emit_event(SessionEvent::PhaseChange(initial_state));
 
         Ok(())
     }

--- a/src/app/user/state.rs
+++ b/src/app/user/state.rs
@@ -14,8 +14,8 @@ use crate::{
         UserPlugins,
     },
     core::{
-        ConsensusPlugin, ConsensusServiceFor, ConversationLifecycle, ConversationPluginsFactory,
-        ScoringConfig, SessionEvent, StewardListConfig,
+        ConsensusPlugin, ConversationLifecycle, ConversationPluginsFactory, ScoringConfig,
+        SessionEvent, StewardListConfig,
     },
     ds::SharedDeliveryService,
     member_id::MemberId,
@@ -476,12 +476,6 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
                 "lifecycle-event buffer mutex poisoned; event dropped"
             ),
         }
-    }
-
-    /// Build a fresh per-conversation `ConsensusService` via the User's
-    /// `ConsensusContext`.
-    pub fn build_consensus_service(&self) -> ConsensusServiceFor<P> {
-        self.plugins.consensus.build_service()
     }
 
     /// Drop this conversation's consensus scope from the shared storage and

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -1,0 +1,109 @@
+//! Step 1 proof: a `SessionRunner` can be built and queried straight from a
+//! `ConversationDeps` bundle, with no `User` in the picture. The integrator
+//! holds one plug-in factory + consensus context and constructs each
+//! conversation from them — exactly what `User` does internally, here done
+//! by hand.
+
+mod common;
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use alloy::signers::local::PrivateKeySigner;
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
+
+use de_mls::app::{ConsensusContext, ConversationDeps, ConversationState, SessionRunner};
+use de_mls::core::{ScoringConfig, SessionEvent, StewardListConfig};
+use de_mls::defaults::{
+    DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage,
+};
+use de_mls::ds::SharedDeliveryService;
+use de_mls::mls_crypto::MlsCredentials;
+
+use common::session_fixtures::CapturingTransport;
+use common::wallet::WalletMemberId;
+
+const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+/// The shared, conversation-agnostic state an integrator keeps once: the
+/// plug-in factory, the consensus context, the identity, and a transport.
+struct Integrator {
+    plugins: DefaultConversationPluginsFactory,
+    consensus: ConsensusContext<DefaultConsensusPlugin>,
+    member_id: WalletMemberId,
+    transport: SharedDeliveryService,
+}
+
+impl Integrator {
+    fn new() -> Self {
+        let signer = PrivateKeySigner::from_str(ALICE).expect("valid private key");
+        let member_id = WalletMemberId::from_address(signer.address());
+        let credentials =
+            Arc::new(MlsCredentials::from_member_id(&member_id).expect("credentials"));
+        let storage = Arc::new(MemoryDeMlsStorage::new());
+        let plugins = DefaultConversationPluginsFactory::new(storage, credentials);
+        let consensus =
+            ConsensusContext::<DefaultConsensusPlugin>::new(EthereumConsensusSigner::new(signer));
+        let transport: SharedDeliveryService = CapturingTransport::new();
+        Self {
+            plugins,
+            consensus,
+            member_id,
+            transport,
+        }
+    }
+
+    /// Fresh per-conversation deps drawn from the shared state.
+    fn deps(
+        &self,
+    ) -> ConversationDeps<'_, DefaultConsensusPlugin, DefaultConversationPluginsFactory> {
+        ConversationDeps {
+            plugins: &self.plugins,
+            consensus: &self.consensus,
+            identity: &self.member_id,
+            transport: Arc::clone(&self.transport),
+            app_id: Arc::from(&[0u8; 16][..]),
+            config: de_mls::app::ConversationConfig::default(),
+            scoring_config: ScoringConfig::default(),
+            steward_list_config: StewardListConfig::default(),
+        }
+    }
+}
+
+#[test]
+fn create_builds_a_working_steward_session_without_user() {
+    let integrator = Integrator::new();
+    let runner = SessionRunner::create("standalone", integrator.deps()).expect("create");
+
+    assert_eq!(runner.get_conversation_state(), ConversationState::Working);
+    assert!(
+        runner.is_steward_for_self(),
+        "creator is the sole steward at epoch 0"
+    );
+    let (epoch, _retry) = runner.get_epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 0);
+
+    // The opening phase is buffered for whoever drains the session.
+    let events = runner.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::PhaseChange(ConversationState::Working))),
+        "create buffers an opening Working PhaseChange"
+    );
+}
+
+#[test]
+fn join_builds_a_pending_join_session_without_user() {
+    let integrator = Integrator::new();
+    let runner = SessionRunner::join("standalone", integrator.deps()).expect("join");
+
+    assert_eq!(
+        runner.get_conversation_state(),
+        ConversationState::PendingJoin
+    );
+    assert!(
+        !runner.is_steward_for_self(),
+        "a pending joiner holds no steward list yet"
+    );
+}


### PR DESCRIPTION
Extracts conversation construction out of `User` so a conversation can be built straight from a dependency bundle, with no `User` in the picture — the first step toward de-mls exposing a standalone per-conversation handle.

`ConversationDeps<'a, P, CP>` gathers everything one conversation needs: the shared plug-in factory and consensus context (borrowed — one set serves every conversation an integrator runs), the identity, the transport, and the per-conversation config plus scoring/steward seed configs. `SessionRunner::create(id, deps)` and `join(id, deps)` hold the construction logic that previously lived inline in `User::start_conversation`; `User` now delegates to them, and the dead `build_consensus_service` helper is gone.

`tests/standalone_construction.rs` builds and queries a runner with no `User`, proving the path. Pure refactor, no behaviour change.