### PR TITLE
refactor(session)!: rename SessionRunner to Conversation

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -7,15 +7,15 @@ use crate::user::{Inbound, UserError};
 use de_mls_ui_protocol::v1::{AppEvent, MemberInfo, encode_hex, format_conversation_request};
 use futures::channel::mpsc::UnboundedSender;
 
-use crate::{CoreCtx, Gateway, SessionRef, UserRef};
+use crate::{ConversationRef, CoreCtx, Gateway, UserRef};
 
-/// Look up a per-conversation session from the `User` registry. Returns
+/// Look up a conversation entry in the `User` registry. Returns
 /// `Err(ConversationNotFound)` when the conversation has been removed.
 /// Centralized so every call site uses the same lookup + error shape.
-pub(crate) async fn lookup_session(
+pub(crate) async fn lookup_conversation(
     user: &UserRef,
     conversation_id: &str,
-) -> Result<SessionRef, UserError> {
+) -> Result<ConversationRef, UserError> {
     user.read()
         .await
         .lookup_entry(conversation_id)?
@@ -38,14 +38,14 @@ pub(crate) async fn load_member_info(
     user: &UserRef,
     conversation_id: &str,
 ) -> anyhow::Result<Vec<MemberInfo>> {
-    let session = lookup_session(user, conversation_id).await?;
-    let runner = session
+    let entry = lookup_conversation(user, conversation_id).await?;
+    let conversation = entry
         .read()
-        .map_err(|_| UserError::LockPoisoned("session"))?;
-    let member_bytes = runner.members()?;
-    let scores = runner.member_scores();
-    let roles = runner.member_roles().unwrap_or_default();
-    let pending_leavers = runner.pending_leave_member_ids().unwrap_or_default();
+        .map_err(|_| UserError::LockPoisoned("conversation"))?;
+    let member_bytes = conversation.members()?;
+    let scores = conversation.member_scores();
+    let roles = conversation.member_roles().unwrap_or_default();
+    let pending_leavers = conversation.pending_leave_member_ids().unwrap_or_default();
 
     Ok(member_bytes
         .into_iter()
@@ -77,26 +77,26 @@ pub(crate) async fn push_consensus_state(
     evt_tx: &UnboundedSender<AppEvent>,
     conversation_id: &str,
 ) {
-    let Ok(session) = lookup_session(user, conversation_id).await else {
+    let Ok(entry) = lookup_conversation(user, conversation_id).await else {
         return;
     };
-    let runner = match session.read() {
+    let conversation = match entry.read() {
         Ok(s) => s,
         Err(_) => {
             tracing::warn!(
                 conversation = %conversation_id,
-                "push_consensus_state skipped: session lock poisoned"
+                "push_consensus_state skipped: conversation lock poisoned"
             );
             return;
         }
     };
-    let proposals = runner.approved_proposals_for_current_epoch();
+    let proposals = conversation.approved_proposals_for_current_epoch();
     let _ = evt_tx.unbounded_send(AppEvent::CurrentEpochProposals {
         conversation_id: conversation_id.to_string(),
         proposals: display_batch(&proposals),
     });
 
-    if let Ok((epoch, retry_round)) = runner.epoch_and_retry() {
+    if let Ok((epoch, retry_round)) = conversation.epoch_and_retry() {
         let _ = evt_tx.unbounded_send(AppEvent::GroupEpoch {
             conversation_id: conversation_id.to_string(),
             epoch,
@@ -122,15 +122,15 @@ pub(crate) async fn push_member_scores(
         members,
     });
 
-    let Ok(session) = lookup_session(user, conversation_id).await else {
+    let Ok(entry) = lookup_conversation(user, conversation_id).await else {
         return;
     };
-    let is_steward = match session.read() {
+    let is_steward = match entry.read() {
         Ok(s) => s.is_steward(),
         Err(_) => {
             tracing::warn!(
                 conversation = %conversation_id,
-                "is_steward read skipped: session lock poisoned"
+                "is_steward read skipped: conversation lock poisoned"
             );
             return;
         }

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -7,7 +7,7 @@ use de_mls_ui_protocol::v1::MemberInfo;
 
 use crate::{
     Gateway, UserRef,
-    forwarder::{display_batch, load_member_info, lookup_session},
+    forwarder::{display_batch, load_member_info, lookup_conversation},
     user::UserError,
 };
 
@@ -24,7 +24,7 @@ impl Gateway<WakuDeliveryService> {
         tracing::info!(group = %conversation_id, "group ready, subtopics subscribed");
 
         // Unified polling loop — stewards create commit candidates
-        // automatically inside `poll_session` when the inactivity timer fires.
+        // automatically inside `poll_conversation` when the inactivity timer fires.
         let user_clone = user_ref.clone();
         tokio::spawn(Self::group_polling_loop(user_clone, conversation_id));
         Ok(())
@@ -52,7 +52,7 @@ impl Gateway<WakuDeliveryService> {
             // Phase 1: Poll until welcome received or timed out.
             let joined = loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                let outcome = match user_clone.read().await.poll_session(&group_name_clone) {
+                let outcome = match user_clone.read().await.poll_conversation(&group_name_clone) {
                     Ok(o) => o,
                     Err(e) if e.is_fatal() => {
                         tracing::warn!(group = %group_name_clone, error = %e, "join poll exiting");
@@ -97,18 +97,18 @@ impl Gateway<WakuDeliveryService> {
     }
 
     /// Unified polling loop for any group member (creator or joiner). All
-    /// time-based session paths are driven by a single `poll_session` call.
+    /// time-based conversation paths are driven by a single `poll_conversation` call.
     async fn group_polling_loop(user: UserRef, conversation_id: String) {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            let outcome = match user.read().await.poll_session(&conversation_id) {
+            let outcome = match user.read().await.poll_conversation(&conversation_id) {
                 Ok(o) => o,
                 Err(e) if e.is_fatal() => {
                     tracing::warn!(group = %conversation_id, error = %e, "polling loop exiting");
                     break;
                 }
                 Err(e) => {
-                    tracing::warn!(group = %conversation_id, error = %e, "poll_session error");
+                    tracing::warn!(group = %conversation_id, error = %e, "poll_conversation error");
                     continue;
                 }
             };
@@ -127,10 +127,10 @@ impl Gateway<WakuDeliveryService> {
         message: String,
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
-        session
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
+        entry
             .write()
-            .map_err(|_| UserError::LockPoisoned("session"))?
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
             .send_message(message.into_bytes())?;
         tracing::debug!(group = %conversation_id, "app message sent");
         Ok(())
@@ -142,14 +142,14 @@ impl Gateway<WakuDeliveryService> {
         user_to_ban: String,
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
 
         let target = Address::from_str(user_to_ban.trim())
             .map_err(|e| anyhow::anyhow!("invalid ban target address {user_to_ban:?}: {e}"))?;
 
-        session
+        entry
             .write()
-            .map_err(|_| UserError::LockPoisoned("session"))?
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
             .remove_member(target.as_slice())?;
 
         Ok(())
@@ -162,10 +162,10 @@ impl Gateway<WakuDeliveryService> {
         vote: bool,
     ) -> anyhow::Result<()> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
-        session
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
+        entry
             .write()
-            .map_err(|_| UserError::LockPoisoned("session"))?
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
             .vote(proposal_id, vote)?;
         Ok(())
     }
@@ -192,21 +192,21 @@ impl Gateway<WakuDeliveryService> {
 
     pub async fn get_steward_status(&self, conversation_id: String) -> anyhow::Result<bool> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
-        let is_steward = session
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
+        let is_steward = entry
             .read()
-            .map_err(|_| UserError::LockPoisoned("session"))?
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
             .is_steward();
         Ok(is_steward)
     }
 
     pub async fn get_group_state(&self, conversation_id: String) -> anyhow::Result<String> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
-        let state = session
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
+        let state = entry
             .read()
-            .map_err(|_| UserError::LockPoisoned("session"))?
-            .conversation_state();
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
+            .state();
         Ok(state.to_string())
     }
 
@@ -216,10 +216,10 @@ impl Gateway<WakuDeliveryService> {
         conversation_id: String,
     ) -> anyhow::Result<Vec<(String, String)>> {
         let user_ref = self.user()?;
-        let session = lookup_session(&user_ref, &conversation_id).await?;
-        let proposals = session
+        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
+        let proposals = entry
             .read()
-            .map_err(|_| UserError::LockPoisoned("session"))?
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
             .approved_proposals_for_current_epoch();
         Ok(display_batch(&proposals))
     }

--- a/crates/de_mls_gateway/src/handler.rs
+++ b/crates/de_mls_gateway/src/handler.rs
@@ -1,9 +1,9 @@
-//! Gateway-side fan-out from per-session [`SessionEvent`]s to the UI event pipe.
+//! Gateway-side fan-out from per-conversation [`ConversationEvent`]s to the UI event pipe.
 //!
 //! [`crate::Gateway`] runs one polling task per logged-in user. Each tick
 //! drains [`crate::user::User::drain_lifecycle_events`] for `Created` /
-//! `Removed`, then drains [`de_mls::session::SessionRunner::drain_events`] on
-//! every active session and dispatches the [`SessionEvent`]s to `AppEvent`
+//! `Removed`, then drains [`de_mls::session::Conversation::drain_events`] on
+//! every active conversation and dispatches the [`ConversationEvent`]s to `AppEvent`
 //! variants on the UI pipe — also maintaining the per-group
 //! `epoch_history` cache used by the History tab.
 
@@ -16,7 +16,7 @@ use futures::channel::mpsc::UnboundedSender;
 use prost::Message;
 
 use de_mls::{
-    core::SessionEvent,
+    core::ConversationEvent,
     protos::de_mls::messages::v1::{AppMessage, ConversationMessage, VotePayload, app_message},
 };
 use de_mls_ds::{OutboundPacket, SharedDeliveryService, TopicFilter, WELCOME_SUBTOPIC};
@@ -29,13 +29,13 @@ use crate::{
     welcome_envelope,
 };
 
-/// Fan-out target for [`SessionEvent`]s on a single conversation. Held as
-/// `Arc` because the spawned per-session subscriber task owns a clone.
-pub(crate) struct GatewaySessionFanout {
+/// Fan-out target for [`ConversationEvent`]s on a single conversation. Held as
+/// `Arc` because the spawned per-conversation subscriber task owns a clone.
+pub(crate) struct GatewayEventFanout {
     pub evt_tx: UnboundedSender<AppEvent>,
     pub topics: Arc<TopicFilter>,
     pub epoch_history: EpochHistoryStore,
-    /// Shared transport handle. The [`SessionEvent::WelcomeReady`] arm
+    /// Shared transport handle. The [`ConversationEvent::WelcomeReady`] arm
     /// uses it to publish the envelope-wrapped welcome on
     /// [`WELCOME_SUBTOPIC`].
     pub transport: SharedDeliveryService,
@@ -47,14 +47,14 @@ pub(crate) struct GatewaySessionFanout {
     pub user: UserRef,
 }
 
-impl GatewaySessionFanout {
-    /// Dispatch one [`SessionEvent`] to the UI pipe + side caches.
-    pub(crate) async fn handle(&self, conversation_id: &str, event: SessionEvent) {
+impl GatewayEventFanout {
+    /// Dispatch one [`ConversationEvent`] to the UI pipe + side caches.
+    pub(crate) async fn handle(&self, conversation_id: &str, event: ConversationEvent) {
         match event {
-            SessionEvent::AppMessage(message) => {
+            ConversationEvent::AppMessage(message) => {
                 let _ = forward_app_message(&self.evt_tx, message);
             }
-            SessionEvent::Leaving => {
+            ConversationEvent::Leaving => {
                 if let Err(e) = self.topics.remove_many(conversation_id) {
                     tracing::warn!(error = %e, "topic filter remove failed");
                 }
@@ -71,12 +71,12 @@ impl GatewaySessionFanout {
                         conversation_id: conversation_id.to_string(),
                     }));
             }
-            SessionEvent::Error { operation, message } => {
+            ConversationEvent::Error { operation, message } => {
                 let _ = self.evt_tx.unbounded_send(AppEvent::Error(format!(
                     "{operation} failed for group {conversation_id}: {message}"
                 )));
             }
-            SessionEvent::OwnProposalSubmitted {
+            ConversationEvent::OwnProposalSubmitted {
                 proposal_id,
                 request,
             } => {
@@ -88,7 +88,7 @@ impl GatewaySessionFanout {
                     address,
                 });
             }
-            SessionEvent::VoteRequested {
+            ConversationEvent::VoteRequested {
                 proposal_id,
                 request,
             } => {
@@ -111,13 +111,13 @@ impl GatewaySessionFanout {
                         conversation_id: conversation_id.to_string(),
                     });
             }
-            SessionEvent::PhaseChange(state) => {
+            ConversationEvent::PhaseChange(state) => {
                 let _ = self.evt_tx.unbounded_send(AppEvent::GroupStateChanged {
                     conversation_id: conversation_id.to_string(),
                     state: state.to_string(),
                 });
             }
-            SessionEvent::CommitApplied(batch) => {
+            ConversationEvent::CommitApplied(batch) => {
                 if batch.is_empty() {
                     return;
                 }
@@ -135,7 +135,7 @@ impl GatewaySessionFanout {
                     epochs: formatted,
                 });
             }
-            SessionEvent::ConsensusReached {
+            ConversationEvent::ConsensusReached {
                 proposal_id,
                 approved,
                 timestamp,
@@ -159,14 +159,14 @@ impl GatewaySessionFanout {
                 push_consensus_state(&self.user, &self.evt_tx, conversation_id).await;
                 push_member_scores(&self.user, &self.evt_tx, conversation_id).await;
             }
-            SessionEvent::FreezeProgress { received, expected } => {
+            ConversationEvent::FreezeProgress { received, expected } => {
                 let _ = self.evt_tx.unbounded_send(AppEvent::FreezeCandidates {
                     conversation_id: conversation_id.to_string(),
                     received,
                     expected,
                 });
             }
-            SessionEvent::WelcomeReady(welcome) => {
+            ConversationEvent::WelcomeReady(welcome) => {
                 let bytes = welcome.welcome_bytes.len();
                 let sync_bytes = welcome.conversation_sync_bytes.len();
                 let packet = OutboundPacket::new(
@@ -219,7 +219,7 @@ pub fn forward_app_message(
         // Other variants (BanRequest, KeyPackage, Proposal, Vote, CommitCandidate,
         // ConversationSync, ProposalAdded, UserVote) are protocol-internal —
         // not surfaced to the UI as chat-style messages. Vote requests arrive
-        // as a dedicated `SessionEvent::VoteRequested`, not as an AppMessage.
+        // as a dedicated `ConversationEvent::VoteRequested`, not as an AppMessage.
         Some(_) => Ok(()),
         None => Err(anyhow::anyhow!("AppMessage payload missing")),
     }

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -34,7 +34,7 @@ use de_mls::{
 use de_mls_ds::{DeliveryService, SharedDeliveryService, WakuDeliveryService};
 use de_mls_ui_protocol::v1::{AppCmd, AppEvent};
 
-use crate::user::{ConsensusContext, SessionEntry, User, UserPlugins};
+use crate::user::{ConsensusContext, ConversationEntry, User, UserPlugins};
 use futures::{
     StreamExt,
     channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded},
@@ -43,7 +43,7 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use tokio::sync::Mutex;
 
-use crate::handler::GatewaySessionFanout;
+use crate::handler::GatewayEventFanout;
 
 pub use crate::bootstrap::{
     AppState, Bootstrap, BootstrapConfig, BootstrapError, CoreCtx, bootstrap_core,
@@ -59,10 +59,10 @@ pub use crate::bootstrap::{
 pub(crate) type UserRef =
     Arc<tokio::sync::RwLock<User<DefaultConsensusPlugin, DefaultConversationPluginsFactory>>>;
 
-/// Type alias for a per-conversation session reference obtained via
+/// Type alias for a conversation registry entry obtained via
 /// `User::lookup_entry`. Re-exports the sync-locked entry from `de_mls::session`.
-pub(crate) type SessionRef =
-    SessionEntry<DefaultConsensusPlugin, DefaultConversationPluginsFactory>;
+pub(crate) type ConversationRef =
+    ConversationEntry<DefaultConsensusPlugin, DefaultConversationPluginsFactory>;
 
 // Global, process-wide gateway instance
 pub static GATEWAY: Lazy<Gateway<WakuDeliveryService>> = Lazy::new(Gateway::new);
@@ -76,7 +76,7 @@ pub fn init_core(core: Arc<CoreCtx<WakuDeliveryService>>) {
 pub(crate) const MAX_EPOCH_HISTORY: usize = 10;
 
 /// Per-group rolling history of committed batches, populated by
-/// `on_commit_applied` and consumed by the History tab via
+/// the gateway's event fanout on `CommitApplied` and consumed by the History tab via
 /// `Gateway::get_epoch_history`. Cap is [`MAX_EPOCH_HISTORY`].
 pub(crate) type EpochHistoryStore =
     Arc<parking_lot::Mutex<HashMap<String, VecDeque<Vec<ConversationUpdateRequest>>>>>;
@@ -99,7 +99,7 @@ pub struct Gateway<DS: DeliveryService> {
     started: AtomicBool,
 
     // Per-group committed-batch history (UI cache). Shared by Arc with the
-    // gateway's ConversationEventHandler so `on_commit_applied` can append.
+    // gateway's event fanout so a `CommitApplied` event can append.
     epoch_history: EpochHistoryStore,
 }
 
@@ -244,10 +244,10 @@ impl Gateway<WakuDeliveryService> {
 
         // Per-conversation subscribers: one task watches the User's
         // lifecycle channel; on each `Created(name)`, spawn a task that
-        // subscribes to the new session's `SessionEvent` stream and
+        // subscribes to the new conversation's `ConversationEvent` stream and
         // forwards to the UI pipe; the consensus event forwarder is
         // spawned on the same trigger.
-        self.spawn_session_subscribers(user_ref.clone(), transport_for_subscribers);
+        self.spawn_conversation_subscribers(user_ref.clone(), transport_for_subscribers);
 
         self.spawn_delivery_service_forwarder(core.clone(), user_ref.clone());
         Ok(user_address)
@@ -255,30 +255,30 @@ impl Gateway<WakuDeliveryService> {
 
     /// Spawn the gateway's UI event pump. Once per polling cycle it
     /// drains [`crate::user::User::drain_lifecycle_events`] (to learn
-    /// when new sessions appear or disappear) and
-    /// [`de_mls::session::SessionRunner::drain_events`] on every active
-    /// session (to forward UI-bound events). Replaces the previous
+    /// when new conversations appear or disappear) and
+    /// [`de_mls::session::Conversation::drain_events`] on every active
+    /// conversation (to forward UI-bound events). Replaces the previous
     /// broadcast-channel subscriber pattern.
-    fn spawn_session_subscribers(&self, user: UserRef, transport: SharedDeliveryService) {
+    fn spawn_conversation_subscribers(&self, user: UserRef, transport: SharedDeliveryService) {
         let evt_tx = self.evt_tx.clone();
         let topics = self.core().topics.clone();
         let epoch_history = self.epoch_history.clone();
         let user_for_loop = user.clone();
 
         tokio::spawn(async move {
-            let mut active_sessions: HashMap<String, Arc<GatewaySessionFanout>> = HashMap::new();
+            let mut active_fanouts: HashMap<String, Arc<GatewayEventFanout>> = HashMap::new();
             loop {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
                 // Drain user-level lifecycle events first so newly-created
-                // sessions get their fanout registered before we look for
+                // conversations get their fanout registered before we look for
                 // events on them.
                 let lifecycle = user_for_loop.read().await.drain_lifecycle_events();
                 let app_id_snapshot = user_for_loop.read().await.app_id().to_vec();
                 for event in lifecycle {
                     match event {
                         crate::user::ConversationLifecycle::Created(name) => {
-                            let fanout = Arc::new(GatewaySessionFanout {
+                            let fanout = Arc::new(GatewayEventFanout {
                                 evt_tx: evt_tx.clone(),
                                 topics: topics.clone(),
                                 epoch_history: epoch_history.clone(),
@@ -286,26 +286,26 @@ impl Gateway<WakuDeliveryService> {
                                 app_id: app_id_snapshot.clone(),
                                 user: user_for_loop.clone(),
                             });
-                            active_sessions.insert(name, fanout);
+                            active_fanouts.insert(name, fanout);
                         }
                         crate::user::ConversationLifecycle::Removed(name) => {
-                            active_sessions.remove(&name);
+                            active_fanouts.remove(&name);
                         }
                     }
                 }
 
-                // Drain each active session's pending events.
-                for (name, fanout) in &active_sessions {
-                    let session = match user_for_loop.read().await.lookup_entry(name) {
+                // Drain each active conversation's pending events.
+                for (name, fanout) in &active_fanouts {
+                    let entry = match user_for_loop.read().await.lookup_entry(name) {
                         Ok(Some(s)) => s,
                         _ => continue,
                     };
-                    let events = match session.read() {
+                    let events = match entry.read() {
                         Ok(g) => g.drain_events(),
                         Err(_) => {
                             tracing::warn!(
                                 conversation = %name,
-                                "session drain skipped: lock poisoned"
+                                "conversation drain skipped: lock poisoned"
                             );
                             continue;
                         }
@@ -314,12 +314,12 @@ impl Gateway<WakuDeliveryService> {
                         fanout.handle(name, event).await;
                     }
 
-                    // Publish any outbound the session buffered. The session is
+                    // Publish any outbound the conversation buffered. The conversation is
                     // pull-only — it never sends. `User`-driven ops already
                     // flushed their own outbound; this catches packets produced
-                    // by direct session calls in the polling / handler paths
+                    // by direct conversation calls in the polling / handler paths
                     // (commit candidates, auto-votes, …).
-                    let outbound = match session.read() {
+                    let outbound = match entry.read() {
                         Ok(g) => g.drain_outbound(),
                         Err(_) => Vec::new(),
                     };

--- a/crates/de_mls_gateway/src/user/error.rs
+++ b/crates/de_mls_gateway/src/user/error.rs
@@ -1,11 +1,11 @@
 //! Error type for the `User` registry layer.
 //!
-//! Session-level failures come from the library as
-//! [`SessionError`] and are wrapped; everything else here is
+//! Conversation-level failures come from the library as
+//! [`ConversationError`] and are wrapped; everything else here is
 //! registry-side: conversation lookup, lock poisoning, and transport
 //! delivery.
 
-use de_mls::session::SessionError;
+use de_mls::session::ConversationError;
 
 /// Errors from `User` operations.
 #[derive(Debug, thiserror::Error)]
@@ -26,7 +26,7 @@ pub enum UserError {
     LockPoisoned(&'static str),
 
     #[error(transparent)]
-    Session(#[from] SessionError),
+    Conversation(#[from] ConversationError),
 }
 
 impl UserError {
@@ -37,12 +37,12 @@ impl UserError {
         match self {
             // The conversation is no longer in the registry — stop polling.
             UserError::ConversationNotFound => true,
-            // Lock poisoning means the session is corrupted — no recovery.
+            // Lock poisoning means the conversation is corrupted — no recovery.
             UserError::LockPoisoned(_) => true,
             UserError::ConversationAlreadyExists
             | UserError::WelcomeNotForUs
             | UserError::Transport(_)
-            | UserError::Session(_) => false,
+            | UserError::Conversation(_) => false,
         }
     }
 }

--- a/crates/de_mls_gateway/src/user/inbound.rs
+++ b/crates/de_mls_gateway/src/user/inbound.rs
@@ -4,7 +4,7 @@
 //! channels here. Conversation traffic (chat / vote / commit / sync — the
 //! envelope self-identifies) goes to [`User::handle_inbound`]; a joiner's
 //! key-package announcement goes to [`User::receive_key_package`]. Both
-//! delegate dedup and dispatch decisions to the runner. Raw MLS welcomes
+//! delegate dedup and dispatch decisions to the conversation. Raw MLS welcomes
 //! enter through [`User::accept_welcome`].
 
 use de_mls::{
@@ -32,8 +32,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Ingest conversation traffic (chat / vote / commit / sync). Self-echoes
     /// are dropped before the registry lookup — our own packets can still
     /// arrive for a conversation we just left, and must not surface as
-    /// `ConversationNotFound`. The runner dedups again for direct integrators.
-    /// On `LeaveRequested` the session has completed its protocol-side
+    /// `ConversationNotFound`. The conversation dedups again for direct integrators.
+    /// On `LeaveRequested` the conversation has completed its protocol-side
     /// teardown; this method finalises the User-side registry cleanup.
     pub fn handle_inbound(&self, inbound: Inbound) -> Result<(), UserError> {
         if inbound.sender == self.app_id {
@@ -43,7 +43,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(&inbound.conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
         let outcome = entry_arc
-            .write_or_err("session")?
+            .write_or_err("conversation")?
             .process_inbound(&inbound.sender, &inbound.payload)?;
         if matches!(outcome, DispatchOutcome::LeaveRequested) {
             self.finalize_self_leave(&inbound.conversation_id)?;
@@ -54,7 +54,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
     /// Ingest a joiner's key-package announcement. Self-echoes are dropped
     /// before the registry lookup (same rationale as [`Self::handle_inbound`]);
-    /// admission decisions are handled inside the runner.
+    /// admission decisions are handled inside the conversation.
     pub fn receive_key_package(&self, inbound: Inbound) -> Result<(), UserError> {
         if inbound.sender == self.app_id {
             return Ok(());
@@ -63,7 +63,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(&inbound.conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
         entry_arc
-            .write_or_err("session")?
+            .write_or_err("conversation")?
             .receive_key_package(&inbound.sender, &inbound.payload)?;
         self.flush(&entry_arc)?;
         Ok(())
@@ -71,11 +71,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
     /// User-side completion of `LeaveConversation`: drop the entry from
     /// the registry, clean up the consensus scope, and broadcast removal.
-    /// The session-side teardown (emit `Leaving`, cancel timers, delete MLS
-    /// state) runs inside the runner before this is called; this method is
-    /// the cleanup callers run when the runner signals it has finished.
+    /// The conversation-side teardown (emit `Leaving`, cancel timers, delete MLS
+    /// state) runs inside the conversation before this is called; this method is
+    /// the cleanup callers run when the conversation signals it has finished.
     pub fn finalize_self_leave(&self, conversation_id: &str) -> Result<(), UserError> {
-        // Scope cleanup before registry remove — the cleanup finds the runner
+        // Scope cleanup before registry remove — the cleanup finds the conversation
         // via lookup_entry, so the entry must still exist. Eviction and
         // `Removed` are unconditional: a scope-delete failure must not strand
         // a zombie.

--- a/crates/de_mls_gateway/src/user/lifecycle.rs
+++ b/crates/de_mls_gateway/src/user/lifecycle.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use de_mls::{
     core::{ConsensusPlugin, ConversationConfig, ConversationPluginsFactory},
-    session::{ConversationDeps, LeaveOutcome, SessionRunner},
+    session::{Conversation, ConversationDeps, LeaveOutcome},
 };
 
 use crate::user::{ConversationLifecycle, LockExt, User, UserError};
@@ -49,12 +49,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             scoring_config: self.plugins.default_scoring_config.clone(),
             steward_list_config: self.plugins.default_steward_list_config.clone(),
         };
-        let runner = if is_creation {
-            SessionRunner::create(conversation_id, deps)?
+        let conversation = if is_creation {
+            Conversation::create(conversation_id, deps)?
         } else {
-            SessionRunner::join(conversation_id, deps)?
+            Conversation::join(conversation_id, deps)?
         };
-        let session = Arc::new(RwLock::new(runner));
+        let entry = Arc::new(RwLock::new(conversation));
         {
             let mut conversations = self
                 .conversations
@@ -63,19 +63,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             if conversations.contains_key(conversation_id) {
                 return Err(UserError::ConversationAlreadyExists);
             }
-            conversations.insert(conversation_id.to_string(), session);
+            conversations.insert(conversation_id.to_string(), entry);
         }
 
-        // The runner already buffered its opening `PhaseChange`; record the
+        // The conversation already buffered its opening `PhaseChange`; record the
         // lifecycle event so integrators draining
-        // [`User::drain_lifecycle_events`] discover the session.
+        // [`User::drain_lifecycle_events`] discover the conversation.
         self.emit_lifecycle(ConversationLifecycle::Created(conversation_id.to_string()));
 
         Ok(())
     }
 
-    /// Leave the conversation. Delegates to [`SessionRunner::leave`]: in
-    /// `PendingJoin` the runner tears down locally and returns `TornDown`;
+    /// Leave the conversation. Delegates to [`Conversation::leave`]: in
+    /// `PendingJoin` the conversation tears down locally and returns `TornDown`;
     /// otherwise it opens a self-leave consensus round and returns
     /// `LeaveInitiated`. On `TornDown` this method finalises the User-side
     /// registry cleanup via `finalize_self_leave`.
@@ -86,7 +86,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
 
-        let outcome = entry_arc.write_or_err("session")?.leave()?;
+        let outcome = entry_arc.write_or_err("conversation")?.leave()?;
         match outcome {
             LeaveOutcome::TornDown => {
                 self.finalize_self_leave(conversation_id)?;

--- a/crates/de_mls_gateway/src/user/lock.rs
+++ b/crates/de_mls_gateway/src/user/lock.rs
@@ -1,6 +1,6 @@
 //! Ergonomic lock acquisition that propagates poisoning as `UserError`.
 //!
-//! `SessionRunner`'s per-conversation lock is `std::sync::RwLock`, which
+//! `Conversation`'s per-conversation lock is `std::sync::RwLock`, which
 //! marks itself poisoned if a holder panics. We never want to swallow that
 //! with `.expect(...)`; the helpers below convert poison errors into
 //! [`UserError::LockPoisoned`] so callers can return them upstream.

--- a/crates/de_mls_gateway/src/user/mod.rs
+++ b/crates/de_mls_gateway/src/user/mod.rs
@@ -1,7 +1,7 @@
 //! [`User`] — multi-conversation facade over the de-mls library. One node
 //! owns one `User`, which holds the per-conversation registry, the plugin
 //! bundle, and the outbound transport. Per-conv protocol work lives on each
-//! [`de_mls::session::SessionRunner`]; callers reach a session via
+//! [`de_mls::session::Conversation`]; callers reach a session via
 //! [`User::lookup_entry`].
 //!
 //! This is the reference integrator — the registry + routing + lifecycle
@@ -17,7 +17,7 @@
 //! - `inbound` — `handle_inbound` / `receive_key_package` entry points,
 //!   `finalize_self_leave` (registry-side completion of `LeaveConversation`).
 //! - `error` — [`UserError`], the registry-level error wrapping the
-//!   library's `SessionError`.
+//!   library's `ConversationError`.
 //! - `consensus` — [`ConsensusContext`], the shared consensus storage +
 //!   signer that mints each conversation's service.
 //! - `plugins` — `UserPlugins<P, CP>` bundle.
@@ -36,4 +36,4 @@ pub use error::UserError;
 pub use inbound::Inbound;
 pub(crate) use lock::LockExt;
 pub use plugins::UserPlugins;
-pub use state::{ConversationLifecycle, SessionEntry, User};
+pub use state::{ConversationEntry, ConversationLifecycle, User};

--- a/crates/de_mls_gateway/src/user/plugins.rs
+++ b/crates/de_mls_gateway/src/user/plugins.rs
@@ -2,7 +2,7 @@
 //!
 //! [`UserPlugins`] holds all User-level plugin state: the per-conversation
 //! factory, the [`ConsensusContext`], and the three default configs cloned
-//! into new sessions. Grouping these here keeps the `User` definition
+//! into new conversations. Grouping these here keeps the `User` definition
 //! surfacing registry + transport at top level.
 
 use de_mls::core::{
@@ -21,7 +21,7 @@ pub struct UserPlugins<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     /// Consensus-plugin state. Owns the shared storage + signer
     /// and mints per-conv services on demand.
     pub consensus: ConsensusContext<P>,
-    /// Seed config copied into newly-created `SessionRunner`s.
+    /// Seed config copied into newly-created `Conversation`s.
     pub default_conversation_config: ConversationConfig,
     /// Seed config for the per-conversation peer-scoring plug-in.
     pub default_scoring_config: ScoringConfig,

--- a/crates/de_mls_gateway/src/user/registry.rs
+++ b/crates/de_mls_gateway/src/user/registry.rs
@@ -1,18 +1,18 @@
-//! Registry CRUD on the `User` side: per-conversation session lookup.
+//! Registry CRUD on the `User` side: conversation lookup.
 
 use de_mls::core::{ConsensusPlugin, ConversationPluginsFactory};
 
-use crate::user::{SessionEntry, User, UserError};
+use crate::user::{ConversationEntry, User, UserError};
 
 impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
-    /// Look up a conversation runner. Returns `Ok(None)` when no runner is
+    /// Look up a conversation. Returns `Ok(None)` when no entry is
     /// registered for `conversation_id`. Takes the outer read lock briefly
     /// to clone the inner `Arc`, then releases it before the caller
-    /// acquires the runner's own lock.
+    /// acquires the conversation's own lock.
     pub fn lookup_entry(
         &self,
         conversation_id: &str,
-    ) -> Result<Option<SessionEntry<P, CP>>, UserError> {
+    ) -> Result<Option<ConversationEntry<P, CP>>, UserError> {
         Ok(self
             .conversations
             .read()

--- a/crates/de_mls_gateway/src/user/state.rs
+++ b/crates/de_mls_gateway/src/user/state.rs
@@ -10,13 +10,14 @@ use std::{
 
 use de_mls::{
     core::{
-        ConsensusPlugin, ConversationPluginsFactory, ScoringConfig, SessionEvent, StewardListConfig,
+        ConsensusPlugin, ConversationEvent, ConversationPluginsFactory, ScoringConfig,
+        StewardListConfig,
     },
     member_id::MemberId,
     mls_crypto::{KeyPackageBytes, MlsError, MlsService},
     protos::de_mls::messages::v1::ConversationUpdateRequest,
     session::{
-        ConversationState, CreatorVote, MemberRole, PollOutcome, SessionError, SessionRunner,
+        Conversation, ConversationError, ConversationState, CreatorVote, MemberRole, PollOutcome,
     },
 };
 use de_mls_ds::{OutboundPacket, SharedDeliveryService};
@@ -27,42 +28,42 @@ use crate::user::{LockExt, UserError, UserPlugins};
 /// removed. Drain via [`User::drain_lifecycle_events`] once per polling cycle.
 #[derive(Debug, Clone)]
 pub enum ConversationLifecycle {
-    /// A new entry has been registered. The session is in the registry;
+    /// A new entry has been registered. The conversation is in the registry;
     /// the integrator can look it up and begin draining its events.
     Created(String),
     /// An entry has been removed from the registry.
     Removed(String),
 }
 
-/// Single registry entry: one `Arc<RwLock<SessionRunner>>` per conversation.
+/// Single registry entry: one `Arc<RwLock<Conversation>>` per conversation.
 /// Cloned out of the registry under the outer read lock, then locked
 /// independently — writes on one conversation don't block reads on another.
-pub type SessionEntry<P, CP> = Arc<RwLock<SessionRunner<P, CP>>>;
+pub type ConversationEntry<P, CP> = Arc<RwLock<Conversation<P, CP>>>;
 
-/// Per-user registry of conversation runners. Each entry's inner per-runner
+/// Per-user registry of conversations. Each entry's inner per-conversation
 /// lock guards per-conversation reads/mutations so a write on conversation
 /// A doesn't block reads on conversation B.
-pub(crate) type ConversationRegistry<P, CP> = RwLock<HashMap<String, SessionEntry<P, CP>>>;
+pub(crate) type ConversationRegistry<P, CP> = RwLock<HashMap<String, ConversationEntry<P, CP>>>;
 
 pub struct User<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     pub(crate) member_id: Box<dyn MemberId>,
     /// Per-instance UUID embedded in every outbound packet. Inbound packets
     /// carrying our `app_id` are self-echoes and silently dropped.
     pub(crate) app_id: Vec<u8>,
-    /// Synchronous outbound transport. The sessions are pull-only and never
-    /// send; [`Self::flush`] drains a session's buffered outbound and
+    /// Synchronous outbound transport. The conversations are pull-only and never
+    /// send; [`Self::flush`] drains a conversation's buffered outbound and
     /// publishes it here. Behind a `Mutex` because the trait takes `&mut self`.
     pub(crate) transport: SharedDeliveryService,
     /// All User-level plugin state: the per-conversation factory, the
     /// consensus context, the key-package provider, and the three default
-    /// configs cloned into newly-created sessions.
+    /// configs cloned into newly-created conversations.
     pub(crate) plugins: UserPlugins<P, CP>,
-    /// Per-conversation `SessionRunner`s.
+    /// Conversation handles keyed by conversation id.
     pub(crate) conversations: ConversationRegistry<P, CP>,
     /// User-level conversation lifecycle events: `Created(name)` /
     /// `Removed(name)`. Integrators drain via
     /// [`Self::drain_lifecycle_events`] once per polling cycle to learn
-    /// when new sessions appear and old ones disappear. Interior `Mutex`
+    /// when new conversations appear and old ones disappear. Interior `Mutex`
     /// so producer-side methods stay `&self`.
     pub(crate) pending_lifecycle_events: Mutex<Vec<ConversationLifecycle>>,
 }
@@ -95,8 +96,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// Drain every pending [`ConversationLifecycle`] event accumulated
     /// since the last call. Returns events in insertion order. Callers
     /// (gateway, integrator) invoke this once per polling cycle to discover
-    /// `Created` / `Removed` sessions and wire up per-session event
-    /// drains via [`SessionRunner::drain_events`].
+    /// `Created` / `Removed` conversations and wire up per-conversation event
+    /// drains via [`Conversation::drain_events`].
     pub fn drain_lifecycle_events(&self) -> Vec<ConversationLifecycle> {
         match self.pending_lifecycle_events.lock() {
             Ok(mut buf) => std::mem::take(&mut *buf),
@@ -124,14 +125,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     }
 
     /// Send a chat message on `conversation_id`. Thin wrapper over
-    /// [`SessionRunner::send_message`]. Errors with
+    /// [`Conversation::send_message`]. Errors with
     /// `ConversationNotFound` if the conversation has been removed, or
-    /// `ConversationBlocked` if the session is gating chat traffic.
+    /// `ConversationBlocked` if the conversation is gating chat traffic.
     pub fn send_message(&self, conversation_id: &str, message: Vec<u8>) -> Result<(), UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("session")?.send_message(message)?;
+        entry.write_or_err("conversation")?.send_message(message)?;
         self.flush(&entry)?;
         Ok(())
     }
@@ -140,7 +141,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// propose adding us. Key-package creation is a user-level concern — the
     /// conversation knows nothing about how a key package is built — so this
     /// builds the announcement and publishes it straight to the transport,
-    /// bypassing the session entirely.
+    /// bypassing the conversation entirely.
     pub fn send_key_package(
         &self,
         conversation_id: &str,
@@ -161,39 +162,39 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// pending-join expiry. Returns [`PollOutcome`] with a wakeup hint and a
     /// `leave_requested` flag the caller uses to decide whether to finalize
     /// the leave.
-    pub fn poll_session(&self, conversation_id: &str) -> Result<PollOutcome, UserError> {
+    pub fn poll_conversation(&self, conversation_id: &str) -> Result<PollOutcome, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        let outcome = entry.write_or_err("session")?.poll();
+        let outcome = entry.write_or_err("conversation")?.poll();
         self.flush(&entry)?;
         Ok(outcome)
     }
 
-    /// Drain pending [`SessionEvent`]s for `conversation_id`. Thin
-    /// wrapper over [`SessionRunner::drain_events`].
-    pub fn drain_events(&self, conversation_id: &str) -> Result<Vec<SessionEvent>, UserError> {
+    /// Drain pending [`ConversationEvent`]s for `conversation_id`. Thin
+    /// wrapper over [`Conversation::drain_events`].
+    pub fn drain_events(&self, conversation_id: &str) -> Result<Vec<ConversationEvent>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.drain_events())
+        Ok(entry.read_or_err("conversation")?.drain_events())
     }
 
     /// Earliest pending deadline on `conversation_id` relative to now,
     /// `None` if nothing is scheduled. Mirrors
-    /// [`SessionRunner::next_wakeup_in`].
+    /// [`Conversation::next_wakeup_in`].
     pub fn next_wakeup_in(&self, conversation_id: &str) -> Result<Option<Duration>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.next_wakeup_in())
+        Ok(entry.read_or_err("conversation")?.next_wakeup_in())
     }
 
     /// Propose adding the holder of `key_package_bytes` to
     /// `conversation_id`. The local vote is bundled YES at submit. On
     /// consensus YES the epoch steward authors a commit containing the
     /// Add; the resulting welcome arrives via
-    /// [`de_mls::core::SessionEvent::WelcomeReady`] for the integrator to
+    /// [`de_mls::core::ConversationEvent::WelcomeReady`] for the integrator to
     /// deliver out of band.
     pub fn add_member(
         &self,
@@ -204,14 +205,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
         entry
-            .write_or_err("session")?
+            .write_or_err("conversation")?
             .add_member(key_package_bytes)?;
         self.flush(&entry)?;
         Ok(())
     }
 
     /// Ingest a raw MLS welcome blob delivered out of band (e.g. the
-    /// inviter's [`de_mls::core::SessionEvent::WelcomeReady`] routed
+    /// inviter's [`de_mls::core::ConversationEvent::WelcomeReady`] routed
     /// through the integrator's transport). Returns the joined
     /// conversation name, or [`UserError::WelcomeNotForUs`] if the
     /// welcome doesn't address this user's key package.
@@ -220,7 +221,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .plugins
             .conversation_plugins
             .welcome_mls(welcome_bytes)
-            .map_err(SessionError::from)?
+            .map_err(ConversationError::from)?
             .ok_or(UserError::WelcomeNotForUs)?;
         let conversation_id = svc.conversation_id().to_string();
 
@@ -231,7 +232,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(&conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
 
-        entry_arc.write_or_err("session")?.complete_join(svc)?;
+        entry_arc.write_or_err("conversation")?.complete_join(svc)?;
         self.flush(&entry_arc)?;
         Ok(conversation_id)
     }
@@ -240,7 +241,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
 
     /// Cast the local member's manual vote on `proposal_id`. Cancels any
     /// pending auto-vote so the manual choice wins. Thin wrapper over
-    /// [`SessionRunner::vote`].
+    /// [`Conversation::vote`].
     pub fn vote(
         &self,
         conversation_id: &str,
@@ -250,19 +251,23 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("session")?.vote(proposal_id, vote)?;
+        entry
+            .write_or_err("conversation")?
+            .vote(proposal_id, vote)?;
         self.flush(&entry)?;
         Ok(())
     }
 
     /// Open a `RemoveMember` consensus round targeting `member_id`. The
     /// local vote is bundled YES at submit. Thin wrapper over
-    /// [`SessionRunner::remove_member`].
+    /// [`Conversation::remove_member`].
     pub fn remove_member(&self, conversation_id: &str, member_id: &[u8]) -> Result<(), UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("session")?.remove_member(member_id)?;
+        entry
+            .write_or_err("conversation")?
+            .remove_member(member_id)?;
         self.flush(&entry)?;
         Ok(())
     }
@@ -271,7 +276,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     /// `creator_vote`. Lower-level than
     /// [`Self::add_member`] / [`Self::remove_member`]; use those
     /// for membership changes. Thin wrapper over
-    /// [`SessionRunner::initiate_proposal`].
+    /// [`Conversation::initiate_proposal`].
     pub fn initiate_proposal(
         &self,
         conversation_id: &str,
@@ -282,7 +287,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
         entry
-            .write_or_err("session")?
+            .write_or_err("conversation")?
             .initiate_proposal(request, creator_vote)?;
         self.flush(&entry)?;
         Ok(())
@@ -291,7 +296,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     // ── State queries ──────────────────────────────────────────────────
 
     /// Current state-machine value for `conversation_id`. Mirrors
-    /// [`SessionRunner::conversation_state`].
+    /// [`Conversation::state`].
     pub fn conversation_state(
         &self,
         conversation_id: &str,
@@ -299,40 +304,40 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.conversation_state())
+        Ok(entry.read_or_err("conversation")?.state())
     }
 
     /// `true` if the local user is on the current steward list for
-    /// `conversation_id`. Mirrors [`SessionRunner::is_steward`].
+    /// `conversation_id`. Mirrors [`Conversation::is_steward`].
     pub fn is_steward(&self, conversation_id: &str) -> Result<bool, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.is_steward())
+        Ok(entry.read_or_err("conversation")?.is_steward())
     }
 
     /// MLS epoch + reelection retry round for `conversation_id`. `(0, 0)`
     /// before MLS is attached. Mirrors
-    /// [`SessionRunner::epoch_and_retry`].
+    /// [`Conversation::epoch_and_retry`].
     pub fn epoch_and_retry(&self, conversation_id: &str) -> Result<(u64, u32), UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.epoch_and_retry()?)
+        Ok(entry.read_or_err("conversation")?.epoch_and_retry()?)
     }
 
     pub fn members(&self, conversation_id: &str) -> Result<Vec<Vec<u8>>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.members()?)
+        Ok(entry.read_or_err("conversation")?.members()?)
     }
 
     pub fn member_scores(&self, conversation_id: &str) -> Result<Vec<(Vec<u8>, i64)>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.member_scores())
+        Ok(entry.read_or_err("conversation")?.member_scores())
     }
 
     pub fn member_score(
@@ -343,7 +348,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.member_score(member_id))
+        Ok(entry.read_or_err("conversation")?.member_score(member_id))
     }
 
     pub fn member_roles(
@@ -353,11 +358,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.member_roles()?)
+        Ok(entry.read_or_err("conversation")?.member_roles()?)
     }
 
     /// Identities with an in-flight self-leave request. Mirrors
-    /// [`SessionRunner::pending_leave_member_ids`].
+    /// [`Conversation::pending_leave_member_ids`].
     pub fn pending_leave_member_ids(
         &self,
         conversation_id: &str,
@@ -365,20 +370,22 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.pending_leave_member_ids()?)
+        Ok(entry
+            .read_or_err("conversation")?
+            .pending_leave_member_ids()?)
     }
 
     /// Buffered pending membership-update count. Mirrors
-    /// [`SessionRunner::pending_update_count`].
+    /// [`Conversation::pending_update_count`].
     pub fn pending_update_count(&self, conversation_id: &str) -> Result<usize, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("session")?.pending_update_count())
+        Ok(entry.read_or_err("conversation")?.pending_update_count())
     }
 
     /// Approved proposals for the current epoch. Mirrors
-    /// [`SessionRunner::approved_proposals_for_current_epoch`].
+    /// [`Conversation::approved_proposals_for_current_epoch`].
     pub fn approved_proposals_for_current_epoch(
         &self,
         conversation_id: &str,
@@ -387,7 +394,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
         Ok(entry
-            .read_or_err("session")?
+            .read_or_err("conversation")?
             .approved_proposals_for_current_epoch())
     }
 }
@@ -412,13 +419,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         }
     }
 
-    /// Publish a session's buffered outbound on the User's transport. The
-    /// session is pull-only — it buffers packets and never sends; this is the
+    /// Publish a conversation's buffered outbound on the User's transport. The
+    /// conversation is pull-only — it buffers packets and never sends; this is the
     /// User's push-adapter so its callers keep their send-on-op behaviour.
     /// (When `User` moves out of the library, the integrator drains and
     /// publishes directly instead.)
-    pub(crate) fn flush(&self, entry: &SessionEntry<P, CP>) -> Result<(), UserError> {
-        let outbound = entry.read_or_err("session")?.drain_outbound();
+    pub(crate) fn flush(&self, entry: &ConversationEntry<P, CP>) -> Result<(), UserError> {
+        let outbound = entry.read_or_err("conversation")?.drain_outbound();
         if outbound.is_empty() {
             return Ok(());
         }
@@ -435,14 +442,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
     }
 
     /// Drop this conversation's consensus scope from the shared storage.
-    /// Called on leave (after the runner has already cancelled its own
+    /// Called on leave (after the conversation has already cancelled its own
     /// auto-votes) and pending-join timeout.
     pub fn cleanup_consensus_scope(&self, conversation_id: &str) -> Result<(), UserError> {
         let scope = P::Scope::from(conversation_id.to_string());
         self.plugins
             .consensus
             .delete_scope(&scope)
-            .map_err(SessionError::from)?;
+            .map_err(ConversationError::from)?;
         Ok(())
     }
 

--- a/crates/de_mls_gateway/tests/app_message_roundtrip.rs
+++ b/crates/de_mls_gateway/tests/app_message_roundtrip.rs
@@ -1,13 +1,13 @@
-//! Application message roundtrip through `SessionRunner::send_message`
-//! and `SessionRunner::dispatch_inbound_result` → `SessionEvent::AppMessage`.
+//! Application message roundtrip through `Conversation::send_message`
+//! and `Conversation::dispatch_inbound_result` → `ConversationEvent::AppMessage`.
 
 use std::time::Duration;
 
-use de_mls::core::{SessionEvent, StewardListConfig};
+use de_mls::core::{ConversationEvent, StewardListConfig};
 use de_mls::protos::de_mls::messages::v1::app_message;
 
 mod common;
-use common::session_fixtures::{
+use common::conversation_fixtures::{
     bootstrap_joined_conversation, deliver, fast_test_config, flush_user, settle_for,
 };
 
@@ -46,7 +46,7 @@ fn chat_message_delivered_to_peer_as_app_message_event() {
         .drain_events()
         .into_iter()
         .find_map(|e| match e {
-            SessionEvent::AppMessage(msg) => match msg.payload {
+            ConversationEvent::AppMessage(msg) => match msg.payload {
                 Some(app_message::Payload::ConversationMessage(cm)) => {
                     Some((cm.message, cm.sender))
                 }
@@ -54,7 +54,8 @@ fn chat_message_delivered_to_peer_as_app_message_event() {
             },
             _ => None,
         });
-    let (body, sender) = chat.expect("bob must surface alice's chat message as a SessionEvent");
+    let (body, sender) =
+        chat.expect("bob must surface alice's chat message as a ConversationEvent");
     assert_eq!(body, b"Hello from alice");
     assert_eq!(sender, users[0].0.member_id_string());
 }

--- a/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
+++ b/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
@@ -1,6 +1,6 @@
-//! Integration-test fixtures for SessionRunner-driven scenarios.
+//! Integration-test fixtures for Conversation-driven scenarios.
 //!
-//! Built around [`User`] + [`de_mls::session::SessionRunner`] over the
+//! Built around [`User`] + [`de_mls::session::Conversation`] over the
 //! `DefaultConversationPluginsFactory`. Every helper drives the production
 //! public surface — no peeking at private state. Packet relay is explicit:
 //! tests drain a [`CapturingTransport`] and call `process_inbound_packet`
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use de_mls::core::StewardListConfig;
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultConversationPluginsFactory};
-use de_mls::session::{ConversationConfig, SessionRunner};
+use de_mls::session::{Conversation, ConversationConfig};
 use de_mls_ds::{
     DeliveryService, DeliveryServiceError, OutboundPacket, SharedDeliveryService, WELCOME_SUBTOPIC,
 };
@@ -28,8 +28,8 @@ use crate::common::wallet::user_from_private_key;
 pub type TransportHandle = Arc<Mutex<CapturingTransport>>;
 
 pub type TestUser = User<DefaultConsensusPlugin, DefaultConversationPluginsFactory>;
-pub type TestSession = SessionRunner<DefaultConsensusPlugin, DefaultConversationPluginsFactory>;
-pub type SessionArc = Arc<RwLock<TestSession>>;
+pub type TestConversation = Conversation<DefaultConsensusPlugin, DefaultConversationPluginsFactory>;
+pub type ConversationArc = Arc<RwLock<TestConversation>>;
 
 /// Test transport that captures every outbound packet for later inspection
 /// instead of sending. `subscribe` is a no-op — tests deliver inbound
@@ -191,7 +191,7 @@ pub fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
     }
 }
 
-/// Drain `SessionEvent::WelcomeReady` events from each session and
+/// Drain `ConversationEvent::WelcomeReady` events from each session and
 /// route each welcome to the matching joiner via
 /// [`TestUser::accept_welcome`], then replay the bundled
 /// `conversation_sync_bytes` through `process_inbound_packet`. Returns
@@ -201,10 +201,10 @@ pub fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
 /// packets (e.g. the post-commit steward election proposal) need the joiner's
 /// MLS attached first.
 pub fn route_welcomes(
-    sessions: &[SessionArc],
+    sessions: &[ConversationArc],
     users: &mut [(TestUser, TransportHandle)],
 ) -> (usize, Vec<Vec<u8>>) {
-    use de_mls::core::SessionEvent;
+    use de_mls::core::ConversationEvent;
     use de_mls::protos::de_mls::messages::v1::MemberWelcome;
 
     // Pair each welcome with its emitter's app_id. The bundled sync is the
@@ -215,7 +215,7 @@ pub fn route_welcomes(
     for (i, s) in sessions.iter().enumerate() {
         let welcomer_app_id = users[i].0.app_id().to_vec();
         for event in s.read().unwrap().drain_events() {
-            if let SessionEvent::WelcomeReady(welcome) = event {
+            if let ConversationEvent::WelcomeReady(welcome) = event {
                 welcomes.push((welcome, welcomer_app_id.clone()));
             }
         }
@@ -225,7 +225,7 @@ pub fn route_welcomes(
     for (welcome, welcomer_app_id) in welcomes {
         let conv_name = sessions
             .first()
-            .map(|s| s.read().unwrap().conversation_id().to_string())
+            .map(|s| s.read().unwrap().id().to_string())
             .unwrap_or_default();
         for (u, _) in users.iter_mut() {
             // Try every user — `welcome_mls` returns `Ok(None)` (which
@@ -248,7 +248,7 @@ pub fn route_welcomes(
     (delivered, sync_bytes_out)
 }
 
-/// Default fast-timing config for SessionRunner-driven tests. All inactivity
+/// Default fast-timing config for Conversation-driven tests. All inactivity
 /// and consensus deadlines are sub-second so a polling loop converges in a
 /// handful of rounds. Override individual fields where the test needs
 /// different timing.
@@ -268,7 +268,7 @@ pub fn fast_test_config() -> ConversationConfig {
 /// One polling cycle on a session: tick deadlines, advance freeze state,
 /// check member-freeze inactivity, and check pending-join expiry. Mirrors the
 /// production `group_polling_loop` body in `de_mls_gateway::group`.
-pub fn poll_once(session: &SessionArc) {
+pub fn poll_once(session: &ConversationArc) {
     let _ = session.write().unwrap().poll();
 }
 
@@ -276,7 +276,7 @@ pub fn poll_once(session: &SessionArc) {
 /// so the relay (which drains the handle) picks it up. The session is
 /// pull-only — direct session calls in tests buffer here instead of sending;
 /// this stands in for the integrator's drain-and-publish.
-pub fn flush_session(session: &SessionArc, transport: &TransportHandle) {
+pub fn flush_conversation(session: &ConversationArc, transport: &TransportHandle) {
     let outbound = session.read().unwrap().drain_outbound();
     let mut t = transport.lock().unwrap();
     for out in outbound {
@@ -343,7 +343,7 @@ pub fn bootstrap_joined_conversation(
             .expect("joiner start");
     }
 
-    let mut sessions: Vec<SessionArc> = Vec::with_capacity(users.len());
+    let mut sessions: Vec<ConversationArc> = Vec::with_capacity(users.len());
     for (u, _) in &users {
         sessions.push(
             u.lookup_entry(conversation)
@@ -383,11 +383,11 @@ pub fn bootstrap_joined_conversation(
             poll_once(s);
         }
         for (i, (_, h)) in users.iter().enumerate() {
-            flush_session(&sessions[i], h);
+            flush_conversation(&sessions[i], h);
         }
 
         // Welcomes never traverse the test transport: the steward emits
-        // them as `SessionEvent::WelcomeReady`. Route each welcome to
+        // them as `ConversationEvent::WelcomeReady`. Route each welcome to
         // its joiner BEFORE relaying packets — same-round app-msg
         // traffic (the post-commit steward election proposal) needs
         // the joiner's MLS attached first.
@@ -408,7 +408,7 @@ pub fn bootstrap_joined_conversation(
 
         let mut all_working = true;
         for s in sessions.iter().skip(1) {
-            if s.read().unwrap().conversation_state() != ConversationState::Working {
+            if s.read().unwrap().state() != ConversationState::Working {
                 all_working = false;
                 break;
             }

--- a/crates/de_mls_gateway/tests/common/mod.rs
+++ b/crates/de_mls_gateway/tests/common/mod.rs
@@ -5,13 +5,13 @@
 //! adding `mod common;` to any test file. Helpers carry `#[allow(dead_code)]`
 //! at the module level because not every binary exercises every helper.
 //!
-//! [`session_fixtures`] drives the reference integrator (`User` +
-//! `SessionRunner`) through `handle_inbound` / `receive_key_package`, with
+//! [`conversation_fixtures`] drives the reference integrator (`User` +
+//! `Conversation`) through `handle_inbound` / `receive_key_package`, with
 //! transport capture and polling helpers. [`wallet`] supplies the test
 //! `MemberId` adapter and a `User` constructor keyed by a private key.
 #![allow(dead_code, unused_imports)]
 
-pub mod session_fixtures;
+pub mod conversation_fixtures;
 pub mod wallet;
 
 pub use wallet::WalletMemberId;

--- a/crates/de_mls_gateway/tests/conversation_sync_idempotent.rs
+++ b/crates/de_mls_gateway/tests/conversation_sync_idempotent.rs
@@ -11,9 +11,9 @@ use de_mls::session::MemberRole;
 use de_mls_ds::OutboundPacket;
 
 mod common;
-use common::session_fixtures::{
-    SessionArc, deliver, fast_test_config, flush_session, make_user, poll_once, route_welcomes,
-    settle_for,
+use common::conversation_fixtures::{
+    ConversationArc, deliver, fast_test_config, flush_conversation, make_user, poll_once,
+    route_welcomes, settle_for,
 };
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -35,7 +35,7 @@ fn second_conversation_sync_is_a_no_op() {
     users[0].0.start_conversation("c2", true).expect("creator");
     users[1].0.start_conversation("c2", false).expect("joiner");
 
-    let sessions: Vec<SessionArc> = users
+    let sessions: Vec<ConversationArc> = users
         .iter()
         .map(|(u, _)| u.lookup_entry("c2").unwrap().unwrap())
         .collect();
@@ -55,12 +55,12 @@ fn second_conversation_sync_is_a_no_op() {
     for _ in 0..30 {
         settle_for(Duration::from_millis(60));
         for (i, (_, h)) in users.iter().enumerate() {
-            flush_session(&sessions[i], h);
+            flush_conversation(&sessions[i], h);
         }
         poll_once(&sessions[0]);
         poll_once(&sessions[1]);
         for (i, (_, h)) in users.iter().enumerate() {
-            flush_session(&sessions[i], h);
+            flush_conversation(&sessions[i], h);
         }
 
         let (_, sync_bytes) = route_welcomes(&sessions, &mut users);
@@ -78,7 +78,7 @@ fn second_conversation_sync_is_a_no_op() {
             }
         }
 
-        if sessions[1].read().unwrap().conversation_state() == ConversationState::Working {
+        if sessions[1].read().unwrap().state() == ConversationState::Working {
             break;
         }
     }
@@ -88,7 +88,7 @@ fn second_conversation_sync_is_a_no_op() {
         "bootstrap must produce a ConversationSync for the joiner"
     );
     assert_eq!(
-        sessions[1].read().unwrap().conversation_state(),
+        sessions[1].read().unwrap().state(),
         ConversationState::Working,
         "bob must be Working after bootstrap"
     );

--- a/crates/de_mls_gateway/tests/freeze_coordinator_ordering.rs
+++ b/crates/de_mls_gateway/tests/freeze_coordinator_ordering.rs
@@ -2,12 +2,12 @@
 //!
 //! During a commit cycle, every session must emit phase events in the
 //! order: `Freezing → Selection → CommitApplied → Working`. The
-//! coordinator runs in `SessionRunner` (Freeze is not a plug-in), so this
+//! coordinator runs in `Conversation` (Freeze is not a plug-in), so this
 //! is a direct probe of its orchestration.
 
 use std::time::Duration;
 
-use de_mls::core::{ConversationState, SessionEvent, StewardListConfig};
+use de_mls::core::{ConversationEvent, ConversationState, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::{
     ConversationUpdateRequest, RemoveMember, conversation_update_request,
@@ -15,8 +15,9 @@ use de_mls::protos::de_mls::messages::v1::{
 use de_mls::session::CreatorVote;
 
 mod common;
-use common::session_fixtures::{
-    bootstrap_joined_conversation, deliver, fast_test_config, flush_session, poll_once, settle_for,
+use common::conversation_fixtures::{
+    bootstrap_joined_conversation, deliver, fast_test_config, flush_conversation, poll_once,
+    settle_for,
 };
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -70,8 +71,8 @@ fn freeze_cycle_emits_phase_events_in_order() {
         settle_for(Duration::from_millis(40));
         poll_once(&alice_session);
         poll_once(&bob_session);
-        flush_session(&alice_session, &alice_tx);
-        flush_session(&bob_session, &bob_tx);
+        flush_conversation(&alice_session, &alice_tx);
+        flush_conversation(&bob_session, &bob_tx);
 
         let mut packets = Vec::new();
         packets.extend(alice_tx.lock().unwrap().drain_packets());
@@ -82,7 +83,7 @@ fn freeze_cycle_emits_phase_events_in_order() {
         }
 
         alice_phases.extend(drain_phase_log(&alice_session));
-        let alice_state = alice_session.read().unwrap().conversation_state();
+        let alice_state = alice_session.read().unwrap().state();
         if alice_state == ConversationState::Freezing || alice_state == ConversationState::Selection
         {
             saw_freezing = true;
@@ -155,17 +156,21 @@ impl PhaseEntry {
 }
 
 /// Drain pending session events and project to the phase-relevant subset.
-fn drain_phase_log(session: &common::session_fixtures::SessionArc) -> Vec<PhaseEntry> {
+fn drain_phase_log(session: &common::conversation_fixtures::ConversationArc) -> Vec<PhaseEntry> {
     session
         .read()
         .unwrap()
         .drain_events()
         .into_iter()
         .filter_map(|e| match e {
-            SessionEvent::PhaseChange(ConversationState::Freezing) => Some(PhaseEntry::Freezing),
-            SessionEvent::PhaseChange(ConversationState::Selection) => Some(PhaseEntry::Selection),
-            SessionEvent::PhaseChange(ConversationState::Working) => Some(PhaseEntry::Working),
-            SessionEvent::CommitApplied(batch) => Some(PhaseEntry::CommitApplied(batch)),
+            ConversationEvent::PhaseChange(ConversationState::Freezing) => {
+                Some(PhaseEntry::Freezing)
+            }
+            ConversationEvent::PhaseChange(ConversationState::Selection) => {
+                Some(PhaseEntry::Selection)
+            }
+            ConversationEvent::PhaseChange(ConversationState::Working) => Some(PhaseEntry::Working),
+            ConversationEvent::CommitApplied(batch) => Some(PhaseEntry::CommitApplied(batch)),
             _ => None,
         })
         .collect()

--- a/crates/de_mls_gateway/tests/leave_after_removal.rs
+++ b/crates/de_mls_gateway/tests/leave_after_removal.rs
@@ -4,13 +4,13 @@
 
 use std::time::Duration;
 
-use de_mls::core::{SessionEvent, StewardListConfig};
+use de_mls::core::{ConversationEvent, StewardListConfig};
 use de_mls::member_id::MemberId;
 use de_mls::protos::de_mls::messages::v1::ConversationUpdateRequest;
 use de_mls::session::CreatorVote;
 
 mod common;
-use common::session_fixtures::{
+use common::conversation_fixtures::{
     bootstrap_joined_conversation, deliver, fast_test_config, flush_user, settle_for,
 };
 
@@ -98,7 +98,7 @@ fn removed_member_emits_leaving_and_is_evicted() {
     assert!(
         target_events
             .iter()
-            .any(|e| matches!(e, SessionEvent::Leaving)),
+            .any(|e| matches!(e, ConversationEvent::Leaving)),
         "removed member's session must emit Leaving"
     );
 }

--- a/crates/de_mls_gateway/tests/leave_evicts_registry.rs
+++ b/crates/de_mls_gateway/tests/leave_evicts_registry.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use de_mls::core::StewardListConfig;
 
 mod common;
-use common::session_fixtures::{fast_test_config, make_user, settle_for};
+use common::conversation_fixtures::{fast_test_config, make_user, settle_for};
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 

--- a/crates/de_mls_gateway/tests/multi_conversation_isolation.rs
+++ b/crates/de_mls_gateway/tests/multi_conversation_isolation.rs
@@ -1,6 +1,6 @@
 //! Per-conversation lock isolation.
 //!
-//! Each `SessionRunner` lives behind its own `RwLock` inside the User's
+//! Each `Conversation` lives behind its own `RwLock` inside the User's
 //! conversation registry. Holding one session's write lock must not
 //! block reads or writes on any other session, nor block the outer
 //! registry read path that `lookup_entry` walks.
@@ -9,7 +9,7 @@ use de_mls::core::StewardListConfig;
 use de_mls::session::ConversationConfig;
 
 mod common;
-use common::session_fixtures::{fast_test_config, make_user};
+use common::conversation_fixtures::{fast_test_config, make_user};
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
@@ -33,7 +33,7 @@ fn write_lock_on_one_session_does_not_block_others() {
     let a_guard = session_a.write().unwrap();
 
     // Outer registry lookups touch only the sync `RwLock<HashMap<…>>`,
-    // not the inner SessionRunner locks. The call is synchronous — it
+    // not the inner Conversation locks. The call is synchronous — it
     // returns immediately even with the inner write lock held.
     alice
         .lookup_entry("conv-a")

--- a/crates/de_mls_gateway/tests/operating_mode_transitions.rs
+++ b/crates/de_mls_gateway/tests/operating_mode_transitions.rs
@@ -11,13 +11,14 @@
 
 use std::time::Duration;
 
-use de_mls::core::{ConversationState, SessionEvent, StewardListConfig};
+use de_mls::core::{ConversationEvent, ConversationState, StewardListConfig};
 use de_mls::protos::de_mls::messages::v1::ViolationEvidence;
 use de_mls::session::CreatorVote;
 
 mod common;
-use common::session_fixtures::{
-    bootstrap_joined_conversation, deliver, fast_test_config, flush_session, poll_once, settle_for,
+use common::conversation_fixtures::{
+    bootstrap_joined_conversation, deliver, fast_test_config, flush_conversation, poll_once,
+    settle_for,
 };
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -37,8 +38,8 @@ fn deadlock_ecp_opens_recovery_and_force_freezes() {
     let alice_tx = users[0].1.clone();
     let bob_tx = users[1].1.clone();
 
-    let mut alice_events: Vec<SessionEvent> = Vec::new();
-    let mut bob_events: Vec<SessionEvent> = Vec::new();
+    let mut alice_events: Vec<ConversationEvent> = Vec::new();
+    let mut bob_events: Vec<ConversationEvent> = Vec::new();
 
     // File a Deadlock ECP. With both members as stewards and bob's
     // auto-vote, the emergency proposal reaches consensus YES.
@@ -59,8 +60,8 @@ fn deadlock_ecp_opens_recovery_and_force_freezes() {
         settle_for(Duration::from_millis(40));
         poll_once(&alice_session);
         poll_once(&bob_session);
-        flush_session(&alice_session, &alice_tx);
-        flush_session(&bob_session, &bob_tx);
+        flush_conversation(&alice_session, &alice_tx);
+        flush_conversation(&bob_session, &bob_tx);
         let packets = alice_tx.lock().unwrap().drain_packets();
         for p in packets {
             deliver(&users[1].0, &p);
@@ -72,16 +73,14 @@ fn deadlock_ecp_opens_recovery_and_force_freezes() {
 
         alice_events.extend(alice_session.read().unwrap().drain_events());
         bob_events.extend(bob_session.read().unwrap().drain_events());
-        if alice_events
-            .iter()
-            .any(|e| matches!(e, SessionEvent::PhaseChange(s) if *s == ConversationState::Freezing))
-        {
+        if alice_events.iter().any(
+            |e| matches!(e, ConversationEvent::PhaseChange(s) if *s == ConversationState::Freezing),
+        ) {
             alice_saw_freezing = true;
         }
-        if bob_events
-            .iter()
-            .any(|e| matches!(e, SessionEvent::PhaseChange(s) if *s == ConversationState::Freezing))
-        {
+        if bob_events.iter().any(
+            |e| matches!(e, ConversationEvent::PhaseChange(s) if *s == ConversationState::Freezing),
+        ) {
             bob_saw_freezing = true;
         }
         if alice_saw_freezing && bob_saw_freezing {

--- a/crates/de_mls_gateway/tests/pending_join_eviction.rs
+++ b/crates/de_mls_gateway/tests/pending_join_eviction.rs
@@ -9,12 +9,12 @@
 
 use std::time::{Duration, Instant};
 
-use de_mls::core::{SessionEvent, StewardListConfig};
+use de_mls::core::{ConversationEvent, StewardListConfig};
 use de_mls::session::ConversationConfig;
 use de_mls_gateway::user::ConversationLifecycle;
 
 mod common;
-use common::session_fixtures::{SessionArc, make_user, settle_for};
+use common::conversation_fixtures::{ConversationArc, make_user, settle_for};
 
 const ALICE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
@@ -58,7 +58,7 @@ fn pending_join_expires_evicts_entry_and_broadcasts_removal() {
     assert!(
         session_events
             .iter()
-            .any(|e| matches!(e, SessionEvent::Leaving)),
+            .any(|e| matches!(e, ConversationEvent::Leaving)),
         "session must emit Leaving on PendingJoin expiry"
     );
 
@@ -88,7 +88,7 @@ fn pending_join_expires_evicts_entry_and_broadcasts_removal() {
     );
 }
 
-fn await_leave_requested(session: &SessionArc, inactivity: Duration) -> bool {
+fn await_leave_requested(session: &ConversationArc, inactivity: Duration) -> bool {
     // Allow up to 6× inactivity so the test isn't fragile on slow CI.
     let deadline = Instant::now() + inactivity * 6;
     loop {

--- a/crates/de_mls_gateway/tests/recovery_inactivity_reelection.rs
+++ b/crates/de_mls_gateway/tests/recovery_inactivity_reelection.rs
@@ -17,7 +17,7 @@ use de_mls::protos::de_mls::messages::v1::{
 use de_mls::session::CreatorVote;
 
 mod common;
-use common::session_fixtures::{
+use common::conversation_fixtures::{
     bootstrap_joined_conversation, deliver, fast_test_config, flush_user, poll_once, settle_for,
 };
 
@@ -120,7 +120,7 @@ fn silent_steward_drives_observer_to_reelection() {
             deliver(&users[steward_idx].0, &p);
         }
 
-        let observer_state = observer_session.read().unwrap().conversation_state();
+        let observer_state = observer_session.read().unwrap().state();
         if observer_state == ConversationState::Reelection {
             entered_reelection = true;
             break;

--- a/crates/de_mls_gateway/tests/rejoin_after_eviction.rs
+++ b/crates/de_mls_gateway/tests/rejoin_after_eviction.rs
@@ -9,7 +9,7 @@ use de_mls::protos::de_mls::messages::v1::ConversationUpdateRequest;
 use de_mls::session::CreatorVote;
 
 mod common;
-use common::session_fixtures::{
+use common::conversation_fixtures::{
     bootstrap_joined_conversation, deliver, fast_test_config, flush_user, route_welcomes,
     settle_for,
 };
@@ -96,7 +96,7 @@ fn evicted_member_can_rejoin_at_higher_epoch() {
     for _ in 0..30 {
         drive_one_round_no_target_eviction(&mut users, target_idx);
         if let Some(s) = users[target_idx].0.lookup_entry("rejoin").unwrap()
-            && s.read().unwrap().conversation_state() == ConversationState::Working
+            && s.read().unwrap().state() == ConversationState::Working
         {
             rejoined = true;
             break;
@@ -129,8 +129,8 @@ fn evicted_member_can_rejoin_at_higher_epoch() {
 
 fn drive_one_round(
     users: &mut [(
-        common::session_fixtures::TestUser,
-        common::session_fixtures::TransportHandle,
+        common::conversation_fixtures::TestUser,
+        common::conversation_fixtures::TransportHandle,
     )],
     target_idx: usize,
 ) {
@@ -169,8 +169,8 @@ fn drive_one_round(
 /// if the pending-join expiry fires.
 fn drive_one_round_no_target_eviction(
     users: &mut [(
-        common::session_fixtures::TestUser,
-        common::session_fixtures::TransportHandle,
+        common::conversation_fixtures::TestUser,
+        common::conversation_fixtures::TransportHandle,
     )],
     target_idx: usize,
 ) {

--- a/crates/de_mls_gateway/tests/self_leave_dedup.rs
+++ b/crates/de_mls_gateway/tests/self_leave_dedup.rs
@@ -1,6 +1,6 @@
 //! Self-leave is idempotent on rapid back-to-back calls.
 //!
-//! `SessionRunner::initiate_self_leave` checks `is_pending_self_leave`
+//! `Conversation::initiate_self_leave` checks `is_pending_self_leave`
 //! locally and falls back to consensus-library `ProposalAlreadyExist`
 //! dedup if the proposal is still mid-vote. Either path means a second
 //! `leave_conversation` call emits no new outbound packets.
@@ -9,7 +9,7 @@ use de_mls::core::StewardListConfig;
 use de_mls::session::ConversationConfig;
 
 mod common;
-use common::session_fixtures::make_user;
+use common::conversation_fixtures::make_user;
 
 const ALICE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 

--- a/crates/de_mls_gateway/tests/steward_inactivity_commit.rs
+++ b/crates/de_mls_gateway/tests/steward_inactivity_commit.rs
@@ -16,9 +16,9 @@ use de_mls::session::CreatorVote;
 use de_mls_ds::OutboundPacket;
 
 mod common;
-use common::session_fixtures::{
-    bootstrap_joined_conversation, deliver, fast_test_config, flush_session, poll_once, predicate,
-    settle_for,
+use common::conversation_fixtures::{
+    bootstrap_joined_conversation, deliver, fast_test_config, flush_conversation, poll_once,
+    predicate, settle_for,
 };
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -68,8 +68,8 @@ fn steward_inactivity_fires_commit_candidate() {
         settle_for(Duration::from_millis(40));
         poll_once(&alice_session);
         poll_once(&bob_session);
-        flush_session(&alice_session, &alice_tx);
-        flush_session(&bob_session, &bob_tx);
+        flush_conversation(&alice_session, &alice_tx);
+        flush_conversation(&bob_session, &bob_tx);
 
         let new_alice = alice_tx.lock().unwrap().drain_packets();
         let new_bob = bob_tx.lock().unwrap().drain_packets();

--- a/crates/de_mls_gateway/tests/steward_small_group_rotation.rs
+++ b/crates/de_mls_gateway/tests/steward_small_group_rotation.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use de_mls::core::{ConversationState, StewardListConfig};
 
 mod common;
-use common::session_fixtures::{
-    SessionArc, TestUser, TransportHandle, bootstrap_joined_conversation, deliver,
+use common::conversation_fixtures::{
+    ConversationArc, TestUser, TransportHandle, bootstrap_joined_conversation, deliver,
     fast_test_config, flush_user, poll_once, settle_for,
 };
 
@@ -39,7 +39,7 @@ fn relay_all(users: &[(TestUser, TransportHandle)]) {
 fn assert_stable_no_election(
     users: &[(TestUser, TransportHandle)],
     conversation: &str,
-    sessions: &[(&str, &SessionArc)],
+    sessions: &[(&str, &ConversationArc)],
 ) {
     assert!(
         sessions[0].1.read().unwrap().is_steward(),
@@ -61,7 +61,7 @@ fn assert_stable_no_election(
             "{label} retry_round must stay 0 — no election fires for unsettled members ({conversation})"
         );
         assert_eq!(
-            s.read().unwrap().conversation_state(),
+            s.read().unwrap().state(),
             ConversationState::Working,
             "{label} must stay Working ({conversation})"
         );
@@ -92,7 +92,7 @@ fn members_over_sn_max_do_not_elect_until_settled() {
         fast_test_config(),
         StewardListConfig::new(1, 2).unwrap(),
     );
-    let s: Vec<SessionArc> = (0..3)
+    let s: Vec<ConversationArc> = (0..3)
         .map(|i| users[i].0.lookup_entry("lg").unwrap().unwrap())
         .collect();
     assert_stable_no_election(

--- a/src/core/consensus_plugin.rs
+++ b/src/core/consensus_plugin.rs
@@ -20,7 +20,7 @@ use hashgraph_like_consensus::{
 ///
 /// Returns `None` when the queue is empty.
 ///
-/// `SessionRunner` holds one receiver per session and drains it from
+/// Each `Conversation` holds one receiver and drains it from
 /// `tick_deadlines`.
 pub trait SyncConsensusReceiver<Scope: ConsensusScope>: Send {
     fn try_recv(&mut self) -> Option<(Scope, ConsensusEvent)>;

--- a/src/core/conversation/conversation.rs
+++ b/src/core/conversation/conversation.rs
@@ -23,7 +23,7 @@ use crate::{
 /// Per-conversation aggregate owned by the orchestrator. Bundles protocol
 /// state, the MLS service, plug-ins, state machine, durable config, and
 /// operating mode behind one type parameter.
-pub struct Conversation<CP: ConversationPluginsFactory> {
+pub struct ConversationCore<CP: ConversationPluginsFactory> {
     pub queues: ConversationQueues,
     /// Per-conversation MLS service. `None` for joiners in `PendingJoin` who
     /// haven't accepted a welcome yet; once attached via
@@ -41,7 +41,7 @@ pub struct Conversation<CP: ConversationPluginsFactory> {
     operating_mode: OperatingMode,
 }
 
-impl<CP: ConversationPluginsFactory> Conversation<CP> {
+impl<CP: ConversationPluginsFactory> ConversationCore<CP> {
     /// Build a fresh conversation. Creator path passes `Some(mls)`; joiner
     /// path passes `None` and attaches later via [`Self::attach_mls`].
     pub(crate) fn new(
@@ -317,8 +317,8 @@ mod tests {
     use super::*;
     use crate::test_fixtures::{StubPluginsFactory, StubScoring, StubStewardList, UnusedMls};
 
-    fn make_conversation(steward_list: StubStewardList) -> Conversation<StubPluginsFactory> {
-        Conversation::new(
+    fn make_conversation(steward_list: StubStewardList) -> ConversationCore<StubPluginsFactory> {
+        ConversationCore::new(
             ConversationQueues::new("g"),
             Some(UnusedMls),
             ConversationStateMachine::new_as_member(),

--- a/src/core/conversation/mod.rs
+++ b/src/core/conversation/mod.rs
@@ -4,7 +4,7 @@
 //! Layout:
 //! - [`queues`] — the [`ConversationQueues`] struct + protocol queues +
 //!   dedup caches.
-//! - [`conversation`] — [`Conversation`], the MLS-bound aggregate
+//! - [`conversation`] — [`ConversationCore`], the MLS-bound aggregate
 //!   (queues + MLS service + plug-ins + state machine), owned by the
 //!   orchestrator.
 //! - [`state_machine`] — passive state enum + named transitions.
@@ -23,7 +23,7 @@ pub use config::{
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_PROPOSAL_EXPIRATION,
     DEFAULT_RECOVERY_INACTIVITY_DURATION, DEFAULT_VOTING_DELAY,
 };
-pub use conversation::Conversation;
+pub use conversation::ConversationCore;
 pub use queues::{BufferedCommitCandidate, ConversationQueues, FreezeBufferOutcome, ProposalId};
 pub use state_machine::{ConversationState, ConversationStateMachine, OperatingMode};
 pub use util::{member_set, self_leave_proposal_id, target_member_id_of};

--- a/src/core/conversation_plugins.rs
+++ b/src/core/conversation_plugins.rs
@@ -23,10 +23,10 @@ pub trait ConversationPluginsFactory {
     /// Returns `Ok(None)` when the welcome isn't for us.
     fn welcome_mls(&self, welcome_bytes: &[u8]) -> Result<Option<Self::Mls>, MlsError>;
 
-    /// Build a fresh peer-scoring plug-in for a new conversation runner.
+    /// Build a fresh peer-scoring plug-in for a new conversation.
     fn make_scoring(&self, config: &ScoringConfig) -> Self::Scoring;
 
-    /// Build a fresh steward-list plug-in for a new conversation runner.
+    /// Build a fresh steward-list plug-in for a new conversation.
     /// Returns an empty plug-in; the lifecycle creator path bootstraps it
     /// via [`StewardListPlugin::install_list`].
     fn make_steward_list(

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -1,7 +1,7 @@
 //! I/O contract between the protocol layer and an integrator.
 //!
-//! [`SessionEvent`] — fire-and-forget notifications about a single
-//! conversation. Each [`crate::session::SessionRunner`] holds a pending
+//! [`ConversationEvent`] — fire-and-forget notifications about a single
+//! conversation. Each [`crate::session::Conversation`] holds a pending
 //! buffer; integrators drain it once per polling cycle.
 //!
 //! The library carries no transport: it buffers `Outbound` and consumes
@@ -15,10 +15,10 @@ use crate::{
 
 /// Per-conversation notification. Sessions append these to their pending
 /// buffer; integrators drain via
-/// [`crate::session::SessionRunner::drain_events`] once per polling cycle. All
-/// variants are fire-and-forget — no failure path back to the session.
+/// [`crate::session::Conversation::drain_events`] once per polling cycle. All
+/// variants are fire-and-forget — no failure path back to the conversation.
 #[derive(Debug, Clone)]
-pub enum SessionEvent {
+pub enum ConversationEvent {
     /// Decrypted application message (chat, vote request, proposal
     /// notification, ban request, …).
     AppMessage(AppMessage),

--- a/src/core/freeze/round.rs
+++ b/src/core/freeze/round.rs
@@ -38,7 +38,7 @@ pub enum FreezeOutcome {
         result: ProcessResult,
         /// Welcome artifact when our own commit added members.
         /// Surfaced to integrators via
-        /// [`crate::core::SessionEvent::WelcomeReady`].
+        /// [`crate::core::ConversationEvent::WelcomeReady`].
         welcome: Option<MemberWelcome>,
     },
     #[default]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,7 +3,7 @@
 //! Wraps MLS cryptography, consensus voting, and message routing. Transport,
 //! UI, and state management live in the app layer.
 //!
-//! Integrators drain `SessionEvent` from each session (transport
+//! Integrators drain `ConversationEvent` from each conversation (transport
 //! + UI delivery) and feed inbound packets to [`crate::core::process_inbound`],
 //! then dispatch the returned [`crate::core::ProcessResult`].
 //! [`crate::defaults::DefaultConsensusPlugin`] bundles in-memory backends for tests
@@ -14,7 +14,7 @@
 //! `consensus_plugin` ([`crate::core::ConsensusPlugin`] +
 //! [`crate::defaults::DefaultConsensusPlugin`]), `conversation_plugins`
 //! ([`crate::core::ConversationPluginsFactory`] — the per-conversation
-//! plug-in factory bundle), `events` (`SessionEvent`),
+//! plug-in factory bundle), `events` (`ConversationEvent`),
 //! `freeze` (round selection + apply),
 //! `inbound` (app-subtopic packet routing), `peer_scoring`
 //! (scoring plug-in contract), `process_result`
@@ -44,7 +44,7 @@ pub use inbound::process_inbound;
 
 // ── Per-conversation types: state, queues, state machine, config ──
 pub use conversation::{
-    BufferedCommitCandidate, Conversation, ConversationConfig, ConversationQueues,
+    BufferedCommitCandidate, ConversationConfig, ConversationCore, ConversationQueues,
     ConversationState, ConversationStateMachine, DEFAULT_COMMIT_INACTIVITY_DURATION,
     DEFAULT_CONSENSUS_TIMEOUT, DEFAULT_ELECTION_VOTING_DELAY, DEFAULT_LIVENESS_CRITERIA_YES,
     DEFAULT_PENDING_UPDATE_MAX_EPOCHS, DEFAULT_PROPOSAL_EXPIRATION,
@@ -63,8 +63,8 @@ pub use peer_scoring::{
 // ── Error type ──
 pub use error::CoreError;
 
-// ── Session-event types ──
-pub use events::SessionEvent;
+// ── Conversation-event types ──
+pub use events::ConversationEvent;
 
 // ── Proposal classification ──
 pub use proposal_kind::ProposalKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! - **[`core`]** - Protocol implementation (message processing, consensus integration)
 //! - **[`mls_crypto`]** - MLS cryptographic operations (OpenMLS wrapper)
-//! - **[`session`]** - Reference session layer (per-conversation `SessionRunner`, state machine)
+//! - **[`session`]** - Reference session layer (the `Conversation` handle, state machine)
 //! - **[`protos`]** - Protobuf message definitions
 //!
 //! The library carries no transport. The reference delivery service (the
@@ -38,11 +38,11 @@
 //! ## Getting Started
 //!
 //! Most developers should start with the [`core`] module documentation, which explains:
-//! - What traits you need to implement (`core::SessionEvent`)
+//! - What traits you need to implement (`core::ConversationEvent`)
 //! - Core operations (start conversation, join, send messages)
 //! - The `ProcessResult` matching flow
 //!
-//! The library exposes the per-conversation [`session::SessionRunner`] handle.
+//! The library exposes the per-conversation [`session::Conversation`] handle.
 //! It carries no transport: it buffers outbound and consumes inbound
 //! payloads, and the integrator owns routing. A ready-to-use reference
 //! integrator (the multi-conversation `User` with registry + routing +
@@ -51,17 +51,17 @@
 //! ## Quick Example
 //!
 //! ```ignore
-//! use de_mls::session::{ConversationDeps, SessionRunner};
+//! use de_mls::session::{ConversationDeps, Conversation};
 //!
-//! // Build a per-conversation session from injected deps (plug-in factory,
-//! // consensus context, identity).
-//! let mut session = SessionRunner::create("de-mls-test", deps)?;
+//! // Build a conversation from injected deps (plug-in factory,
+//! // consensus service, identity).
+//! let mut conversation = Conversation::create("de-mls-test", deps)?;
 //!
 //! // Send a chat message — buffered, never auto-sent.
-//! session.send_message(b"Hello, world!".to_vec())?;
+//! conversation.send_message(b"Hello, world!".to_vec())?;
 //!
 //! // Drain outbound and publish it on your own transport.
-//! for out in session.drain_outbound() { /* publish */ }
+//! for out in conversation.drain_outbound() { /* publish */ }
 //! ```
 
 /// Protocol implementation.

--- a/src/session/consensus/bridge.rs
+++ b/src/session/consensus/bridge.rs
@@ -18,7 +18,7 @@ use tracing::info;
 use crate::{
     core::{ConsensusPlugin, ConsensusServiceFor, CoreError, self_leave_proposal_id},
     protos::de_mls::messages::v1::{AppMessage, ConversationUpdateRequest},
-    session::error::SessionError,
+    session::error::ConversationError,
 };
 
 /// Per-proposal consensus-session parameters.
@@ -71,7 +71,7 @@ pub(crate) fn cast_vote<P>(
     proposal_id: u32,
     vote: bool,
     consensus: &ConsensusServiceFor<P>,
-) -> Result<AppMessage, SessionError>
+) -> Result<AppMessage, ConversationError>
 where
     P: ConsensusPlugin,
 {
@@ -140,7 +140,7 @@ pub(crate) fn submit_self_leave_proposal<P>(
     self_member_id: &[u8],
     consensus: &ConsensusServiceFor<P>,
     params: ProposalParams,
-) -> Result<Option<(u32, AppMessage)>, SessionError>
+) -> Result<Option<(u32, AppMessage)>, ConversationError>
 where
     P: ConsensusPlugin,
 {

--- a/src/session/consensus/events.rs
+++ b/src/session/consensus/events.rs
@@ -6,23 +6,23 @@ use tracing::{error, info};
 
 use crate::{
     core::{
-        ConsensusApplyResult, ConsensusPlugin, ConversationPluginsFactory, PeerScoringPlugin,
-        ScoreOp, SessionEvent, StewardListPlugin, apply_consensus_result, emergency_score_ops,
+        ConsensusApplyResult, ConsensusPlugin, ConversationEvent, ConversationPluginsFactory,
+        PeerScoringPlugin, ScoreOp, StewardListPlugin, apply_consensus_result, emergency_score_ops,
     },
     protos::de_mls::messages::v1::{
         ConversationUpdateRequest, StewardElectionProposal, conversation_update_request,
     },
-    session::{ConversationState, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState},
 };
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     /// Apply one resolved outcome: surface the decision to the integrator,
     /// apply the queue effects, then run whatever follow-up the result
     /// calls for (election install/retry, freeze entry, emergency scoring).
     pub(crate) fn apply_consensus_outcome(
         &mut self,
         event: ConsensusEvent,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ConversationError> {
         let (proposal_id, approved, timestamp) = match &event {
             ConsensusEvent::ConsensusReached {
                 proposal_id,
@@ -38,10 +38,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Any outcome moots both pending deadlines for this proposal.
         self.cancel_auto_vote(proposal_id);
         self.unregister_consensus_timeout(proposal_id);
-        let already_applied = self
-            .conversation
-            .queues
-            .is_consensus_outcome_applied(proposal_id);
+        let already_applied = self.core.queues.is_consensus_outcome_applied(proposal_id);
         if already_applied {
             tracing::debug!(
                 conversation = %self.conversation_id,
@@ -53,7 +50,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         // Emitted before any effects, so the integrator sees the decision
         // in the same polling cycle as the state changes it triggers.
-        self.emit_event(SessionEvent::ConsensusReached {
+        self.emit_event(ConversationEvent::ConsensusReached {
             proposal_id,
             approved,
             timestamp,
@@ -68,22 +65,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             conversation = %self.conversation_id,
             proposal_id, approved, "consensus reached"
         );
-        self.conversation
-            .queues
-            .mark_consensus_outcome_applied(proposal_id);
-        let consensus_apply = apply_consensus_result(
-            &mut self.conversation.queues,
-            proposal_id,
-            approved,
-            &request,
-        )?;
+        self.core.queues.mark_consensus_outcome_applied(proposal_id);
+        let consensus_apply =
+            apply_consensus_result(&mut self.core.queues, proposal_id, approved, &request)?;
 
         // A peer steward can reach consensus and broadcast its commit
         // candidate before our own outcome lands. Now that the approved
         // queue is populated, replay any stashed candidate so the freeze
         // round starts with it instead of empty (which would force a
         // needless reelection).
-        self.conversation.replay_early_candidates()?;
+        self.core.replay_early_candidates()?;
 
         match consensus_apply {
             ConsensusApplyResult::NoAction => {}
@@ -94,7 +85,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 self.handle_election_rejected()?;
             }
             ConsensusApplyResult::RecoveryModeOpened => {
-                self.conversation.enter_recovery_mode();
+                self.core.enter_recovery_mode();
                 self.start_freezing_and_emit();
             }
             ConsensusApplyResult::UrgentRemoval { target } => {
@@ -105,7 +96,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 self.refresh_stewards_after_removal(&target)?;
             }
             ConsensusApplyResult::RejectedMembership { target } => {
-                self.conversation.queues.remove_pending_update(&target);
+                self.core.queues.remove_pending_update(&target);
             }
         }
 
@@ -118,10 +109,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         Ok(())
     }
 
-    /// Emit a [`SessionEvent::PhaseChange`] if a transition occurred.
+    /// Emit a [`ConversationEvent::PhaseChange`] if a transition occurred.
     fn emit_phase_change(&self, transition: Option<ConversationState>) {
         if let Some(state) = transition {
-            self.emit_event(SessionEvent::PhaseChange(state));
+            self.emit_event(ConversationEvent::PhaseChange(state));
         }
     }
 
@@ -136,8 +127,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// the next epoch still has a live epoch + backup steward. Election
     /// rejection here is deferred, not fatal — the list heals on a later
     /// reconcile.
-    fn refresh_stewards_after_removal(&mut self, target: &[u8]) -> Result<(), SessionError> {
-        if !self.conversation.steward_list.is_steward(target) {
+    fn refresh_stewards_after_removal(&mut self, target: &[u8]) -> Result<(), ConversationError> {
+        if !self.core.steward_list.is_steward(target) {
             return Ok(());
         }
         if let Err(e) = self.initiate_steward_election(true) {
@@ -156,11 +147,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     fn handle_election_accepted(
         &mut self,
         election: StewardElectionProposal,
-    ) -> Result<(), SessionError> {
-        self.conversation.expect_mls()?;
+    ) -> Result<(), ConversationError> {
+        self.core.expect_mls()?;
         // The proposal carries no separate candidate pool: `proposed_stewards`
         // is the full set the proposer sorted.
-        let is_valid = self.conversation.steward_list.validate_proposed(
+        let is_valid = self.core.steward_list.validate_proposed(
             &election.proposed_stewards,
             election.election_epoch,
             &election.proposed_stewards,
@@ -174,7 +165,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             return Ok(());
         }
 
-        self.conversation.steward_list.install_list(
+        self.core.steward_list.install_list(
             election.election_epoch,
             &election.proposed_stewards,
             election.proposed_stewards.len(),
@@ -182,13 +173,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         )?;
         // `retry_round` stays > 0 until the next successful commit, so the
         // post-election inactivity check keeps the short recovery window.
-        self.conversation.exit_recovery_mode();
-        let resumed_from_reelection =
-            if self.conversation.current_state() == ConversationState::Reelection {
-                Some(self.start_working())
-            } else {
-                None
-            };
+        self.core.exit_recovery_mode();
+        let resumed_from_reelection = if self.core.current_state() == ConversationState::Reelection
+        {
+            Some(self.start_working())
+        } else {
+            None
+        };
         self.emit_phase_change(resumed_from_reelection);
         info!(
             conversation = %self.conversation_id,
@@ -203,10 +194,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Bump the retry round and re-run the election, or escalate to a
     /// `Deadlock` emergency proposal once retries are exhausted.
-    fn handle_election_rejected(&mut self) -> Result<(), SessionError> {
-        self.conversation.steward_list.bump_retry();
-        let round = self.conversation.steward_list.next_retry_round();
-        let max = self.conversation.steward_list.max_retries();
+    fn handle_election_rejected(&mut self) -> Result<(), ConversationError> {
+        self.core.steward_list.bump_retry();
+        let round = self.core.steward_list.next_retry_round();
+        let max = self.core.steward_list.max_retries();
         if round > max {
             info!(
                 conversation = %self.conversation_id,
@@ -214,7 +205,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             );
             if let Err(e) = self.initiate_deadlock_ecp() {
                 error!(conversation = %self.conversation_id, error = %e, "Deadlock ECP filing failed");
-                self.emit_event(SessionEvent::Error {
+                self.emit_event(ConversationEvent::Error {
                     operation: "Reelection stuck".to_string(),
                     message: e.to_string(),
                 });
@@ -241,20 +232,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         proposal_id: u32,
         request: &ConversationUpdateRequest,
         score_ops: &[ScoreOp],
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ConversationError> {
         // The threshold-cross flag is dropped: the terminal
         // `check_and_initiate_score_removals` sweep below covers it.
-        let _ = self.conversation.scoring.apply_ops(score_ops);
+        let _ = self.core.scoring.apply_ops(score_ops);
         if let Some(conversation_update_request::Payload::EmergencyCriteria(ec)) = &request.payload
             && let Some(ev) = &ec.evidence
         {
-            self.conversation
+            self.core
                 .queues
                 .remove_pending_removal(&ev.target_member_id);
         }
 
-        self.conversation.queues.remove_emergency(proposal_id);
-        let resumed_event = if self.conversation.current_state() == ConversationState::Reelection {
+        self.core.queues.remove_emergency(proposal_id);
+        let resumed_event = if self.core.current_state() == ConversationState::Reelection {
             Some(self.start_working())
         } else {
             None

--- a/src/session/consensus/voting.rs
+++ b/src/session/consensus/voting.rs
@@ -10,13 +10,13 @@ use tracing::info;
 
 use crate::{
     core::{
-        ConsensusPlugin, ConversationPluginsFactory, ProposalKind, SessionEvent,
+        ConsensusPlugin, ConversationEvent, ConversationPluginsFactory, ProposalKind,
         SyncConsensusReceiver, self_leave_proposal_id,
     },
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::{AppMessage, ConversationUpdateRequest},
     session::{
-        ConversationState, SessionError, SessionRunner,
+        Conversation, ConversationError, ConversationState,
         consensus::bridge::{
             ProposalParams, cast_vote, submit_proposal, submit_self_leave_proposal,
         },
@@ -38,7 +38,7 @@ pub enum CreatorVote {
     Deferred,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     // ── Public API ───────────────────────────────────────────────────
 
     /// Open a consensus vote for `request`; [`CreatorVote`] picks the wire
@@ -56,13 +56,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         &mut self,
         request: ConversationUpdateRequest,
         creator_vote: CreatorVote,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ConversationError> {
         let kind = ProposalKind::of(&request);
         let expected_voters = self.check_proposal_allowed(kind)?;
 
-        let liveness_criteria_yes = self.conversation.config.liveness_criteria_yes;
-        let consensus_timeout = self.conversation.config.consensus_timeout;
-        let voting_delay = self.conversation.config.voting_delay_for(kind);
+        let liveness_criteria_yes = self.core.config.liveness_criteria_yes;
+        let consensus_timeout = self.core.config.consensus_timeout;
+        let voting_delay = self.core.config.voting_delay_for(kind);
 
         let (proposal_id, unbundled) = submit_proposal::<P>(
             &self.conversation_id,
@@ -71,17 +71,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             &self.consensus,
             ProposalParams {
                 expected_voters,
-                proposal_expiration: self.conversation.config.proposal_expiration,
+                proposal_expiration: self.core.config.proposal_expiration,
                 consensus_timeout,
                 liveness_criteria_yes,
             },
         )?;
 
-        self.conversation
+        self.core
             .queues
             .insert_voting_proposal(proposal_id, request.clone());
         if kind.is_emergency() {
-            self.conversation.queues.insert_emergency(proposal_id);
+            self.core.queues.insert_emergency(proposal_id);
         }
         // Removed again by `apply_consensus_outcome` if an outcome lands
         // before the deadline fires.
@@ -103,23 +103,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     "YES vote cast (bundled at submit)"
                 );
                 let outbound: AppMessage = proposal.into();
-                let payload = self
-                    .conversation
-                    .expect_mls_mut()?
-                    .build_message(&outbound)?;
+                let payload = self.core.expect_mls_mut()?.build_message(&outbound)?;
                 self.broadcast(payload);
-                self.emit_event(SessionEvent::OwnProposalSubmitted {
+                self.emit_event(ConversationEvent::OwnProposalSubmitted {
                     proposal_id,
                     request,
                 });
             }
             CreatorVote::Deferred => {
-                let payload = self
-                    .conversation
-                    .expect_mls_mut()?
-                    .build_message(&unbundled)?;
+                let payload = self.core.expect_mls_mut()?.build_message(&unbundled)?;
                 self.broadcast(payload);
-                self.emit_event(SessionEvent::VoteRequested {
+                self.emit_event(ConversationEvent::VoteRequested {
                     proposal_id,
                     request,
                 });
@@ -134,10 +128,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// manual choice wins. Blocked while an epoch rotation is in flight
     /// (`Freezing`/`Selection`) — the encrypted vote might not decrypt on
     /// peers that already merged the next commit.
-    pub fn vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), SessionError> {
-        let state = self.conversation.current_state();
+    pub fn vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), ConversationError> {
+        let state = self.core.current_state();
         if state == ConversationState::Freezing || state == ConversationState::Selection {
-            return Err(SessionError::ConversationBlocked(state.to_string()));
+            return Err(ConversationError::ConversationBlocked(state.to_string()));
         }
         self.cancel_auto_vote(proposal_id);
         self.broadcast_vote(proposal_id, vote)
@@ -207,12 +201,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Safe to repeat: the pending-leave check catches local duplicates,
     /// and the deterministic [`self_leave_proposal_id`] dedupes
     /// retransmits inside the consensus library.
-    pub(crate) fn initiate_self_leave(&mut self) -> Result<(), SessionError> {
-        if self
-            .conversation
-            .queues
-            .is_pending_self_leave(&self.self_member_id)
-        {
+    pub(crate) fn initiate_self_leave(&mut self) -> Result<(), ConversationError> {
+        if self.core.queues.is_pending_self_leave(&self.self_member_id) {
             info!(
                 conversation = %self.conversation_id,
                 "self-leave already in flight, ignoring duplicate"
@@ -226,7 +216,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Ownership must be recorded before the session opens: the bundled
         // YES fires `ConsensusReached` synchronously, and the outcome
         // handler needs `is_owner_of_proposal` to already be true.
-        self.conversation
+        self.core
             .queues
             .insert_voting_proposal(proposal_id, request.clone());
 
@@ -236,8 +226,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             &self.consensus,
             ProposalParams {
                 expected_voters: 1,
-                proposal_expiration: self.conversation.config.proposal_expiration,
-                consensus_timeout: self.conversation.config.consensus_timeout,
+                proposal_expiration: self.core.config.proposal_expiration,
+                consensus_timeout: self.core.config.consensus_timeout,
                 liveness_criteria_yes: true,
             },
         )?;
@@ -248,10 +238,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             return Ok(());
         };
 
-        let payload = self
-            .conversation
-            .expect_mls_mut()?
-            .build_message(&app_msg)?;
+        let payload = self.core.expect_mls_mut()?.build_message(&app_msg)?;
         self.broadcast(payload);
         Ok(())
     }
@@ -262,29 +249,29 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// voter count (the full member set). During `Reelection` only
     /// emergency and election proposals pass; an active emergency
     /// partial-freezes everything below its priority.
-    fn check_proposal_allowed(&self, kind: ProposalKind) -> Result<u32, SessionError> {
-        let state = self.conversation.current_state();
+    fn check_proposal_allowed(&self, kind: ProposalKind) -> Result<u32, ConversationError> {
+        let state = self.core.current_state();
 
         match state {
             ConversationState::Reelection => {
                 if !kind.is_emergency() && !kind.is_steward_election() {
-                    return Err(SessionError::ConversationBlocked(state.to_string()));
+                    return Err(ConversationError::ConversationBlocked(state.to_string()));
                 }
-                if self.conversation.queues.partial_freeze_blocks(kind) {
-                    return Err(SessionError::PartialFreeze);
+                if self.core.queues.partial_freeze_blocks(kind) {
+                    return Err(ConversationError::PartialFreeze);
                 }
             }
             ConversationState::Freezing | ConversationState::Selection => {
-                return Err(SessionError::ConversationBlocked(state.to_string()));
+                return Err(ConversationError::ConversationBlocked(state.to_string()));
             }
             _ => {
-                if self.conversation.queues.partial_freeze_blocks(kind) {
-                    return Err(SessionError::PartialFreeze);
+                if self.core.queues.partial_freeze_blocks(kind) {
+                    return Err(ConversationError::PartialFreeze);
                 }
             }
         }
 
-        let members = self.conversation.expect_mls()?.members()?;
+        let members = self.core.expect_mls()?.members()?;
         Ok(members.len() as u32)
     }
 
@@ -307,10 +294,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         match self.consensus.handle_consensus_timeout(&scope, proposal_id) {
             Ok(_) => {}
             Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
-                let resolved_locally = self
-                    .conversation
-                    .queues
-                    .is_consensus_outcome_applied(proposal_id);
+                let resolved_locally = self.core.queues.is_consensus_outcome_applied(proposal_id);
                 if resolved_locally {
                     tracing::debug!(
                         conversation = %self.conversation_id,
@@ -334,13 +318,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Cast a vote in the local session, encrypt the Vote-only wire
     /// message, and buffer it for broadcast. Manual votes and the auto-vote
     /// timer share this path; the consensus library can't tell them apart.
-    fn broadcast_vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), SessionError> {
+    fn broadcast_vote(&mut self, proposal_id: u32, vote: bool) -> Result<(), ConversationError> {
         let app_message =
             cast_vote::<P>(&self.conversation_id, proposal_id, vote, &self.consensus)?;
-        let payload = self
-            .conversation
-            .expect_mls_mut()?
-            .build_message(&app_message)?;
+        let payload = self.core.expect_mls_mut()?.build_message(&app_message)?;
         self.broadcast(payload);
         Ok(())
     }

--- a/src/session/construct.rs
+++ b/src/session/construct.rs
@@ -1,11 +1,11 @@
-//! Standalone construction of a [`SessionRunner`] from a [`ConversationDeps`]
+//! Standalone construction of a [`Conversation`] from a [`ConversationDeps`]
 //! bundle — no `User` required.
 //!
 //! [`ConversationDeps`] gathers everything a single conversation needs:
 //! the shared plug-in factory (borrowed — one serves every conversation an
 //! integrator runs), a ready consensus service, the identity, and the
-//! per-conversation configs. [`SessionRunner::create`] and
-//! [`SessionRunner::join`] consume one bundle and return a runner ready to
+//! per-conversation configs. [`Conversation::create`] and
+//! [`Conversation::join`] consume one bundle and return a conversation ready to
 //! drop into a registry.
 
 use std::sync::Arc;
@@ -15,12 +15,12 @@ use tracing::info;
 
 use crate::{
     core::{
-        ConsensusPlugin, ConsensusServiceFor, ConversationConfig, ConversationPluginsFactory,
-        ConversationQueues, ConversationStateMachine, PeerScoringPlugin, ScoringConfig,
-        SessionEvent, StewardListConfig, StewardListPlugin,
+        ConsensusPlugin, ConsensusServiceFor, ConversationConfig, ConversationEvent,
+        ConversationPluginsFactory, ConversationQueues, ConversationStateMachine,
+        PeerScoringPlugin, ScoringConfig, StewardListConfig, StewardListPlugin,
     },
     member_id::MemberId,
-    session::{ConversationState, PhaseTimer, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState, PhaseTimer},
 };
 
 /// Everything one conversation needs to come into being.
@@ -33,11 +33,11 @@ use crate::{
 pub struct ConversationDeps<'a, P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     /// Builds the per-conversation MLS / scoring / steward plug-ins.
     pub plugins: &'a CP,
-    /// This conversation's consensus service, ready to use. The runner
+    /// This conversation's consensus service, ready to use. The conversation
     /// subscribes to its event bus at construction.
     pub consensus: ConsensusServiceFor<P>,
     /// Local participant identity; the constructor snapshots its bytes
-    /// and display form onto the runner.
+    /// and display form onto the conversation.
     pub identity: &'a dyn MemberId,
     /// Per-instance UUID stamped on every outbound packet for echo dedup.
     pub app_id: Arc<[u8]>,
@@ -49,24 +49,23 @@ pub struct ConversationDeps<'a, P: ConsensusPlugin, CP: ConversationPluginsFacto
     pub steward_list_config: StewardListConfig,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
-    /// Build a runner for a brand-new conversation we create and steward.
-    /// Starts in `Working` with the local member installed as sole steward
-    /// at epoch 0.
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
+    /// Create a brand-new conversation we steward. Starts in `Working` with
+    /// the local member installed as sole steward at epoch 0.
     pub fn create(
         conversation_id: &str,
         deps: ConversationDeps<P, CP>,
-    ) -> Result<Self, SessionError> {
+    ) -> Result<Self, ConversationError> {
         Self::build(conversation_id, deps, true)
     }
 
-    /// Build a runner that joins an existing conversation. Starts in
-    /// `PendingJoin` with no MLS state; the steward list and scoring fill in
-    /// once the welcome and `ConversationSync` arrive.
+    /// Join an existing conversation. Starts in `PendingJoin` with no MLS
+    /// state; the steward list and scoring fill in once the welcome and
+    /// `ConversationSync` arrive.
     pub fn join(
         conversation_id: &str,
         deps: ConversationDeps<P, CP>,
-    ) -> Result<Self, SessionError> {
+    ) -> Result<Self, ConversationError> {
         Self::build(conversation_id, deps, false)
     }
 
@@ -75,7 +74,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         conversation_id: &str,
         deps: ConversationDeps<P, CP>,
         is_creation: bool,
-    ) -> Result<Self, SessionError> {
+    ) -> Result<Self, ConversationError> {
         let self_member_id_bytes = deps.identity.member_id_bytes().to_vec();
 
         let (queues, mls_opt, state_machine, phase_timer) = if is_creation {
@@ -128,7 +127,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
         let consensus = deps.consensus;
         let consensus_rx = consensus.event_bus().subscribe();
-        let runner = SessionRunner::new(
+        let conversation = Conversation::new(
             conversation_id.to_string(),
             queues,
             mls_opt,
@@ -143,9 +142,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             Arc::from(deps.identity.member_id_display()),
             deps.app_id,
         );
-        // Surface the opening phase so a caller draining session events sees
+        // Surface the opening phase so a caller draining conversation events sees
         // the conversation's starting state without a separate query.
-        runner.emit_event(SessionEvent::PhaseChange(initial_state));
-        Ok(runner)
+        conversation.emit_event(ConversationEvent::PhaseChange(initial_state));
+        Ok(conversation)
     }
 }

--- a/src/session/conversation.rs
+++ b/src/session/conversation.rs
@@ -1,8 +1,8 @@
-//! [`SessionRunner`] struct, constructor, and the state-machine + phase-timer
-//! coordinators that compose [`crate::core::Conversation`] with
+//! [`Conversation`] struct, constructor, and the state-machine + phase-timer
+//! coordinators that compose [`crate::core::ConversationCore`] with
 //! [`crate::session::PhaseTimer`] under one lock. Per-conversation method
 //! bodies (proposal submission, voting, inbound dispatch, etc.) live in
-//! sibling modules and extend `SessionRunner` via additional `impl` blocks.
+//! sibling modules and extend `Conversation` via additional `impl` blocks.
 
 use std::{
     collections::HashMap,
@@ -16,25 +16,25 @@ use hashgraph_like_consensus::events::ConsensusEventBus;
 
 use crate::{
     core::{
-        ConsensusPlugin, ConsensusServiceFor, Conversation, ConversationConfig,
-        ConversationPluginsFactory, ConversationQueues, ConversationState,
-        ConversationStateMachine, SessionEvent,
+        ConsensusPlugin, ConsensusServiceFor, ConversationConfig, ConversationCore,
+        ConversationEvent, ConversationPluginsFactory, ConversationQueues, ConversationState,
+        ConversationStateMachine,
     },
-    session::{Outbound, PhaseTimer, SessionError},
+    session::{ConversationError, Outbound, PhaseTimer},
 };
 
-/// Outcome of [`SessionRunner::leave`].
+/// Outcome of [`Conversation::leave`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LeaveOutcome {
     /// `PendingJoin` path: local teardown complete. The integrator must remove
     /// the registry entry and clean up the consensus scope.
     TornDown,
-    /// Active-session path: a self-leave consensus round has been opened. The
-    /// session stays active until the next steward commit merges the removal.
+    /// Active-conversation path: a self-leave consensus round has been opened. The
+    /// conversation stays active until the next steward commit merges the removal.
     LeaveInitiated,
 }
 
-/// Receiver type the runner drains from `tick_deadlines`. Resolves to the
+/// Receiver type the conversation drains from `tick_deadlines`. Resolves to the
 /// `Receiver` associated type on the plugin's [`ConsensusEventBus`], which
 /// is bound to implement [`crate::core::SyncConsensusReceiver`].
 pub(crate) type ConsensusReceiver<P> = <<P as ConsensusPlugin>::EventBus as ConsensusEventBus<
@@ -44,29 +44,29 @@ pub(crate) type ConsensusReceiver<P> = <<P as ConsensusPlugin>::EventBus as Cons
 /// One pending auto-vote: cast `vote` for `proposal_id` once the wall-clock
 /// catches up to `fire_at`. Registered by `initiate_proposal` (Deferred
 /// path) and `on_incoming_proposal`; cancelled on manual vote or consensus
-/// resolution; fired by [`SessionRunner::tick_deadlines`].
+/// resolution; fired by [`Conversation::tick_deadlines`].
 #[derive(Debug, Clone, Copy)]
 pub struct AutoVoteEntry {
     pub fire_at: Instant,
     pub vote: bool,
 }
 
-pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
-    /// Conversation name. Identifies this session in the integrator's
+pub struct Conversation<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
+    /// Conversation name. Identifies this conversation in the integrator's
     /// registry and is used to construct scope keys for consensus operations.
-    /// Read via [`SessionRunner::conversation_id`].
+    /// Read via [`Conversation::conversation_id`].
     pub(crate) conversation_id: String,
-    pub(crate) conversation: Conversation<CP>,
+    pub(crate) core: ConversationCore<CP>,
     /// Per-conversation consensus service. Owns this conversation's scope
     /// in the shared storage and a private event bus. Minted from the
-    /// [`crate::session::ConversationDeps`] consensus context at construction.
+    /// [`crate::session::ConversationDeps`] consensus service at construction.
     pub(crate) consensus: ConsensusServiceFor<P>,
     /// Subscriber on `consensus.event_bus()`. Drained by
     /// `tick_deadlines`, which dispatches each event through
-    /// `apply_consensus_outcome`. Subscribed when the runner is built in
-    /// [`SessionRunner::create`] / [`SessionRunner::join`].
+    /// `apply_consensus_outcome`. Subscribed when the conversation is built in
+    /// [`Conversation::create`] / [`Conversation::join`].
     pub(crate) consensus_rx: ConsensusReceiver<P>,
-    /// Wall-clock anchor combined with `conversation.state_machine` by
+    /// Wall-clock anchor combined with `core.state_machine` by
     /// coordinator methods.
     phase_timer: PhaseTimer,
     /// Pending auto-votes by `proposal_id`. Walked by
@@ -77,30 +77,30 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     /// Pending consensus-session timeouts: `proposal_id -> fire_at`.
     /// Registered when a proposal opens (own or incoming peer); fired by
     /// `tick_deadlines` which calls `consensus.handle_consensus_timeout`.
-    /// Removed when the session resolves naturally via `apply_consensus_outcome`.
+    /// Removed when the consensus session resolves naturally via `apply_consensus_outcome`.
     pub(crate) pending_consensus_timeouts: HashMap<u32, Instant>,
     /// Identity bytes of the local member, derived from the integrator's
-    /// [`crate::member_id::MemberId`] at session construction. Read via
-    /// [`SessionRunner::member_id_bytes`].
+    /// [`crate::member_id::MemberId`] at construction. Read via
+    /// [`Conversation::member_id_bytes`].
     pub(crate) self_member_id: Arc<[u8]>,
-    /// Display form of the local member id, derived at session construction.
+    /// Display form of the local member id, derived at construction.
     /// `Arc<str>` for the same reason as `self_member_id` — cheap clone
-    /// across guard boundaries. Read via [`SessionRunner::member_id_display`].
+    /// across guard boundaries. Read via [`Conversation::member_id_display`].
     pub(crate) member_id_display: Arc<str>,
     /// Per-instance app id supplied at construction. Tagged on every
     /// outbound packet and used for self-echo filtering in
-    /// [`SessionRunner::process_inbound`]. Read via [`SessionRunner::app_id`].
+    /// [`Conversation::process_inbound`]. Read via [`Conversation::app_id`].
     pub(crate) app_id: Arc<[u8]>,
-    /// Pending [`SessionEvent`]s waiting for a caller to drain. Interior
+    /// Pending [`ConversationEvent`]s waiting for a caller to drain. Interior
     /// `Mutex` so producer-side `emit_event` stays `&self`; consumers
     /// drain via [`Self::drain_events`] once per polling cycle.
-    pending_events: Mutex<Vec<SessionEvent>>,
+    pending_events: Mutex<Vec<ConversationEvent>>,
     /// Outbound the conversation produced, waiting for the integrator to
-    /// publish. The session never sends — it buffers here and the caller
+    /// publish. The conversation never sends — it buffers here and the caller
     /// drains via [`Self::drain_outbound`] once per cycle. Interior `Mutex`
     /// so producer-side `broadcast` stays `&self`.
     pending_outbound: Mutex<Vec<Outbound>>,
-    /// Last freeze-progress snapshot emitted as `SessionEvent::FreezeProgress`.
+    /// Last freeze-progress snapshot emitted as `ConversationEvent::FreezeProgress`.
     /// `poll()` compares the current `(received, expected)` against this and
     /// emits a new event only when the count changes, avoiding repeated events
     /// on consecutive polling ticks that observe the same progress. Reset to
@@ -108,15 +108,15 @@ pub struct SessionRunner<P: ConsensusPlugin, CP: ConversationPluginsFactory> {
     pub(crate) last_freeze_progress: Option<(usize, usize)>,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
-    /// Build a fresh runner. Creator path passes `Some(mls)`; joiner
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
+    /// Build a fresh conversation. Creator path passes `Some(mls)`; joiner
     /// path passes `None` and attaches the MLS service later via
-    /// `conversation.attach_mls`. `consensus_rx` is a subscriber on
+    /// `core.attach_mls`. `consensus_rx` is a subscriber on
     /// `consensus.event_bus()`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         conversation_id: String,
-        conversation: ConversationQueues,
+        queues: ConversationQueues,
         mls: Option<CP::Mls>,
         state_machine: ConversationStateMachine,
         phase_timer: PhaseTimer,
@@ -131,14 +131,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     ) -> Self {
         Self {
             conversation_id,
-            conversation: Conversation::new(
-                conversation,
-                mls,
-                state_machine,
-                config,
-                scoring,
-                steward_list,
-            ),
+            core: ConversationCore::new(queues, mls, state_machine, config, scoring, steward_list),
             consensus,
             consensus_rx,
             phase_timer,
@@ -153,29 +146,29 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
     }
 
-    /// Append a [`SessionEvent`] to the pending-events buffer. The caller's
+    /// Append a [`ConversationEvent`] to the pending-events buffer. The caller's
     /// polling cycle drains it via [`Self::drain_events`]. Stays `&self`
-    /// thanks to the interior [`Mutex`], so the many session-coordinator
+    /// thanks to the interior [`Mutex`], so the many coordinator
     /// methods that emit during a brief read guard don't need to escalate
     /// to a write guard. Fire-and-forget (no `Result`), but a poisoned
     /// buffer is logged rather than silently dropped.
-    pub(crate) fn emit_event(&self, event: SessionEvent) {
+    pub(crate) fn emit_event(&self, event: ConversationEvent) {
         match self.pending_events.lock() {
             Ok(mut buf) => buf.push(event),
             Err(_) => {
-                tracing::error!(?event, "session-event buffer mutex poisoned; event dropped")
+                tracing::error!(?event, "event buffer mutex poisoned; event dropped")
             }
         }
     }
 
-    /// Drain every pending [`SessionEvent`] accumulated since the last
+    /// Drain every pending [`ConversationEvent`] accumulated since the last
     /// call. Returns events in insertion order. Callers (UI fanout,
     /// audit log) invoke this once per polling cycle.
-    pub fn drain_events(&self) -> Vec<SessionEvent> {
+    pub fn drain_events(&self) -> Vec<ConversationEvent> {
         match self.pending_events.lock() {
             Ok(mut buf) => std::mem::take(&mut *buf),
             Err(_) => {
-                tracing::error!("session-event buffer mutex poisoned; UI fanout will miss events");
+                tracing::error!("event buffer mutex poisoned; UI fanout will miss events");
                 Vec::new()
             }
         }
@@ -201,22 +194,22 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     /// State-driven phase-timer deadline, if one is currently active. The
-    /// session's polling paths (the freeze and pending-join steps in
+    /// conversation's polling paths (the freeze and pending-join steps in
     /// `poll`, and the inactivity check in
     /// `check_steward_inactivity`) all gate on the phase timer; this
     /// surfaces the same wall-clock target so an external scheduler can
     /// wake us at the right time.
     fn phase_deadline(&self) -> Option<Instant> {
         let anchor = self.phase_timer.started_at()?;
-        let cfg = &self.conversation.config;
-        match self.conversation.current_state() {
+        let cfg = &self.core.config;
+        match self.core.current_state() {
             ConversationState::Freezing => Some(anchor + cfg.freeze_duration),
             ConversationState::PendingJoin => Some(anchor + cfg.commit_inactivity_duration * 3),
             ConversationState::Working => {
-                if self.conversation.queues.approved_proposals_count() == 0 {
+                if self.core.queues.approved_proposals_count() == 0 {
                     return None;
                 }
-                let dur = if self.conversation.is_in_recovery_mode() {
+                let dur = if self.core.is_in_recovery_mode() {
                     cfg.recovery_inactivity_duration
                 } else {
                     cfg.commit_inactivity_duration
@@ -230,7 +223,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Buffer encrypted conversation traffic (chat, votes, sync, commit
     /// candidates) as an [`Outbound`], stamped with this conversation and the
     /// local sender. Stays `&self` thanks to the interior `Mutex`, so send
-    /// sites in `&self` methods don't escalate to a write guard. The session
+    /// sites in `&self` methods don't escalate to a write guard. The conversation
     /// never sends — the caller drains via [`Self::drain_outbound`].
     pub(crate) fn broadcast(&self, payload: Vec<u8>) {
         let out = Outbound {
@@ -282,7 +275,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         self.pending_auto_votes.remove(&proposal_id);
     }
 
-    /// Drop every pending auto-vote on this runner. Called on every path that
+    /// Drop every pending auto-vote on this conversation. Called on every path that
     /// emits `Leaving` so no stale entries fire against a conversation we've
     /// left.
     pub(crate) fn cancel_all_auto_votes(&mut self) {
@@ -295,9 +288,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// entry and clean up the consensus scope. In all other states, opens a
     /// self-leave consensus round and returns [`LeaveOutcome::LeaveInitiated`];
     /// the leave completes when the next steward commit merges the removal.
-    pub fn leave(&mut self) -> Result<LeaveOutcome, SessionError> {
-        if self.conversation.current_state() == ConversationState::PendingJoin {
-            self.emit_event(SessionEvent::Leaving);
+    pub fn leave(&mut self) -> Result<LeaveOutcome, ConversationError> {
+        if self.core.current_state() == ConversationState::PendingJoin {
+            self.emit_event(ConversationEvent::Leaving);
             self.cancel_all_auto_votes();
             return Ok(LeaveOutcome::TornDown);
         }
@@ -315,7 +308,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Drop the pending consensus timeout for `proposal_id`. Called from
     /// `apply_consensus_outcome` once the library reaches/fails consensus,
     /// so the timeout can't fire a stale `handle_consensus_timeout` against
-    /// an already-resolved session.
+    /// an already-resolved consensus session.
     pub(crate) fn unregister_consensus_timeout(&mut self, proposal_id: u32) {
         self.pending_consensus_timeouts.remove(&proposal_id);
     }
@@ -323,7 +316,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     // ── State-machine + phase-timer coordinators ────────────────────
 
     pub(crate) fn start_working(&mut self) -> ConversationState {
-        self.conversation.state_machine.start_working();
+        self.core.state_machine.start_working();
         self.phase_timer.clear();
         info!(state = "Working", "state transition");
         ConversationState::Working
@@ -333,7 +326,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// phase timer. Returns `Some(Freezing)` on transition; `None` (no-op)
     /// from any other state.
     pub(crate) fn start_freezing(&mut self) -> Option<ConversationState> {
-        if self.conversation.state_machine.start_freezing() {
+        if self.core.state_machine.start_freezing() {
             self.phase_timer.start();
             info!(state = "Freezing", "state transition");
             Some(ConversationState::Freezing)
@@ -343,13 +336,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     pub(crate) fn start_selection(&mut self) -> ConversationState {
-        self.conversation.state_machine.start_selection();
+        self.core.state_machine.start_selection();
         info!(state = "Selection", "state transition");
         ConversationState::Selection
     }
 
     pub(crate) fn start_reelection(&mut self) -> ConversationState {
-        self.conversation.state_machine.start_reelection();
+        self.core.state_machine.start_reelection();
         self.phase_timer.clear();
         info!(state = "Reelection", "state transition");
         ConversationState::Reelection
@@ -358,18 +351,18 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// `true` once 3× `commit_inactivity_duration` has passed in
     /// `PendingJoin` without a welcome.
     pub(crate) fn is_pending_join_expired(&self) -> bool {
-        self.conversation.current_state() == ConversationState::PendingJoin
+        self.core.current_state() == ConversationState::PendingJoin
             && self
                 .phase_timer
-                .elapsed_since_anchor(self.conversation.config.commit_inactivity_duration * 3)
+                .elapsed_since_anchor(self.core.config.commit_inactivity_duration * 3)
     }
 
     /// `true` once the freeze window elapsed while in `Freezing`.
     pub(crate) fn is_freeze_timed_out(&self) -> bool {
-        self.conversation.current_state() == ConversationState::Freezing
+        self.core.current_state() == ConversationState::Freezing
             && self
                 .phase_timer
-                .elapsed_since_anchor(self.conversation.config.freeze_duration)
+                .elapsed_since_anchor(self.core.config.freeze_duration)
     }
 
     /// Drives the "steward waited too long to commit" transition into
@@ -382,8 +375,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         approved_proposals_count: usize,
         inactivity_duration: Duration,
     ) -> Option<ConversationState> {
-        if self.conversation.current_state() != ConversationState::Working
-            || approved_proposals_count == 0
+        if self.core.current_state() != ConversationState::Working || approved_proposals_count == 0
         {
             return None;
         }
@@ -419,15 +411,15 @@ mod tests {
         StubPluginsFactory, StubScoring, StubStewardList, UnusedMls, make_test_consensus_service,
     };
 
-    fn make_runner_pending_join(
+    fn make_conversation_pending_join(
         commit_inactivity: Duration,
-    ) -> SessionRunner<DefaultConsensusPlugin, StubPluginsFactory> {
+    ) -> Conversation<DefaultConsensusPlugin, StubPluginsFactory> {
         let config = ConversationConfig {
             commit_inactivity_duration: commit_inactivity,
             ..ConversationConfig::default()
         };
         let (consensus, consensus_rx) = make_test_consensus_service();
-        let mut runner = SessionRunner::new(
+        let mut conversation = Conversation::new(
             "g".to_string(),
             ConversationQueues::new("g"),
             Some(UnusedMls),
@@ -442,13 +434,13 @@ mod tests {
             Arc::from("0xtest-display"),
             Arc::from(&[0u8; 16][..]),
         );
-        runner.phase_timer.start();
-        runner
+        conversation.phase_timer.start();
+        conversation
     }
 
-    fn make_runner_working() -> SessionRunner<DefaultConsensusPlugin, StubPluginsFactory> {
+    fn make_conversation_working() -> Conversation<DefaultConsensusPlugin, StubPluginsFactory> {
         let (consensus, consensus_rx) = make_test_consensus_service();
-        SessionRunner::new(
+        Conversation::new(
             "g".to_string(),
             ConversationQueues::new("g"),
             Some(UnusedMls),
@@ -471,28 +463,28 @@ mod tests {
     #[test]
     fn pending_join_expires_after_three_times_commit_inactivity() {
         let inactivity = Duration::from_millis(50);
-        let mut runner = make_runner_pending_join(inactivity);
+        let mut conversation = make_conversation_pending_join(inactivity);
 
         assert!(
-            !runner.is_pending_join_expired(),
+            !conversation.is_pending_join_expired(),
             "fresh anchor must not be expired"
         );
 
         // Just inside the window: anchor 2.5× inactivity in the past.
-        runner
+        conversation
             .phase_timer
             .set_started_at_for_test(Some(Instant::now() - inactivity * 5 / 2));
         assert!(
-            !runner.is_pending_join_expired(),
+            !conversation.is_pending_join_expired(),
             "before 3× boundary must not be expired"
         );
 
         // Past the boundary: anchor 4× inactivity in the past.
-        runner
+        conversation
             .phase_timer
             .set_started_at_for_test(Some(Instant::now() - inactivity * 4));
         assert!(
-            runner.is_pending_join_expired(),
+            conversation.is_pending_join_expired(),
             "past 3× boundary must be expired"
         );
     }
@@ -501,12 +493,12 @@ mod tests {
     /// regardless of how old the anchor is.
     #[test]
     fn pending_join_expired_only_in_pending_join_state() {
-        let mut runner = make_runner_working();
-        runner
+        let mut conversation = make_conversation_working();
+        conversation
             .phase_timer
             .set_started_at_for_test(Some(Instant::now() - Duration::from_secs(3600)));
         assert!(
-            !runner.is_pending_join_expired(),
+            !conversation.is_pending_join_expired(),
             "Working state must never report pending-join-expired"
         );
     }
@@ -515,32 +507,32 @@ mod tests {
     /// Second tick before timeout still returns `None`. State must remain Working.
     #[test]
     fn check_steward_inactivity_first_tick_anchors_and_returns_none() {
-        let mut runner = make_runner_working();
+        let mut conversation = make_conversation_working();
         assert_eq!(
-            runner.conversation.current_state(),
+            conversation.core.current_state(),
             ConversationState::Working
         );
         assert!(
-            runner.phase_timer.started_at().is_none(),
-            "fresh runner has no anchor"
+            conversation.phase_timer.started_at().is_none(),
+            "fresh conversation has no anchor"
         );
 
         let result =
-            runner.check_steward_inactivity(/* approved */ 1, Duration::from_secs(10));
+            conversation.check_steward_inactivity(/* approved */ 1, Duration::from_secs(10));
 
         assert_eq!(result, None, "first tick auto-anchors and returns None");
         assert!(
-            runner.phase_timer.started_at().is_some(),
+            conversation.phase_timer.started_at().is_some(),
             "anchor must be set after first tick"
         );
         assert_eq!(
-            runner.conversation.current_state(),
+            conversation.core.current_state(),
             ConversationState::Working,
             "state must stay Working until inactivity actually elapses"
         );
 
         let result =
-            runner.check_steward_inactivity(/* approved */ 1, Duration::from_secs(10));
+            conversation.check_steward_inactivity(/* approved */ 1, Duration::from_secs(10));
         assert_eq!(
             result, None,
             "second tick before timeout still returns None"
@@ -550,11 +542,11 @@ mod tests {
     /// No approved work → no anchor started, no transition.
     #[test]
     fn check_steward_inactivity_noop_without_approved_work() {
-        let mut runner = make_runner_working();
-        let result = runner.check_steward_inactivity(0, Duration::from_secs(10));
+        let mut conversation = make_conversation_working();
+        let result = conversation.check_steward_inactivity(0, Duration::from_secs(10));
         assert_eq!(result, None);
         assert!(
-            runner.phase_timer.started_at().is_none(),
+            conversation.phase_timer.started_at().is_none(),
             "no approved work must not start the timer"
         );
     }
@@ -566,20 +558,20 @@ mod tests {
     /// up an event log over multiple polling cycles.
     #[test]
     fn emit_event_then_drain_returns_insertion_order_and_clears_buffer() {
-        let runner = make_runner_working();
-        runner.emit_event(SessionEvent::PhaseChange(ConversationState::Working));
-        runner.emit_event(SessionEvent::Leaving);
+        let conversation = make_conversation_working();
+        conversation.emit_event(ConversationEvent::PhaseChange(ConversationState::Working));
+        conversation.emit_event(ConversationEvent::Leaving);
 
-        let drained = runner.drain_events();
+        let drained = conversation.drain_events();
         assert_eq!(drained.len(), 2);
         assert!(matches!(
             drained[0],
-            SessionEvent::PhaseChange(ConversationState::Working)
+            ConversationEvent::PhaseChange(ConversationState::Working)
         ));
-        assert!(matches!(drained[1], SessionEvent::Leaving));
+        assert!(matches!(drained[1], ConversationEvent::Leaving));
 
         // Second drain returns empty — buffer was cleared.
-        assert!(runner.drain_events().is_empty());
+        assert!(conversation.drain_events().is_empty());
     }
 
     /// `register_auto_vote` is idempotent — re-registering the same
@@ -588,16 +580,16 @@ mod tests {
     /// re-submit.
     #[test]
     fn register_auto_vote_replaces_existing_entry() {
-        let mut runner = make_runner_working();
-        runner.register_auto_vote(7, Duration::from_secs(10), true);
-        let first_fire = runner.pending_auto_votes[&7].fire_at;
+        let mut conversation = make_conversation_working();
+        conversation.register_auto_vote(7, Duration::from_secs(10), true);
+        let first_fire = conversation.pending_auto_votes[&7].fire_at;
 
         // Re-register with a different `vote` and a longer delay; the
         // second insert must overwrite, not co-exist.
         std::thread::sleep(Duration::from_millis(2));
-        runner.register_auto_vote(7, Duration::from_secs(20), false);
-        assert_eq!(runner.pending_auto_votes.len(), 1);
-        let entry = runner.pending_auto_votes[&7];
+        conversation.register_auto_vote(7, Duration::from_secs(20), false);
+        assert_eq!(conversation.pending_auto_votes.len(), 1);
+        let entry = conversation.pending_auto_votes[&7];
         assert!(!entry.vote);
         assert!(entry.fire_at > first_fire);
     }
@@ -607,18 +599,18 @@ mod tests {
     /// auto-votes from outside `tick_deadlines`.
     #[test]
     fn cancel_auto_vote_removes_only_the_targeted_proposal() {
-        let mut runner = make_runner_working();
-        runner.register_auto_vote(1, Duration::from_secs(5), true);
-        runner.register_auto_vote(2, Duration::from_secs(5), false);
-        runner.register_auto_vote(3, Duration::from_secs(5), true);
+        let mut conversation = make_conversation_working();
+        conversation.register_auto_vote(1, Duration::from_secs(5), true);
+        conversation.register_auto_vote(2, Duration::from_secs(5), false);
+        conversation.register_auto_vote(3, Duration::from_secs(5), true);
 
-        runner.cancel_auto_vote(2);
-        assert!(runner.pending_auto_votes.contains_key(&1));
-        assert!(!runner.pending_auto_votes.contains_key(&2));
-        assert!(runner.pending_auto_votes.contains_key(&3));
+        conversation.cancel_auto_vote(2);
+        assert!(conversation.pending_auto_votes.contains_key(&1));
+        assert!(!conversation.pending_auto_votes.contains_key(&2));
+        assert!(conversation.pending_auto_votes.contains_key(&3));
 
-        runner.cancel_all_auto_votes();
-        assert!(runner.pending_auto_votes.is_empty());
+        conversation.cancel_all_auto_votes();
+        assert!(conversation.pending_auto_votes.is_empty());
     }
 
     /// `register_consensus_timeout` records `now + delay`;
@@ -627,17 +619,17 @@ mod tests {
     /// so `tick_deadlines` doesn't fire a stale `handle_consensus_timeout`.
     #[test]
     fn register_then_unregister_consensus_timeout() {
-        let mut runner = make_runner_working();
+        let mut conversation = make_conversation_working();
         let before = Instant::now();
-        runner.register_consensus_timeout(42, Duration::from_secs(30));
-        let fire_at = runner.pending_consensus_timeouts[&42];
+        conversation.register_consensus_timeout(42, Duration::from_secs(30));
+        let fire_at = conversation.pending_consensus_timeouts[&42];
         assert!(fire_at > before + Duration::from_secs(29));
         assert!(fire_at < Instant::now() + Duration::from_secs(31));
 
-        runner.unregister_consensus_timeout(42);
-        assert!(!runner.pending_consensus_timeouts.contains_key(&42));
+        conversation.unregister_consensus_timeout(42);
+        assert!(!conversation.pending_consensus_timeouts.contains_key(&42));
 
         // Unregistering an unknown id is a no-op (no panic, no error).
-        runner.unregister_consensus_timeout(999);
+        conversation.unregister_consensus_timeout(999);
     }
 }

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -6,13 +6,13 @@ use hashgraph_like_consensus::error::ConsensusError;
 
 use crate::{core::CoreError, mls_crypto::MlsError};
 
-/// Errors from operations on a single conversation session.
+/// Errors from operations on a single conversation.
 ///
 /// Registry-level failures (conversation lookup, lock poisoning, transport
 /// delivery) are integrator concerns and live in the integrator's own error
 /// type — see the reference `User` in the gateway crate.
 #[derive(Debug, thiserror::Error)]
-pub enum SessionError {
+pub enum ConversationError {
     #[error("Cannot send message: conversation is in {0} state")]
     ConversationBlocked(String),
 

--- a/src/session/inbound.rs
+++ b/src/session/inbound.rs
@@ -1,6 +1,6 @@
 //! Session-side inbound dispatch.
 //!
-//! [`SessionRunner::process_inbound`] is the single entry point for all
+//! [`Conversation::process_inbound`] is the single entry point for all
 //! conversation traffic. It owns echo-dedup, `PendingJoin`-drop, and the
 //! internal `dispatch_inbound_result` chain. `LeaveConversation` is terminal:
 //! `prepare_self_leave` emits `Leaving`, cancels timers, and deletes local MLS
@@ -15,8 +15,8 @@ use tracing::{error, info};
 
 use crate::{
     core::{
-        ConsensusPlugin, ConversationPluginsFactory, PeerScoringPlugin, ProcessResult,
-        ProposalKind, ScoreSnapshot, SessionEvent, StewardList, StewardListConfig,
+        ConsensusPlugin, ConversationEvent, ConversationPluginsFactory, PeerScoringPlugin,
+        ProcessResult, ProposalKind, ScoreSnapshot, StewardList, StewardListConfig,
         StewardListPlugin, member_set,
     },
     mls_crypto::MlsService,
@@ -25,24 +25,25 @@ use crate::{
         TimingConfig, conversation_update_request,
     },
     session::{
-        ConversationState, SessionError, SessionRunner, consensus::bridge::forward_incoming_vote,
+        Conversation, ConversationError, ConversationState,
+        consensus::bridge::forward_incoming_vote,
     },
 };
 
-/// What [`SessionRunner::process_inbound`] hands back to the integrator.
+/// What [`Conversation::process_inbound`] hands back to the integrator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DispatchOutcome {
     /// No further integrator action required.
     Done,
     /// Packet was self-echoed or dropped (no MLS attached yet). No action.
     Dropped,
-    /// The session has completed its protocol-side teardown (emitted
+    /// The conversation has completed its protocol-side teardown (emitted
     /// `Leaving`, deleted MLS state). The integrator must remove the
     /// registry entry and clean up the consensus scope.
     LeaveRequested,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     /// Ingest a joiner's key-package announcement (a [`MemberInvite`]).
     /// Drops self-echoes (`sender == self.app_id`). If the holder isn't
     /// already a member, promotes the invite to a membership-change proposal
@@ -51,13 +52,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         &mut self,
         sender: &[u8],
         payload: &[u8],
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ConversationError> {
         if sender == self.app_id.as_ref() {
             return Ok(());
         }
         let invite = MemberInvite::decode(payload)?;
         let already_member = self
-            .conversation
+            .core
             .mls()
             .map(|m| m.is_member(&invite.member_id))
             .unwrap_or(false);
@@ -82,13 +83,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Decrypt and dispatch an inbound conversation payload. Drops self-echoes
     /// and packets arriving before MLS is attached (`PendingJoin`). Runs the
     /// full dispatch chain internally. Returns [`DispatchOutcome::LeaveRequested`]
-    /// when the session has completed its protocol-side teardown; the integrator
+    /// when the conversation has completed its protocol-side teardown; the integrator
     /// must then remove the registry entry and clean up the consensus scope.
     pub fn process_inbound(
         &mut self,
         sender: &[u8],
         payload: &[u8],
-    ) -> Result<DispatchOutcome, SessionError> {
+    ) -> Result<DispatchOutcome, ConversationError> {
         if sender == self.app_id.as_ref() {
             return Ok(DispatchOutcome::Dropped);
         }
@@ -99,19 +100,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             );
             return Ok(DispatchOutcome::Dropped);
         }
-        let result = self.conversation.process_inbound(payload)?;
+        let result = self.core.process_inbound(payload)?;
         self.dispatch_inbound_result(result)
     }
 
     /// Attach a freshly-built MLS service after a joiner accepts a welcome.
     pub(crate) fn attach_mls(&mut self, mls: CP::Mls) {
-        self.conversation.attach_mls(mls);
+        self.core.attach_mls(mls);
     }
 
     /// Whether this conversation's MLS service is attached. `false` for a
     /// joiner still in `PendingJoin` (no welcome yet).
     pub fn has_mls(&self) -> bool {
-        self.conversation.mls().is_some()
+        self.core.mls().is_some()
     }
 
     /// Complete a join after receiving a welcome. Idempotent: returns
@@ -119,8 +120,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// the MLS service if absent, then dispatches `JoinedConversation`
     /// internally (broadcasts the join message, seeds scoring, transitions to
     /// `Working`).
-    pub fn complete_join(&mut self, mls: CP::Mls) -> Result<(), SessionError> {
-        if self.conversation.current_state() != ConversationState::PendingJoin {
+    pub fn complete_join(&mut self, mls: CP::Mls) -> Result<(), ConversationError> {
+        if self.core.current_state() != ConversationState::PendingJoin {
             return Ok(());
         }
         if !self.has_mls() {
@@ -133,10 +134,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     pub(crate) fn dispatch_inbound_result(
         &mut self,
         result: ProcessResult,
-    ) -> Result<DispatchOutcome, SessionError> {
+    ) -> Result<DispatchOutcome, ConversationError> {
         match result {
             ProcessResult::AppMessage(msg) => {
-                self.emit_event(SessionEvent::AppMessage(*msg));
+                self.emit_event(ConversationEvent::AppMessage(*msg));
                 Ok(DispatchOutcome::Done)
             }
             ProcessResult::Proposal(proposal) => {
@@ -145,7 +146,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
             ProcessResult::Vote(vote) => {
                 let outcome_applied = self
-                    .conversation
+                    .core
                     .queues
                     .is_consensus_outcome_applied(vote.proposal_id);
                 forward_incoming_vote::<P>(
@@ -204,7 +205,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// blocked. We don't drop today — the RFC's Δ-synchrony assumption keeps
     /// divergence windows small. Consensus-service-level priority gating is
     /// tracked as a backlog item in `docs/ROADMAP.md`.
-    fn on_incoming_proposal(&mut self, proposal: Proposal) -> Result<(), SessionError> {
+    fn on_incoming_proposal(&mut self, proposal: Proposal) -> Result<(), ConversationError> {
         let decoded = match ConversationUpdateRequest::decode(proposal.payload.as_slice()) {
             Ok(req) => Some(req),
             Err(e) => {
@@ -217,19 +218,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             }
         };
         if let Some(req) = decoded.as_ref() {
-            let current_epoch = match self.conversation.mls() {
+            let current_epoch = match self.core.mls() {
                 Some(mls) => mls.current_epoch()?,
                 None => 0,
             };
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
-                    self.conversation
-                        .queues
-                        .insert_emergency(proposal.proposal_id);
+                    self.core.queues.insert_emergency(proposal.proposal_id);
                 }
                 Some(conversation_update_request::Payload::MemberInvite(_))
                 | Some(conversation_update_request::Payload::RemoveMember(_)) => {
-                    self.conversation
+                    self.core
                         .queues
                         .insert_pending_update(req.clone(), current_epoch);
                 }
@@ -246,20 +245,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let scope = P::Scope::from(self.conversation_id.clone());
         self.consensus.process_incoming_proposal(&scope, proposal)?;
         // Skip the vote request + auto-vote for fast-path proposals: the
-        // creator's bundled YES already resolved the session, so peers have
+        // creator's bundled YES already resolved the consensus session, so peers have
         // nothing to vote on.
         if expected_voters > 1 {
             // A votable peer proposal always decodes as a
             // `ConversationUpdateRequest`; an opaque payload can't be
             // surfaced for a vote, so only the auto-vote drives it.
             if let Some(request) = decoded {
-                self.emit_event(SessionEvent::VoteRequested {
+                self.emit_event(ConversationEvent::VoteRequested {
                     proposal_id,
                     request,
                 });
             }
-            let delay = self.conversation.config.voting_delay_for(kind);
-            let vote = self.conversation.config.liveness_criteria_yes;
+            let delay = self.core.config.voting_delay_for(kind);
+            let vote = self.core.config.liveness_criteria_yes;
             self.register_auto_vote(proposal_id, delay, vote);
         }
         Ok(())
@@ -268,7 +267,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// We just joined via welcome. Broadcast a system "joined" chat
     /// message, seed scoring with the current member set, and
     /// transition to Working.
-    fn on_joined_conversation(&mut self) -> Result<(), SessionError> {
+    fn on_joined_conversation(&mut self) -> Result<(), ConversationError> {
         let msg: AppMessage = ConversationMessage {
             message: format!("User {} joined the conversation", self.member_id_display)
                 .into_bytes(),
@@ -277,14 +276,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
         .into();
         let conversation_id = self.conversation_id.clone();
-        let mls = self.conversation.expect_mls_mut()?;
+        let mls = self.core.expect_mls_mut()?;
         let mls_members = mls.members().unwrap_or_default();
         let payload = mls.build_message(&msg)?;
         self.broadcast(payload);
         self.sync_scoring_members(&mls_members);
 
         let event = self.start_working();
-        self.emit_event(SessionEvent::PhaseChange(event));
+        self.emit_event(ConversationEvent::PhaseChange(event));
         info!(conversation = %conversation_id, "joined conversation");
         Ok(())
     }
@@ -293,8 +292,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Working, and run steward housekeeping (list reconcile, election
     /// kick-off, buffered-update drain). The commit author's `SuccessfulCommit`
     /// reward is emitted by `finalize_freeze_round`, not here.
-    fn on_conversation_updated(&mut self) -> Result<(), SessionError> {
-        let mls_members = match self.conversation.mls() {
+    fn on_conversation_updated(&mut self) -> Result<(), ConversationError> {
+        let mls_members = match self.core.mls() {
             Some(mls) => mls.members().unwrap_or_default(),
             None => Vec::new(),
         };
@@ -304,8 +303,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Transition to Working BEFORE steward checks (election needs Working
         // state). Reset reelection_round: this commit advanced the epoch,
         // so whatever retry cycle we were in belongs to the previous epoch.
-        self.conversation.steward_list.reset_retry();
-        let state = self.conversation.current_state();
+        self.core.steward_list.reset_retry();
+        let state = self.core.current_state();
         let working_event = if matches!(
             state,
             ConversationState::Working
@@ -323,7 +322,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         self.maybe_close_recovery_window();
 
         if let Some(event) = working_event {
-            self.emit_event(SessionEvent::PhaseChange(event));
+            self.emit_event(ConversationEvent::PhaseChange(event));
         }
         Ok(())
     }
@@ -331,7 +330,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Fire a steward election while `recovery_mode` is set so the next
     /// list installs and closes the window.
     fn maybe_close_recovery_window(&mut self) {
-        if !self.conversation.is_in_recovery_mode() {
+        if !self.core.is_in_recovery_mode() {
             return;
         }
         if let Err(e) = self.initiate_steward_election(true) {
@@ -346,10 +345,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Protocol-side teardown for `LeaveConversation`: emit `Leaving`, cancel
     /// pending timers, and delete the local MLS state. The integrator removes
     /// the registry entry and cleans up the consensus scope.
-    fn prepare_self_leave(&mut self) -> Result<(), SessionError> {
-        self.emit_event(SessionEvent::Leaving);
+    fn prepare_self_leave(&mut self) -> Result<(), ConversationError> {
+        self.emit_event(ConversationEvent::Leaving);
         self.cancel_all_auto_votes();
-        let taken_mls = self.conversation.take_mls();
+        let taken_mls = self.core.take_mls();
         if let Some(mut mls) = taken_mls {
             // The leave is already committed (`Leaving` emitted, MLS
             // detached); a delete failure must log and continue, else the
@@ -363,13 +362,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
     /// Peer broadcast a commit candidate. If we were in Working, enter
     /// Freezing and — if we're a steward — build our own candidate too.
-    fn on_commit_candidate_received(&mut self, steward: &[u8]) -> Result<(), SessionError> {
+    fn on_commit_candidate_received(&mut self, steward: &[u8]) -> Result<(), ConversationError> {
         tracing::debug!(
             conversation = %self.conversation_id,
             steward = ?steward,
             "candidate received from peer steward"
         );
-        let state = self.conversation.current_state();
+        let state = self.core.current_state();
         if state != ConversationState::Working && state != ConversationState::Reelection {
             return Ok(());
         }
@@ -377,12 +376,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         let Some(event) = self.start_freezing() else {
             return Ok(());
         };
-        let epoch = self.conversation.expect_mls()?.current_epoch()?;
-        self.conversation.queues.start_freeze_round(epoch);
+        let epoch = self.core.expect_mls()?.current_epoch()?;
+        self.core.queues.start_freeze_round(epoch);
 
         let self_member_id = Arc::clone(&self.self_member_id);
-        let outbound = if self.conversation.steward_list.is_steward(&self_member_id) {
-            match self.conversation.create_commit_candidate(&self_member_id) {
+        let outbound = if self.core.steward_list.is_steward(&self_member_id) {
+            match self.core.create_commit_candidate(&self_member_id) {
                 Ok(payload) => payload,
                 Err(e) => {
                     error!(
@@ -397,7 +396,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             None
         };
 
-        self.emit_event(SessionEvent::PhaseChange(event));
+        self.emit_event(ConversationEvent::PhaseChange(event));
         if let Some(payload) = outbound {
             self.broadcast(payload);
         }
@@ -408,16 +407,16 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// list. Validates the proposed list against the members it carries
     /// (not the full MLS set — the list may have been generated before we
     /// existed), then applies list + protocol flags + timing + peer scores.
-    fn on_conversation_sync(&mut self, sync: ConversationSync) -> Result<(), SessionError> {
-        if self.conversation.steward_list.current_list().is_some() {
+    fn on_conversation_sync(&mut self, sync: ConversationSync) -> Result<(), ConversationError> {
+        if self.core.steward_list.current_list().is_some() {
             return Ok(());
         }
         let conversation_id = self.conversation_id.clone();
         let (members, current_epoch) = {
-            let mls = self.conversation.expect_mls()?;
+            let mls = self.core.expect_mls()?;
             (mls.members()?, mls.current_epoch()?)
         };
-        let local_default_peer_score = self.conversation.scoring.default_score();
+        let local_default_peer_score = self.core.scoring.default_score();
         if !validate_conversation_sync(
             &conversation_id,
             &sync,
@@ -445,25 +444,23 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     fn apply_conversation_sync_to_entry(
         &mut self,
         sync: &ConversationSync,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ConversationError> {
         let mut protocol_config =
             StewardListConfig::new(sync.sn_min as usize, sync.sn_max as usize)?;
         protocol_config.allow_subset_candidates = sync.allow_subset_candidates;
 
         let sn = sync.steward_members.len();
-        self.conversation.steward_list.set_config(protocol_config);
-        self.conversation.steward_list.install_list(
+        self.core.steward_list.set_config(protocol_config);
+        self.core.steward_list.install_list(
             sync.election_epoch,
             &sync.steward_members,
             sn,
             sync.retry_round,
         )?;
-        self.conversation
+        self.core
             .steward_list
             .set_max_retries(sync.max_reelection_attempts);
-        self.conversation
-            .scoring
-            .set_threshold(sync.threshold_peer_score);
+        self.core.scoring.set_threshold(sync.threshold_peer_score);
         let snapshot = ScoreSnapshot {
             diverged: sync
                 .peer_scores
@@ -476,11 +473,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // member in this snapshot — they'll submit
         // `SCORE_BELOW_THRESHOLD` from their own event chain. Drop our
         // result to avoid duplicate proposals from joiners.
-        let _ = self.conversation.scoring.apply_snapshot(&snapshot);
-        self.conversation.config.liveness_criteria_yes = sync.liveness_criteria_yes;
-        self.conversation.config.pending_update_max_epochs = sync.pending_update_max_epochs;
+        let _ = self.core.scoring.apply_snapshot(&snapshot);
+        self.core.config.liveness_criteria_yes = sync.liveness_criteria_yes;
+        self.core.config.pending_update_max_epochs = sync.pending_update_max_epochs;
         if let Some(timing) = &sync.timing {
-            self.conversation.config.apply_timing(timing);
+            self.core.config.apply_timing(timing);
         }
         Ok(())
     }
@@ -503,7 +500,7 @@ fn validate_conversation_sync(
     current_epoch: u64,
     members: &[Vec<u8>],
     local_default_peer_score: i64,
-) -> Result<bool, SessionError> {
+) -> Result<bool, ConversationError> {
     if sync.election_epoch > current_epoch {
         info!(
             conversation = conversation_id,

--- a/src/session/messaging.rs
+++ b/src/session/messaging.rs
@@ -1,4 +1,4 @@
-//! Send operations on `SessionRunner`: app messages, ban requests, and
+//! Send operations on `Conversation`: app messages, ban requests, and
 //! member-add proposals.
 //!
 //! Also defines [`Outbound`] — the conversation's I/O-agnostic product, and
@@ -12,14 +12,14 @@ use crate::{
     protos::de_mls::messages::v1::{
         AppMessage, ConversationMessage, ConversationUpdateRequest, MemberInvite,
     },
-    session::{ConversationState, CreatorVote, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState, CreatorVote},
 };
 
 /// A payload the conversation produced for the integrator to broadcast,
 /// tagged with the conversation it belongs to and the local sender (for
 /// self-message filtering). Already-encrypted bytes plus pragmatic
-/// addressing — no transport subtopic. The session never sends: it buffers
-/// these and the integrator drains them via [`SessionRunner::drain_outbound`]
+/// addressing — no transport subtopic. The conversation never sends: it buffers
+/// these and the integrator drains them via [`Conversation::drain_outbound`]
 /// and maps each onto its own transport (the conversation only ever emits
 /// broadcast traffic — chat, votes, sync, commit candidates). The reference
 /// transport's `From<Outbound>` conversion lives in the `de-mls-ds` crate.
@@ -30,22 +30,22 @@ pub struct Outbound {
     pub payload: Vec<u8>,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
-    /// Buffer a chat message for broadcast. The session never sends — the
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
+    /// Buffer a chat message for broadcast. The conversation never sends — the
     /// message is enqueued and the integrator drains it via
-    /// [`SessionRunner::drain_outbound`]. Blocked in `PendingJoin` (no keys
+    /// [`Conversation::drain_outbound`]. Blocked in `PendingJoin` (no keys
     /// yet), `Freezing`, and `Selection` (epoch rotation in flight — the
     /// message might not decrypt on peers who already merged the next
     /// commit). Governance traffic has its own gate (`check_proposal_allowed`).
-    pub fn send_message(&mut self, message: Vec<u8>) -> Result<(), SessionError> {
-        let state = self.conversation.current_state();
+    pub fn send_message(&mut self, message: Vec<u8>) -> Result<(), ConversationError> {
+        let state = self.core.current_state();
         if matches!(
             state,
             ConversationState::PendingJoin
                 | ConversationState::Freezing
                 | ConversationState::Selection
         ) {
-            return Err(SessionError::ConversationBlocked(state.to_string()));
+            return Err(ConversationError::ConversationBlocked(state.to_string()));
         }
 
         let app_msg: AppMessage = ConversationMessage {
@@ -54,10 +54,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             conversation_id: self.conversation_id.clone(),
         }
         .into();
-        let payload = self
-            .conversation
-            .expect_mls_mut()?
-            .build_message(&app_msg)?;
+        let payload = self.core.expect_mls_mut()?.build_message(&app_msg)?;
         self.broadcast(payload);
         Ok(())
     }
@@ -65,12 +62,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Start a `MemberInvite` consensus round for the given TLS-encoded key
     /// package. Parses the key package, extracts the member id, and submits a
     /// proposal with a bundled YES vote. The resulting welcome fires as
-    /// [`crate::core::SessionEvent::WelcomeReady`] for the integrator to
+    /// [`crate::core::ConversationEvent::WelcomeReady`] for the integrator to
     /// deliver out of band.
-    pub fn add_member(&mut self, key_package_bytes: &[u8]) -> Result<(), SessionError> {
-        let state = self.conversation.current_state();
+    pub fn add_member(&mut self, key_package_bytes: &[u8]) -> Result<(), ConversationError> {
+        let state = self.core.current_state();
         if state != ConversationState::Working {
-            return Err(SessionError::ConversationBlocked(state.to_string()));
+            return Err(ConversationError::ConversationBlocked(state.to_string()));
         }
         let (kp_bytes, member_id) = key_package_bytes_from_tls(key_package_bytes.to_vec())?;
         self.initiate_proposal(
@@ -86,10 +83,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Start a `RemoveMember` consensus round targeting `member_id`. The
     /// requester's intent is the removal → the creator's vote is bundled as
     /// YES at submit; no vote request is shown to the requester.
-    pub fn remove_member(&mut self, member_id: &[u8]) -> Result<(), SessionError> {
-        let state = self.conversation.current_state();
+    pub fn remove_member(&mut self, member_id: &[u8]) -> Result<(), ConversationError> {
+        let state = self.core.current_state();
         if state != ConversationState::Working {
-            return Err(SessionError::ConversationBlocked(state.to_string()));
+            return Err(ConversationError::ConversationBlocked(state.to_string()));
         }
 
         self.initiate_proposal(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,30 +1,31 @@
 //! Reference session layer — wires [`crate::core`] into a working chat app
 //! with consensus, state machine, peer scoring, and freeze/commit timing.
 //!
-//! The unit of integration is the per-conversation [`SessionRunner`](crate::session::SessionRunner): drive it
+//! The unit of integration is [`Conversation`](crate::session::Conversation): drive it
 //! from a transport receive loop (feeding inbound packets) and a periodic poll
 //! on each conversation's freeze/commit deadlines, draining outbound payloads
-//! and session events as you go.
+//! and conversation events as you go.
 //!
 //! [`crate::core::ConversationStateMachine`] owns the per-conversation state
 //! enum (`PendingJoin → Working → Freezing → Selection → Reelection`);
-//! `PhaseTimer` owns the wall-clock anchor; [`SessionRunner`](crate::session::SessionRunner) composes a
-//! [`crate::core::Conversation`] with that timer through coordinator methods
+//! `PhaseTimer` owns the wall-clock anchor; [`Conversation`](crate::session::Conversation) composes a
+//! [`crate::core::ConversationCore`] with that timer through coordinator methods
 //! that update both atomically. State transitions return the new
 //! [`crate::core::ConversationState`]; the session-side dispatcher emits a
-//! `SessionEvent::PhaseChange` on each one.
+//! `ConversationEvent::PhaseChange` on each one.
 //!
 //! Use this layer directly for epoch-based steward chat; write a custom session
 //! layer if you need a different consensus model, state machine, or epoch
 //! timing.
 //!
-//! [`SessionRunner`](crate::session::SessionRunner) is defined in the `runner` module; per-conversation method
+//! [`Conversation`](crate::session::Conversation) is defined in the `conversation` module; per-conversation method
 //! bodies (proposal submission, voting, inbound dispatch, freeze ticks, steward
 //! housekeeping, query getters) live in sibling modules and extend
-//! `SessionRunner` via additional `impl` blocks.
+//! `Conversation` via additional `impl` blocks.
 
 mod consensus;
 mod construct;
+mod conversation;
 mod display;
 mod error;
 mod inbound;
@@ -32,7 +33,6 @@ mod messaging;
 mod phase_timer;
 mod poll;
 mod query;
-mod runner;
 mod steward;
 
 pub use crate::core::{
@@ -43,12 +43,11 @@ pub use crate::core::{
 };
 pub use consensus::CreatorVote;
 pub use construct::ConversationDeps;
+pub use conversation::{Conversation, LeaveOutcome};
 pub use display::{MemberRole, MessageType, message_types};
-pub use error::SessionError;
+pub use error::ConversationError;
 pub use inbound::DispatchOutcome;
 pub use messaging::{Outbound, build_key_package_announcement};
 pub use poll::PollOutcome;
-pub use runner::LeaveOutcome;
-pub use runner::SessionRunner;
 
 pub(crate) use phase_timer::PhaseTimer;

--- a/src/session/phase_timer.rs
+++ b/src/session/phase_timer.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 /// Wall-clock anchor for the active phase. Holds only the anchor
 /// `Instant`; queries take the relevant `Duration` as a parameter.
-/// [`crate::session::SessionRunner`] composes the timer with the state
+/// [`crate::session::Conversation`] composes the timer with the state
 /// machine and [`crate::core::ConversationConfig`] durations.
 #[derive(Debug, Clone, Default)]
 pub struct PhaseTimer {

--- a/src/session/poll.rs
+++ b/src/session/poll.rs
@@ -1,6 +1,6 @@
-//! Unified per-cycle polling entry point for [`crate::session::SessionRunner`].
+//! Unified per-cycle polling entry point for [`crate::session::Conversation`].
 //!
-//! [`SessionRunner::poll`] drives all time-based session paths in one call:
+//! [`Conversation::poll`] drives all time-based conversation paths in one call:
 //! consensus-deadline ticks, freeze progression, steward-inactivity freeze
 //! entry, and pending-join expiry. The sub-steps are private to this module —
 //! the integrator calls `poll()` once per wakeup cycle and reacts to the
@@ -12,27 +12,27 @@ use tracing::{error, info, warn};
 
 use crate::{
     core::{
-        ConsensusPlugin, ConversationPluginsFactory, FreezeFinalizeResult, FreezeOutcome,
-        PeerScoringPlugin, ScoreEvent, ScoreOp, SessionEvent, StewardListPlugin,
+        ConsensusPlugin, ConversationEvent, ConversationPluginsFactory, FreezeFinalizeResult,
+        FreezeOutcome, PeerScoringPlugin, ScoreEvent, ScoreOp, StewardListPlugin,
     },
     mls_crypto::MlsService,
-    session::{ConversationState, DispatchOutcome, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState, DispatchOutcome},
 };
 
-/// Summary returned by [`SessionRunner::poll`] after one polling pass.
+/// Summary returned by [`Conversation::poll`] after one polling pass.
 #[derive(Debug, Clone)]
 pub struct PollOutcome {
     /// Earliest deadline still pending after this pass. Forward to an
     /// external scheduler as the next wakeup hint.
     pub next_wakeup_in: Option<Duration>,
-    /// `true` if this session should be torn down: either a `PendingJoin`
+    /// `true` if this conversation should be torn down: either a `PendingJoin`
     /// expiry or a commit that ejected the local member. The integrator
     /// must remove the registry entry and clean up the consensus scope
     /// before its next polling cycle.
     pub leave_requested: bool,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     /// Drive one polling cycle: tick consensus deadlines, advance freeze
     /// state, check steward inactivity, and check pending-join expiry.
     ///
@@ -40,7 +40,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// failed; step errors are transient (a step that can't act this cycle
     /// retries on the next) and are logged rather than surfaced.
     ///
-    /// Returns [`PollOutcome::leave_requested`] when the session is ready
+    /// Returns [`PollOutcome::leave_requested`] when the conversation is ready
     /// to be torn down; the integrator finalizes the leave.
     pub fn poll(&mut self) -> PollOutcome {
         let mut leave_requested = false;
@@ -76,31 +76,31 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     /// Polling check for `PendingJoin`: returns `true` once the pending-join
-    /// window elapses without a welcome. By then the session has emitted
-    /// `SessionEvent::Leaving` and cancelled its timers; the integrator
+    /// window elapses without a welcome. By then the conversation has emitted
+    /// `ConversationEvent::Leaving` and cancelled its timers; the integrator
     /// handles registry-side cleanup.
     fn check_pending_join(&mut self) -> bool {
-        if self.conversation.current_state() != ConversationState::PendingJoin {
+        if self.core.current_state() != ConversationState::PendingJoin {
             return false;
         }
         if !self.is_pending_join_expired() {
             return false;
         }
         info!(conversation = %self.conversation_id, "pending join timed out");
-        self.emit_event(SessionEvent::Leaving);
+        self.emit_event(ConversationEvent::Leaving);
         self.cancel_all_auto_votes();
         true
     }
 
     /// Drive the freeze phase forward. While `Freezing`, emits
-    /// [`SessionEvent::FreezeProgress`] as candidates arrive; once all
+    /// [`ConversationEvent::FreezeProgress`] as candidates arrive; once all
     /// expected candidates are in or the freeze window elapses, transitions
     /// to `Selection`, finalises the round, and dispatches the resulting
     /// [`crate::core::ProcessResult`]. Returns
     /// [`DispatchOutcome::LeaveRequested`] if the applied commit ejected the
     /// local member — `poll()` surfaces that as `leave_requested`.
-    fn advance_freeze(&mut self) -> Result<DispatchOutcome, SessionError> {
-        let state = self.conversation.current_state();
+    fn advance_freeze(&mut self) -> Result<DispatchOutcome, ConversationError> {
+        let state = self.core.current_state();
         if state != ConversationState::Freezing {
             self.last_freeze_progress = None;
             return Ok(DispatchOutcome::Done);
@@ -109,36 +109,32 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // Early selection: skip remaining freeze time if all expected
         // stewards have submitted candidates.
         let all_candidates_in = self
-            .conversation
+            .core
             .steward_list
             .current_list()
-            .is_some_and(|list| self.conversation.queues.freeze_candidate_count() >= list.len());
+            .is_some_and(|list| self.core.queues.freeze_candidate_count() >= list.len());
 
         if !all_candidates_in && !self.is_freeze_timed_out() {
             // Still freezing — surface candidate progress when it changes.
             let (received, expected) = self.freeze_candidate_count();
             if self.last_freeze_progress != Some((received, expected)) {
                 self.last_freeze_progress = Some((received, expected));
-                self.emit_event(SessionEvent::FreezeProgress { received, expected });
+                self.emit_event(ConversationEvent::FreezeProgress { received, expected });
             }
             return Ok(DispatchOutcome::Done);
         }
         self.last_freeze_progress = None;
 
         let selection_event = self.start_selection();
-        let has_proposals = self.conversation.queues.approved_proposals_count() > 0;
-        self.emit_event(SessionEvent::PhaseChange(selection_event));
+        let has_proposals = self.core.queues.approved_proposals_count() > 0;
+        self.emit_event(ConversationEvent::PhaseChange(selection_event));
 
         let conversation_id = self.conversation_id.clone();
-        let allow_subset = self
-            .conversation
-            .steward_list
-            .config()
-            .allow_subset_candidates;
+        let allow_subset = self.core.steward_list.config().allow_subset_candidates;
         let self_member_id = Arc::clone(&self.self_member_id);
-        let mut finalize_result = if self.conversation.mls().is_some() {
+        let mut finalize_result = if self.core.mls().is_some() {
             match self
-                .conversation
+                .core
                 .finalize_freeze_round(allow_subset, &self_member_id)
             {
                 Ok(result) => result,
@@ -155,15 +151,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         // observation, no ECP needed). A downward threshold cross schedules
         // a removal-init pass below.
         let downward_cross = if !finalize_result.score_ops.is_empty() {
-            self.conversation
-                .scoring
-                .apply_ops(&finalize_result.score_ops)
+            self.core.scoring.apply_ops(&finalize_result.score_ops)
         } else {
             false
         };
 
         if !finalize_result.committed_batch.is_empty() {
-            self.emit_event(SessionEvent::CommitApplied(std::mem::take(
+            self.emit_event(ConversationEvent::CommitApplied(std::mem::take(
                 &mut finalize_result.committed_batch,
             )));
         }
@@ -191,7 +185,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                         let _ = self.reconcile_steward_list()?;
                         self.build_conversation_sync_payload()?.unwrap_or_default()
                     };
-                    self.emit_event(SessionEvent::WelcomeReady(welcome));
+                    self.emit_event(ConversationEvent::WelcomeReady(welcome));
                 }
 
                 let outcome = match self.dispatch_inbound_result(result) {
@@ -220,13 +214,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                     // the same event independently; threshold-crossing
                     // removal still goes through SCORE_BELOW_THRESHOLD
                     // consensus in steward.rs.
-                    let accuse_target = match self.conversation.mls() {
+                    let accuse_target = match self.core.mls() {
                         Some(mls) => {
                             let violation_epoch = mls.current_epoch()?;
                             let members = mls.members()?;
                             let self_member_id: &[u8] = &self.self_member_id;
-                            let eligible = self.conversation.queues.steward_eligibility(&members);
-                            self.conversation
+                            let eligible = self.core.queues.steward_eligibility(&members);
+                            self.core
                                 .steward_list
                                 .epoch_steward(violation_epoch, &eligible)
                                 .filter(|id| !id.is_empty() && *id != self_member_id)
@@ -235,7 +229,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                         None => None,
                     };
                     let cross = if let Some(steward_id) = accuse_target {
-                        self.conversation.scoring.apply_op(&ScoreOp {
+                        self.core.scoring.apply_op(&ScoreOp {
                             member_id: steward_id,
                             event: ScoreEvent::CensorshipInactivity,
                         })
@@ -245,7 +239,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
 
                     (event, cross)
                 } else {
-                    self.conversation.queues.clear_freeze_round();
+                    self.core.queues.clear_freeze_round();
                     let event = self.start_working();
                     (event, false)
                 };
@@ -255,7 +249,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                 }
 
                 let entered_reelection = transition_event == ConversationState::Reelection;
-                self.emit_event(SessionEvent::PhaseChange(transition_event));
+                self.emit_event(ConversationEvent::PhaseChange(transition_event));
 
                 // Layer 2 recovery: regenerate the steward list. Only the
                 // responsible proposer's call actually submits.
@@ -274,35 +268,35 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// candidate-build failure is logged and the freeze transition proceeds
     /// (peers' candidates still get processed). No-ops outside `Working`
     /// (via `check_steward_inactivity`) and while an election is in flight.
-    fn start_freeze_on_inactivity(&mut self) -> Result<(), SessionError> {
-        if self.conversation.current_state() == ConversationState::PendingJoin {
+    fn start_freeze_on_inactivity(&mut self) -> Result<(), ConversationError> {
+        if self.core.current_state() == ConversationState::PendingJoin {
             return Ok(());
         }
 
-        let proposal_count = self.conversation.queues.approved_proposals_count();
+        let proposal_count = self.core.queues.approved_proposals_count();
         // Hold the freeze while an election is in flight — committing on
         // the known-stale list would just produce a NoCandidate.
-        if self.conversation.queues.has_election_in_flight() {
+        if self.core.queues.has_election_in_flight() {
             return Ok(());
         }
         // Recovery uses the shorter retry inactivity window so we don't
         // burn another full epoch waiting for a steward to commit.
-        let in_recovery = self.conversation.is_in_recovery_mode()
-            || self.conversation.steward_list.next_retry_round() > 0;
+        let in_recovery =
+            self.core.is_in_recovery_mode() || self.core.steward_list.next_retry_round() > 0;
         let inactivity = if in_recovery {
-            self.conversation.config.recovery_inactivity_duration
+            self.core.config.recovery_inactivity_duration
         } else {
-            self.conversation.config.commit_inactivity_duration
+            self.core.config.commit_inactivity_duration
         };
         let Some(event) = self.check_steward_inactivity(proposal_count, inactivity) else {
             return Ok(());
         };
-        let epoch = self.conversation.expect_mls()?.current_epoch()?;
-        self.conversation.queues.start_freeze_round(epoch);
+        let epoch = self.core.expect_mls()?.current_epoch()?;
+        self.core.queues.start_freeze_round(epoch);
 
         let self_member_id = Arc::clone(&self.self_member_id);
-        let outbound = if self.conversation.steward_list.is_steward(&self_member_id) {
-            match self.conversation.create_commit_candidate(&self_member_id) {
+        let outbound = if self.core.steward_list.is_steward(&self_member_id) {
+            match self.core.create_commit_candidate(&self_member_id) {
                 Ok(payload) => payload,
                 Err(e) => {
                     error!(
@@ -323,7 +317,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             "steward inactivity transition"
         );
 
-        self.emit_event(SessionEvent::PhaseChange(event));
+        self.emit_event(ConversationEvent::PhaseChange(event));
 
         if let Some(payload) = outbound {
             self.broadcast(payload);

--- a/src/session/query.rs
+++ b/src/session/query.rs
@@ -4,16 +4,18 @@ use crate::{
     core::{ConsensusPlugin, ConversationPluginsFactory, PeerScoringPlugin, StewardListPlugin},
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::ConversationUpdateRequest,
-    session::{ConversationState, MemberRole, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState, MemberRole},
 };
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
-    pub fn conversation_state(&self) -> ConversationState {
-        self.conversation.current_state()
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
+    /// Current state of the conversation's state machine.
+    pub fn state(&self) -> ConversationState {
+        self.core.current_state()
     }
 
-    /// Name of the conversation this session runs.
-    pub fn conversation_id(&self) -> &str {
+    /// Name of this conversation. Identifies it in the integrator's
+    /// registry and on every [`crate::session::Outbound`] it produces.
+    pub fn id(&self) -> &str {
         &self.conversation_id
     }
 
@@ -27,8 +29,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         &self.member_id_display
     }
 
-    /// App id this session tags on outbound packets and uses for self-echo
-    /// filtering in [`SessionRunner::process_inbound`].
+    /// App id this conversation tags on outbound packets and uses for self-echo
+    /// filtering in [`Conversation::process_inbound`].
     pub fn app_id(&self) -> &[u8] {
         &self.app_id
     }
@@ -36,27 +38,27 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Current MLS epoch + reelection retry round. `(0, 0)` when the
     /// conversation has no MLS state yet (pending join). Intended for UI
     /// status display.
-    pub fn epoch_and_retry(&self) -> Result<(u64, u32), SessionError> {
-        let epoch = match self.conversation.mls() {
+    pub fn epoch_and_retry(&self) -> Result<(u64, u32), ConversationError> {
+        let epoch = match self.core.mls() {
             Some(mls) => mls.current_epoch()?,
             None => 0,
         };
-        Ok((epoch, self.conversation.steward_list.next_retry_round()))
+        Ok((epoch, self.core.steward_list.next_retry_round()))
     }
 
     /// Count of buffered pending membership updates. Used by tests and the UI
     /// to verify buffer hygiene (e.g., that a joiner's buffer is empty right
     /// after they receive the welcome).
     pub fn pending_update_count(&self) -> usize {
-        self.conversation.queues.pending_update_count()
+        self.core.queues.pending_update_count()
     }
 
     /// Freeze round progress: `(received, expected)`. Returns `(0, 0)` if not
     /// in freeze or no steward list is known.
     pub fn freeze_candidate_count(&self) -> (usize, usize) {
-        let received = self.conversation.queues.freeze_candidate_count();
+        let received = self.core.queues.freeze_candidate_count();
         let expected = self
-            .conversation
+            .core
             .steward_list
             .current_list()
             .map(|l| l.len())
@@ -65,55 +67,50 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     pub fn is_steward(&self) -> bool {
-        self.conversation
-            .steward_list
-            .is_steward(&self.self_member_id)
+        self.core.steward_list.is_steward(&self.self_member_id)
     }
 
     /// Identity bytes of every current member of this conversation, as
     /// reported by MLS. Returns an empty vec when the local user has no
     /// MLS state yet (pending join).
-    pub fn members(&self) -> Result<Vec<Vec<u8>>, SessionError> {
-        match self.conversation.mls() {
+    pub fn members(&self) -> Result<Vec<Vec<u8>>, ConversationError> {
+        match self.core.mls() {
             Some(mls) => Ok(mls.members()?),
             None => Ok(Vec::new()),
         }
     }
 
     pub fn member_scores(&self) -> Vec<(Vec<u8>, i64)> {
-        self.conversation.scoring.all_members_with_scores()
+        self.core.scoring.all_members_with_scores()
     }
 
     pub fn member_score(&self, member_id: &[u8]) -> Option<i64> {
-        self.conversation.scoring.score_for(member_id)
+        self.core.scoring.score_for(member_id)
     }
 
     /// Identities that have an in-flight self-leave request. Used by the UI
     /// to render a "pending leave" indicator.
-    pub fn pending_leave_member_ids(&self) -> Result<Vec<Vec<u8>>, SessionError> {
-        let members = self.conversation.expect_mls()?.members()?;
+    pub fn pending_leave_member_ids(&self) -> Result<Vec<Vec<u8>>, ConversationError> {
+        let members = self.core.expect_mls()?.members()?;
         Ok(members
             .into_iter()
-            .filter(|id| self.conversation.queues.is_pending_self_leave(id))
+            .filter(|id| self.core.queues.is_pending_self_leave(id))
             .collect())
     }
 
     /// Steward role for each member. Uses live rotation so removed or
     /// pending-leave stewards are skipped in role display.
-    pub fn member_roles(&self) -> Result<Vec<(Vec<u8>, MemberRole)>, SessionError> {
-        let mls = self.conversation.expect_mls()?;
+    pub fn member_roles(&self) -> Result<Vec<(Vec<u8>, MemberRole)>, ConversationError> {
+        let mls = self.core.expect_mls()?;
         let epoch = mls.current_epoch()?;
         let members = mls.members()?;
 
-        let eligible = self.conversation.queues.steward_eligibility(&members);
-        let (live_epoch, live_backup) = self
-            .conversation
-            .steward_list
-            .epoch_and_backup(epoch, &eligible);
+        let eligible = self.core.queues.steward_eligibility(&members);
+        let (live_epoch, live_backup) = self.core.steward_list.epoch_and_backup(epoch, &eligible);
         let live_epoch = live_epoch.map(|s| s.to_vec());
         let live_backup = live_backup.map(|s| s.to_vec());
-        let exhausted = self.conversation.steward_list.is_exhausted(epoch);
-        let has_list = self.conversation.steward_list.current_list().is_some();
+        let exhausted = self.core.steward_list.is_exhausted(epoch);
+        let has_list = self.core.steward_list.current_list().is_some();
         let roles = members
             .iter()
             .cloned()
@@ -123,12 +120,12 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
                         MemberRole::EpochSteward
                     } else if live_backup.as_deref().is_some_and(|bs| bs == id) {
                         MemberRole::BackupSteward
-                    } else if self.conversation.steward_list.is_steward(&id) {
+                    } else if self.core.steward_list.is_steward(&id) {
                         MemberRole::Steward
                     } else {
                         MemberRole::Member
                     }
-                } else if has_list && self.conversation.steward_list.is_steward(&id) {
+                } else if has_list && self.core.steward_list.is_steward(&id) {
                     MemberRole::Steward
                 } else {
                     MemberRole::Member
@@ -140,7 +137,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     }
 
     pub fn approved_proposals_for_current_epoch(&self) -> Vec<ConversationUpdateRequest> {
-        self.conversation
+        self.core
             .queues
             .approved_proposals()
             .values()

--- a/src/session/steward.rs
+++ b/src/session/steward.rs
@@ -1,4 +1,4 @@
-//! Steward housekeeping on `SessionRunner`: list generation/election,
+//! Steward housekeeping on `Conversation`: list generation/election,
 //! pending-update buffering and drain, scoring sync, conversation-sync
 //! broadcast.
 
@@ -16,11 +16,11 @@ use crate::{
         AppMessage, ConversationSync, ConversationUpdateRequest, PeerScore,
         StewardElectionProposal, TimingConfig, ViolationEvidence, conversation_update_request,
     },
-    session::{ConversationState, CreatorVote, SessionError, SessionRunner},
+    session::{Conversation, ConversationError, ConversationState, CreatorVote},
 };
 
 /// Outcome of reconciling the steward list to the current epoch — see
-/// [`SessionRunner::reconcile_steward_list`].
+/// [`Conversation::reconcile_steward_list`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StewardListReconcile {
     /// List already covered the epoch, or the settled members were installed
@@ -31,7 +31,7 @@ pub(crate) enum StewardListReconcile {
     NeedsElection,
 }
 
-impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
+impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     // ── Public API ───────────────────────────────────────────────────
 
     /// Add any MLS members not yet tracked in scoring, and drop scored
@@ -39,7 +39,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// [`scoring_member_diff`]; this method only applies the diff.
     pub(crate) fn sync_scoring_members(&mut self, mls_members: &[Vec<u8>]) {
         let scored: Vec<Vec<u8>> = self
-            .conversation
+            .core
             .scoring
             .all_members_with_scores()
             .into_iter()
@@ -51,17 +51,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // returns false; an exotic config could surface a fresh member
             // as below-threshold, but the score-removal chain doesn't fire
             // on membership-sync ticks today.
-            let _ = self.conversation.scoring.add_member(member_id);
+            let _ = self.core.scoring.add_member(member_id);
         }
         for member_id in &diff.to_remove {
-            self.conversation.scoring.remove_member(member_id);
+            self.core.scoring.remove_member(member_id);
         }
     }
 
     /// Reconcile the list after an epoch advance, opening a voted election when
     /// it's needed. Election-init failures are logged, not surfaced — the
     /// conversation may legitimately reject a new proposal right now.
-    pub(crate) fn steward_list_housekeeping(&mut self) -> Result<(), SessionError> {
+    pub(crate) fn steward_list_housekeeping(&mut self) -> Result<(), ConversationError> {
         let reconcile = self.reconcile_steward_list()?;
         if reconcile == StewardListReconcile::NeedsElection
             && let Err(e) = self.initiate_steward_election(false)
@@ -76,33 +76,28 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// installs them locally (deterministic, no vote); `> sn_max` returns
     /// [`StewardListReconcile::NeedsElection`]. Every node computes the same
     /// local list, so they agree without a round.
-    pub(crate) fn reconcile_steward_list(&mut self) -> Result<StewardListReconcile, SessionError> {
+    pub(crate) fn reconcile_steward_list(
+        &mut self,
+    ) -> Result<StewardListReconcile, ConversationError> {
         let (current_epoch, members) = {
-            let mls = self.conversation.expect_mls()?;
+            let mls = self.core.expect_mls()?;
             (mls.current_epoch()?, mls.members()?)
         };
-        if !self.conversation.steward_list.is_exhausted(current_epoch) {
+        if !self.core.steward_list.is_exhausted(current_epoch) {
             return Ok(StewardListReconcile::Settled);
         }
         // Stewards are settled members only — a just-joined member can't commit
         // or vote yet, so it's excluded until the next epoch.
-        let settled = self
-            .conversation
-            .queues
-            .settled_members(&members, current_epoch);
-        if self
-            .conversation
-            .steward_list
-            .election_required(settled.len())
-        {
+        let settled = self.core.queues.settled_members(&members, current_epoch);
+        if self.core.steward_list.election_required(settled.len()) {
             return Ok(StewardListReconcile::NeedsElection);
         }
         let sn = self
-            .conversation
+            .core
             .steward_list
             .config()
             .compute_list_size(settled.len());
-        self.conversation
+        self.core
             .steward_list
             .install_list(current_epoch, &settled, sn, 0)?;
         Ok(StewardListReconcile::Settled)
@@ -115,8 +110,8 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     pub(crate) fn handle_incoming_update_request(
         &mut self,
         request: ConversationUpdateRequest,
-    ) -> Result<(), SessionError> {
-        let state = self.conversation.current_state();
+    ) -> Result<(), ConversationError> {
+        let state = self.core.current_state();
         if state == ConversationState::PendingJoin {
             return Ok(());
         }
@@ -126,21 +121,21 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
         }
         // No MLS outside PendingJoin (e.g. Leaving teardown): buffer only,
         // with no epoch or steward context.
-        let (members, current_epoch) = match self.conversation.mls() {
+        let (members, current_epoch) = match self.core.mls() {
             Some(mls) => (mls.members()?, mls.current_epoch()?),
             None => (Vec::new(), 0),
         };
 
         let inserted = self
-            .conversation
+            .core
             .queues
             .insert_pending_update(request.clone(), current_epoch);
 
         // Only the epoch steward proposes immediately. The buffer
         // survives freeze rounds so a later steward can retry.
         let is_epoch_steward = {
-            let eligible = self.conversation.queues.steward_eligibility(&members);
-            self.conversation
+            let eligible = self.core.queues.steward_eligibility(&members);
+            self.core
                 .steward_list
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == &*self.self_member_id)
@@ -151,7 +146,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             conversation = %self.conversation_id,
             epoch = current_epoch,
             inserted,
-            buffer_total = self.conversation.queues.pending_update_count(),
+            buffer_total = self.core.queues.pending_update_count(),
             is_epoch_steward,
             state = %state,
             propose = should_propose,
@@ -174,27 +169,25 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Drop Add entries whose target is now a member and Remove entries
     /// whose target is now gone, then expire entries older than
     /// `pending_update_max_epochs`.
-    pub(crate) fn prune_pending_updates_after_commit(&mut self) -> Result<(), SessionError> {
+    pub(crate) fn prune_pending_updates_after_commit(&mut self) -> Result<(), ConversationError> {
         let (current_epoch, members, max_age) = {
-            let Some(mls) = self.conversation.mls() else {
+            let Some(mls) = self.core.mls() else {
                 return Ok(());
             };
             (
                 mls.current_epoch()?,
                 mls.members()?,
-                self.conversation.config.pending_update_max_epochs,
+                self.core.config.pending_update_max_epochs,
             )
         };
 
-        let before = self.conversation.queues.pending_update_count();
-        self.conversation
-            .queues
-            .prune_pending_updates_for_members(&members);
+        let before = self.core.queues.pending_update_count();
+        self.core.queues.prune_pending_updates_for_members(&members);
         let expired = self
-            .conversation
+            .core
             .queues
             .expire_pending_updates(current_epoch, max_age);
-        let after = self.conversation.queues.pending_update_count();
+        let after = self.core.queues.pending_update_count();
         if before != after {
             info!(
                 conversation = %self.conversation_id,
@@ -210,20 +203,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// On epoch advance, the new live epoch steward drains the pending-update
     /// buffer into voting proposals. Skips entries already covered by the
     /// current voting/approved queues so we don't double-propose.
-    pub(crate) fn process_buffered_updates(&mut self) -> Result<(), SessionError> {
+    pub(crate) fn process_buffered_updates(&mut self) -> Result<(), ConversationError> {
         let (current_epoch, to_propose, conversation_id): (
             u64,
             Vec<ConversationUpdateRequest>,
             String,
         ) = {
-            let (current_epoch, members) = match self.conversation.mls() {
+            let (current_epoch, members) = match self.core.mls() {
                 Some(mls) => (mls.current_epoch()?, mls.members()?),
                 None => (0, Vec::new()),
             };
             let self_member_id: &[u8] = &self.self_member_id;
-            let eligible = self.conversation.queues.steward_eligibility(&members);
+            let eligible = self.core.queues.steward_eligibility(&members);
             let is_live = self
-                .conversation
+                .core
                 .steward_list
                 .epoch_steward(current_epoch, &eligible)
                 .is_some_and(|es| es == self_member_id);
@@ -234,13 +227,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // Collect buffered updates whose target isn't already in an
             // active proposal queue. Both the voting and approved queues
             // live on `ConversationQueues`.
-            let approved = self.conversation.queues.approved_proposals();
+            let approved = self.core.queues.approved_proposals();
             let approved_targets: std::collections::HashSet<&[u8]> =
                 approved.values().filter_map(target_member_id_of).collect();
             let members_set = member_set(&members);
 
             let to_propose: Vec<ConversationUpdateRequest> = self
-                .conversation
+                .core
                 .queues
                 .pending_updates()
                 .iter()
@@ -289,17 +282,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Returns `Ok(None)` when there's no steward list yet. The caller
     /// owns delivery: broadcast it as an [`Outbound`](crate::session::Outbound)
     /// or feed it into another channel. The post-commit join path bundles
-    /// the same payload into [`crate::core::SessionEvent::WelcomeReady`].
+    /// the same payload into [`crate::core::ConversationEvent::WelcomeReady`].
     pub(crate) fn build_conversation_sync_payload(
         &mut self,
-    ) -> Result<Option<Vec<u8>>, SessionError> {
+    ) -> Result<Option<Vec<u8>>, ConversationError> {
         // Sparse snapshot — only members whose score has diverged
         // from `default_score`. Joiners init every member at default
         // via membership sync before applying the snapshot, so
         // missing entries imply default. Saves wire size at scale
         // (Waku message budget concern past ~1k members).
         let scores: Vec<PeerScore> = self
-            .conversation
+            .core
             .scoring
             .snapshot()
             .diverged
@@ -310,20 +303,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             })
             .collect();
 
-        let list = match self.conversation.steward_list.current_list() {
+        let list = match self.core.steward_list.current_list() {
             Some(l) => l,
             None => return Ok(None),
         };
 
-        let timing = TimingConfig::from(&self.conversation.config);
+        let timing = TimingConfig::from(&self.core.config);
 
         // Filter ghosts and queued-removal targets so joiners don't
         // inherit stewards they would have to walk past on the very
         // first epoch.
-        let mls_members = self.conversation.expect_mls()?.members()?;
+        let mls_members = self.core.expect_mls()?.members()?;
         let steward_members = {
-            let eligible = self.conversation.queues.steward_eligibility(&mls_members);
-            self.conversation.steward_list.steward_members(&eligible)
+            let eligible = self.core.queues.steward_eligibility(&mls_members);
+            self.core.steward_list.steward_members(&eligible)
         };
 
         // `retry_round` is the seed that produced the *stored* list —
@@ -335,40 +328,32 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             election_epoch: list.election_epoch(),
             sn_min: list.config().sn_min as u32,
             sn_max: list.config().sn_max as u32,
-            allow_subset_candidates: self
-                .conversation
-                .steward_list
-                .config()
-                .allow_subset_candidates,
+            allow_subset_candidates: self.core.steward_list.config().allow_subset_candidates,
             peer_scores: scores,
             timing: Some(timing),
             retry_round: list.retry_round(),
-            max_reelection_attempts: self.conversation.steward_list.max_retries(),
-            liveness_criteria_yes: self.conversation.config.liveness_criteria_yes,
-            threshold_peer_score: self.conversation.scoring.threshold(),
-            pending_update_max_epochs: self.conversation.config.pending_update_max_epochs,
+            max_reelection_attempts: self.core.steward_list.max_retries(),
+            liveness_criteria_yes: self.core.config.liveness_criteria_yes,
+            threshold_peer_score: self.core.scoring.threshold(),
+            pending_update_max_epochs: self.core.config.pending_update_max_epochs,
         };
 
         let app_msg: AppMessage = sync.into();
-        Ok(Some(
-            self.conversation
-                .expect_mls_mut()?
-                .build_message(&app_msg)?,
-        ))
+        Ok(Some(self.core.expect_mls_mut()?.build_message(&app_msg)?))
     }
 
     /// Steward-only: file `ScoreBelowThreshold` ECPs for any member whose
     /// score fell at or below the removal threshold. Skips self and any
     /// target already covered by a pending removal.
-    pub(crate) fn check_and_initiate_score_removals(&mut self) -> Result<(), SessionError> {
+    pub(crate) fn check_and_initiate_score_removals(&mut self) -> Result<(), ConversationError> {
         // Reactive entry: callers chain into this after a scoring apply
         // emitted a downward cross, so we expect at least one tracked
         // member to be at-or-below threshold. The scan is the source of
         // truth — events just trigger the look.
         let (epoch, to_remove, self_id_arc, conversation_id) = {
-            let epoch = self.conversation.expect_mls()?.current_epoch()?;
+            let epoch = self.core.expect_mls()?.current_epoch()?;
             let self_id_arc = Arc::clone(&self.self_member_id);
-            let is_steward = self.conversation.steward_list.is_steward(&self_id_arc);
+            let is_steward = self.core.steward_list.is_steward(&self_id_arc);
             if !is_steward {
                 return Ok(());
             }
@@ -385,20 +370,20 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             //     same target before the RemoveMember commits.
             let self_id: &[u8] = &self_id_arc;
             let to_remove: Vec<(Vec<u8>, i64)> = self
-                .conversation
+                .core
                 .scoring
                 .members_below_threshold()
                 .into_iter()
                 .filter(|id| id.as_slice() != self_id)
-                .filter(|id| !self.conversation.queues.has_pending_removal(id))
-                .filter(|id| !self.conversation.queues.has_approved_removal(id))
+                .filter(|id| !self.core.queues.has_pending_removal(id))
+                .filter(|id| !self.core.queues.has_approved_removal(id))
                 .filter_map(|id| {
-                    let score = self.conversation.scoring.score_for(&id)?;
+                    let score = self.core.scoring.score_for(&id)?;
                     Some((id, score))
                 })
                 .collect();
             for (id, _) in &to_remove {
-                self.conversation.queues.insert_pending_removal(id.clone());
+                self.core.queues.insert_pending_removal(id.clone());
             }
             (epoch, to_remove, self_id_arc, self.conversation_id.clone())
         };
@@ -419,7 +404,7 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // member must be removed. The steward's vote is YES by
             // protocol, so we bundle it at submit and skip the vote request.
             if let Err(e) = self.initiate_proposal(request, CreatorVote::Yes) {
-                self.conversation.queues.remove_pending_removal(&target_id);
+                self.core.queues.remove_pending_removal(&target_id);
                 error!(
                     conversation = %conversation_id,
                     target = ?target_id,
@@ -443,16 +428,19 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// already in `approved_proposals` thanks to
     /// [`crate::core::apply_consensus_result`], so `has_approved_removal`
     /// catches them without an explicit exclude.
-    pub(crate) fn initiate_steward_election(&mut self, recovery: bool) -> Result<(), SessionError> {
+    pub(crate) fn initiate_steward_election(
+        &mut self,
+        recovery: bool,
+    ) -> Result<(), ConversationError> {
         let (proposed_stewards, election_epoch, retry_round, conversation_id) = {
-            let mls = self.conversation.expect_mls()?;
+            let mls = self.core.expect_mls()?;
             let epoch = mls.current_epoch()?;
             let mls_members = mls.members()?;
             let self_member_id: &[u8] = &self.self_member_id;
 
             // `has_election_in_flight` is a proposal-queue check, not a
             // steward-list one — gated here, before the plug-in call.
-            if self.conversation.queues.has_election_in_flight() {
+            if self.core.queues.has_election_in_flight() {
                 return Ok(());
             }
 
@@ -462,15 +450,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // — they may not have attached MLS and can't serve as stewards yet.
             let candidate_pool: Vec<Vec<u8>> = mls_members
                 .iter()
-                .filter(|m| self.conversation.queues.is_settled(m, epoch))
-                .filter(|m| !(recovery && self.conversation.queues.has_approved_removal(m)))
+                .filter(|m| self.core.queues.is_settled(m, epoch))
+                .filter(|m| !(recovery && self.core.queues.has_approved_removal(m)))
                 .cloned()
                 .collect();
             let pool_set: std::collections::HashSet<&[u8]> =
                 candidate_pool.iter().map(Vec::as_slice).collect();
             let eligible = |c: &[u8]| pool_set.contains(c);
 
-            match self.conversation.steward_list.propose_election(
+            match self.core.steward_list.propose_election(
                 epoch,
                 &candidate_pool,
                 self_member_id,
@@ -525,9 +513,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
     /// Layer 3 escalation: file a `Deadlock` ECP after re-election retries
     /// exhaust. Only the deterministic responsible proposer submits;
     /// others no-op. On YES the ECP opens `recovery_mode`.
-    pub(crate) fn initiate_deadlock_ecp(&mut self) -> Result<(), SessionError> {
+    pub(crate) fn initiate_deadlock_ecp(&mut self) -> Result<(), ConversationError> {
         let (is_authorized, self_id, epoch, conversation_id) = {
-            let mls = self.conversation.expect_mls()?;
+            let mls = self.core.expect_mls()?;
             let mls_members = mls.members()?;
             let epoch = mls.current_epoch()?;
             let self_id: &[u8] = &self.self_member_id;
@@ -535,9 +523,9 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> SessionRunner<P, CP> {
             // predicate (MLS-present and not queued for removal).
             let mls_set: std::collections::HashSet<&[u8]> =
                 mls_members.iter().map(Vec::as_slice).collect();
-            let conversation_ref = &self.conversation.queues;
+            let conversation_ref = &self.core.queues;
             let authorized = self
-                .conversation
+                .core
                 .steward_list
                 .election_proposer(|c: &[u8]| {
                     mls_set.contains(c) && !conversation_ref.has_approved_removal(c)

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -1,5 +1,5 @@
 //! Crate-internal test fixtures: minimal trait impls for tests that need
-//! to construct a [`crate::core::Conversation`] or [`crate::session::SessionRunner`]
+//! to construct a [`crate::core::ConversationCore`] or [`crate::session::Conversation`]
 //! without standing up real MLS / scoring / steward backends.
 //!
 //! Most methods are `unreachable!()` — tests should only exercise the
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// Build a `ConsensusServiceFor<DefaultConsensusPlugin>` paired with a
-/// subscribed receiver for [`crate::session::SessionRunner::new`].
+/// subscribed receiver for [`crate::session::Conversation::new`].
 pub(crate) fn make_test_consensus_service() -> (
     ConsensusServiceFor<DefaultConsensusPlugin>,
     crate::defaults::SyncEventReceiver<String>,
@@ -244,10 +244,10 @@ impl PeerScoringPlugin for StubScoring {
 }
 
 /// Test plug-in bundle wiring the three stubs into the [`ConversationPluginsFactory`]
-/// trait so tests can construct [`crate::core::Conversation`] and
-/// [`crate::session::SessionRunner`] under their single `<CP>` parameter. The
+/// trait so tests can construct [`crate::core::ConversationCore`] and
+/// [`crate::session::Conversation`] under their single `<CP>` parameter. The
 /// factory methods are `unreachable!()` — tests build plug-in instances
-/// directly and hand them to the handle/runner constructors.
+/// directly and hand them to the conversation constructors.
 pub(crate) struct StubPluginsFactory;
 
 impl ConversationPluginsFactory for StubPluginsFactory {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,20 +1,4 @@
 //! Shared fixtures for integration tests.
-//!
-//! Rust compiles each file in `tests/` as its own binary; a file under
-//! `tests/common/` is *not* a test binary, so this module can be reused by
-//! adding `mod common;` to any test file. Helpers carry `#[allow(dead_code)]`
-//! at the module level because not every binary exercises every helper.
-//!
-//! Two distinct fixture surfaces live here:
-//!
-//! - [`session_fixtures`] is the public-surface fixture set: `User` +
-//!   `SessionRunner` driven through `process_inbound_packet`, transport
-//!   capture, polling helpers. Default for new tests.
-//! - The low-level helpers in this file (`StewardHandle`, `JoinerHandle`,
-//!   `process_inbound_compat`, `build_commit_candidate`) let a test reach
-//!   into `core::process_inbound` and the MLS layer directly, which is
-//!   what the forgery / adversarial-input tests in `core_violations.rs`
-//!   need. New tests should prefer [`session_fixtures`].
 #![allow(dead_code)]
 
 pub mod wallet;
@@ -229,7 +213,7 @@ pub fn process_inbound_compat(
     } else if subtopic == APP_MSG_SUBTOPIC {
         let Some(mls) = mls else {
             // App messages on a conversation with no MLS state are
-            // silently ignored. Mirrors `SessionRunner::process_inbound_packet`,
+            // silently ignored. Mirrors `Conversation::process_inbound_packet`,
             // which gates app payloads on `conversation.mls().is_some()`.
             return Ok(ProcessResult::Noop(NoopReason::UnknownAppMessage));
         };

--- a/tests/core_process_inbound.rs
+++ b/tests/core_process_inbound.rs
@@ -34,7 +34,7 @@ fn test_process_inbound_welcome_already_joined_ignores() {
 
     // A second welcome (this one for joiner2's KP) doesn't address us, so
     // try_accept_welcome surfaces "not for us" rather than disturbing our
-    // MLS state. `SessionRunner` additionally guards on
+    // MLS state. `Conversation` additionally guards on
     // `conversation.mls().is_some()` to skip wholesale; both safeguards land at
     // the same outcome.
     let mut joiner2 = setup_joiner(

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -1,4 +1,4 @@
-//! Step 1 proof: a `SessionRunner` can be built and queried straight from a
+//! Step 1 proof: a `Conversation` can be built and queried straight from a
 //! `ConversationDeps` bundle, with no `User` in the picture. The integrator
 //! holds one plug-in factory plus shared consensus storage + signer, and
 //! mints each conversation's consensus service from them — exactly what
@@ -13,13 +13,13 @@ use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
 use de_mls::core::{
-    ConsensusPlugin, ConsensusServiceFor, ScoringConfig, SessionEvent, StewardListConfig,
+    ConsensusPlugin, ConsensusServiceFor, ConversationEvent, ScoringConfig, StewardListConfig,
 };
 use de_mls::defaults::{
     DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage,
 };
 use de_mls::mls_crypto::MlsCredentials;
-use de_mls::session::{ConversationDeps, ConversationState, SessionRunner};
+use de_mls::session::{Conversation, ConversationDeps, ConversationState};
 
 use common::wallet::WalletMemberId;
 
@@ -77,22 +77,23 @@ impl Integrator {
 #[test]
 fn create_builds_a_working_steward_session_without_user() {
     let integrator = Integrator::new();
-    let runner = SessionRunner::create("standalone", integrator.deps()).expect("create");
+    let conversation = Conversation::create("standalone", integrator.deps()).expect("create");
 
-    assert_eq!(runner.conversation_state(), ConversationState::Working);
+    assert_eq!(conversation.state(), ConversationState::Working);
     assert!(
-        runner.is_steward(),
+        conversation.is_steward(),
         "creator is the sole steward at epoch 0"
     );
-    let (epoch, _retry) = runner.epoch_and_retry().expect("epoch");
+    let (epoch, _retry) = conversation.epoch_and_retry().expect("epoch");
     assert_eq!(epoch, 0);
 
     // The opening phase is buffered for whoever drains the session.
-    let events = runner.drain_events();
+    let events = conversation.drain_events();
     assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, SessionEvent::PhaseChange(ConversationState::Working))),
+        events.iter().any(|e| matches!(
+            e,
+            ConversationEvent::PhaseChange(ConversationState::Working)
+        )),
         "create buffers an opening Working PhaseChange"
     );
 }
@@ -100,11 +101,11 @@ fn create_builds_a_working_steward_session_without_user() {
 #[test]
 fn join_builds_a_pending_join_session_without_user() {
     let integrator = Integrator::new();
-    let runner = SessionRunner::join("standalone", integrator.deps()).expect("join");
+    let conversation = Conversation::join("standalone", integrator.deps()).expect("join");
 
-    assert_eq!(runner.conversation_state(), ConversationState::PendingJoin);
+    assert_eq!(conversation.state(), ConversationState::PendingJoin);
     assert!(
-        !runner.is_steward(),
+        !conversation.is_steward(),
         "a pending joiner holds no steward list yet"
     );
 }


### PR DESCRIPTION
Completes the rename: the public per-conversation handle is now `Conversation`, taking the name the product was always meant to have.

- `SessionRunner` becomes `session::Conversation`; the core aggregate it wraps becomes `ConversationCore` and the handle holds it as a `core` field.
- `SessionEvent` and `SessionError` become `ConversationEvent` and `ConversationError`, matching their producer.
- Getters lose the stutter: `conversation_state()` is `state()`, `conversation_id()` is `id()`.
- The gateway follows: `poll_conversation`, `ConversationEntry`, `UserError::Conversation`, lock labels and fixtures renamed to match.
- Prose now uses "session" in exactly two senses — the session layer and consensus sessions; everywhere it meant the handle it now says conversation. A few stale comments found in the sweep were fixed along the way.

