### PR TITLE
feat(welcome): deliver the welcome to every member

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -185,34 +185,14 @@ impl Gateway<WakuDeliveryService> {
                 if is_welcome_channel
                     && let Some(mw) = crate::welcome_envelope::decode(&pkt.payload)
                 {
-                    let accepted = user.write().await.accept_welcome(&mw.welcome_bytes);
-                    match accepted {
-                        Ok(_) if !mw.conversation_sync_bytes.is_empty() => {
-                            // Replay the bundled ConversationSync through the
-                            // standard inbound path now that MLS is attached —
-                            // the sync payload is an MLS-encrypted app message
-                            // addressed to the new epoch.
-                            let sync_inbound = Inbound {
-                                conversation_id: pkt.conversation_id.clone(),
-                                sender: pkt.app_id.clone(),
-                                payload: mw.conversation_sync_bytes,
-                            };
-                            if let Err(e) = user.read().await.handle_inbound(sync_inbound) {
-                                tracing::warn!(
-                                    group = %conversation_id,
-                                    error = %e,
-                                    "bundled sync replay failed"
-                                );
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                group = %conversation_id,
-                                error = %e,
-                                "accept_welcome failed"
-                            );
-                        }
+                    // `accept_welcome` completes the join and applies the
+                    // bundled ConversationSync in one step.
+                    if let Err(e) = user.write().await.accept_welcome(&mw) {
+                        tracing::warn!(
+                            group = %conversation_id,
+                            error = %e,
+                            "accept_welcome failed"
+                        );
                     }
                     continue;
                 }

--- a/crates/de_mls_gateway/src/handler.rs
+++ b/crates/de_mls_gateway/src/handler.rs
@@ -166,7 +166,16 @@ impl GatewayEventFanout {
                     expected,
                 });
             }
-            ConversationEvent::WelcomeReady(welcome) => {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally,
+            } => {
+                // Only the minting committer publishes to the welcome
+                // subtopic; peers receiving the in-group broadcast would
+                // otherwise flood the joiner with duplicates.
+                if !minted_locally {
+                    return;
+                }
                 let bytes = welcome.welcome_bytes.len();
                 let sync_bytes = welcome.conversation_sync_bytes.len();
                 let packet = OutboundPacket::new(

--- a/crates/de_mls_gateway/src/user/state.rs
+++ b/crates/de_mls_gateway/src/user/state.rs
@@ -15,7 +15,7 @@ use de_mls::{
     },
     member_id::MemberId,
     mls_crypto::{KeyPackageBytes, MlsError, MlsService},
-    protos::de_mls::messages::v1::ConversationUpdateRequest,
+    protos::de_mls::messages::v1::{ConversationUpdateRequest, MemberWelcome},
     session::{
         Conversation, ConversationError, ConversationState, CreatorVote, MemberRole, PollOutcome,
     },
@@ -211,16 +211,17 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
         Ok(())
     }
 
-    /// Ingest a raw MLS welcome blob delivered out of band (e.g. the
+    /// Ingest a [`MemberWelcome`] delivered out of band (e.g. the
     /// inviter's [`de_mls::core::ConversationEvent::WelcomeReady`] routed
-    /// through the integrator's transport). Returns the joined
-    /// conversation name, or [`UserError::WelcomeNotForUs`] if the
-    /// welcome doesn't address this user's key package.
-    pub fn accept_welcome(&mut self, welcome_bytes: &[u8]) -> Result<String, UserError> {
+    /// through the integrator's transport). Completes the join and applies
+    /// the bundled `ConversationSync`. Returns the joined conversation
+    /// name, or [`UserError::WelcomeNotForUs`] if the welcome doesn't
+    /// address this user's key package.
+    pub fn accept_welcome(&mut self, welcome: &MemberWelcome) -> Result<String, UserError> {
         let svc = self
             .plugins
             .conversation_plugins
-            .welcome_mls(welcome_bytes)
+            .welcome_mls(&welcome.welcome_bytes)
             .map_err(ConversationError::from)?
             .ok_or(UserError::WelcomeNotForUs)?;
         let conversation_id = svc.conversation_id().to_string();
@@ -232,7 +233,11 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> User<P, CP> {
             .lookup_entry(&conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
 
-        entry_arc.write_or_err("conversation")?.complete_join(svc)?;
+        {
+            let mut conversation = entry_arc.write_or_err("conversation")?;
+            conversation.complete_join(svc)?;
+            conversation.apply_welcome_sync(&welcome.conversation_sync_bytes)?;
+        }
         self.flush(&entry_arc)?;
         Ok(conversation_id)
     }

--- a/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
+++ b/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
@@ -205,11 +205,11 @@ pub fn broadcast(packets: &[OutboundPacket], receivers: &[&TestUser]) {
 }
 
 /// Drain `ConversationEvent::WelcomeReady` events from each session and
-/// route each welcome to the matching joiner via
-/// [`TestUser::accept_welcome`], then replay the bundled
-/// `conversation_sync_bytes` through `process_inbound_packet`. Returns
-/// `(delivered_count, sync_bytes_captured)` — the second element holds every
-/// non-empty `conversation_sync_bytes` from delivered welcomes, in order. Call
+/// route each locally-minted welcome to the matching joiner via
+/// [`TestUser::accept_welcome`] (which also applies the bundled
+/// `conversation_sync_bytes`). Returns `(delivered_count,
+/// sync_bytes_captured)` — the second element holds every non-empty
+/// `conversation_sync_bytes` from delivered welcomes, in order. Call
 /// this once per polling round, BEFORE relaying packets — same-round app-msg
 /// packets (e.g. the post-commit steward election proposal) need the joiner's
 /// MLS attached first.
@@ -220,48 +220,33 @@ pub fn route_welcomes(
     use de_mls::core::ConversationEvent;
     use de_mls::protos::de_mls::messages::v1::MemberWelcome;
 
-    // Pair each welcome with its emitter's app_id. The bundled sync is the
-    // welcomer's outbound packet, so the replayed `Inbound` must carry the
-    // welcomer's app_id — replaying it under the joiner's own app_id would
-    // trip `handle_inbound`'s echo-dedup and silently drop it.
-    //
     // Route only minted welcomes — peers re-emit the committer's broadcast
     // as `minted_locally: false`, and routing those too would just bounce
     // off the joiner as duplicates (mirrors the gateway's delivery gate).
-    let mut welcomes: Vec<(MemberWelcome, Vec<u8>)> = Vec::new();
-    for (i, s) in sessions.iter().enumerate() {
-        let welcomer_app_id = users[i].0.app_id().to_vec();
+    let mut welcomes: Vec<MemberWelcome> = Vec::new();
+    for s in sessions.iter() {
         for event in s.read().unwrap().drain_events() {
             if let ConversationEvent::WelcomeReady {
                 welcome,
                 minted_locally: true,
             } = event
             {
-                welcomes.push((welcome, welcomer_app_id.clone()));
+                welcomes.push(welcome);
             }
         }
     }
     let mut delivered = 0;
     let mut sync_bytes_out = Vec::new();
-    for (welcome, welcomer_app_id) in welcomes {
-        let conv_name = sessions
-            .first()
-            .map(|s| s.read().unwrap().id().to_string())
-            .unwrap_or_default();
+    for welcome in welcomes {
         for (u, _) in users.iter_mut() {
             // Try every user — `welcome_mls` returns `Ok(None)` (which
             // `accept_welcome` surfaces as `Err(WelcomeNotForUs)`) for
             // anyone the welcome doesn't address. Only the targeted
-            // joiner attaches MLS and gets the bundled sync replayed.
-            if u.accept_welcome(&welcome.welcome_bytes).is_ok() {
+            // joiner attaches MLS and gets the bundled sync applied.
+            if u.accept_welcome(&welcome).is_ok() {
                 delivered += 1;
                 if !welcome.conversation_sync_bytes.is_empty() {
                     sync_bytes_out.push(welcome.conversation_sync_bytes.clone());
-                    let _ = u.handle_inbound(Inbound {
-                        conversation_id: conv_name.clone(),
-                        sender: welcomer_app_id.clone(),
-                        payload: welcome.conversation_sync_bytes.clone(),
-                    });
                 }
             }
         }

--- a/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
+++ b/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
@@ -132,6 +132,19 @@ pub mod predicate {
         }
         MemberInvite::decode(p.payload.as_slice()).is_ok()
     }
+
+    /// Matches the committer's in-group welcome broadcast on the app-msg
+    /// subtopic. Decodable for the same reason as [`is_commit_candidate`]:
+    /// the outer prost wrapper is plaintext.
+    pub fn is_member_welcome(p: &OutboundPacket) -> bool {
+        if p.subtopic != APP_MSG_SUBTOPIC {
+            return false;
+        }
+        let Ok(msg) = AppMessage::decode(p.payload.as_slice()) else {
+            return false;
+        };
+        matches!(msg.payload, Some(app_message::Payload::MemberWelcome(_)))
+    }
 }
 
 /// Build a [`TestUser`] with a [`CapturingTransport`] using the given
@@ -211,11 +224,19 @@ pub fn route_welcomes(
     // welcomer's outbound packet, so the replayed `Inbound` must carry the
     // welcomer's app_id — replaying it under the joiner's own app_id would
     // trip `handle_inbound`'s echo-dedup and silently drop it.
+    //
+    // Route only minted welcomes — peers re-emit the committer's broadcast
+    // as `minted_locally: false`, and routing those too would just bounce
+    // off the joiner as duplicates (mirrors the gateway's delivery gate).
     let mut welcomes: Vec<(MemberWelcome, Vec<u8>)> = Vec::new();
     for (i, s) in sessions.iter().enumerate() {
         let welcomer_app_id = users[i].0.app_id().to_vec();
         for event in s.read().unwrap().drain_events() {
-            if let ConversationEvent::WelcomeReady(welcome) = event {
+            if let ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally: true,
+            } = event
+            {
                 welcomes.push((welcome, welcomer_app_id.clone()));
             }
         }

--- a/crates/de_mls_gateway/tests/welcome_broadcast.rs
+++ b/crates/de_mls_gateway/tests/welcome_broadcast.rs
@@ -1,0 +1,139 @@
+//! Welcome broadcast: when a commit adds a member, every group member
+//! surfaces `ConversationEvent::WelcomeReady` — the committing steward
+//! mints it (`minted_locally == true`) and broadcasts it in-group, peers
+//! receive the same welcome with `minted_locally == false`. Duplicate
+//! broadcast deliveries emit a single event, and the joiner can complete
+//! the join from a welcome captured on any member.
+
+use std::time::Duration;
+
+use de_mls::core::{ConversationEvent, ConversationState, StewardListConfig};
+use de_mls::protos::de_mls::messages::v1::MemberWelcome;
+
+mod common;
+use common::conversation_fixtures::{
+    ConversationArc, bootstrap_joined_conversation, deliver, fast_test_config, flush_conversation,
+    make_user, poll_once, predicate, settle_for,
+};
+
+const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+
+/// Drain a session's events and keep only the `WelcomeReady` ones.
+fn drain_welcomes(session: &ConversationArc) -> Vec<(MemberWelcome, bool)> {
+    session
+        .read()
+        .unwrap()
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally,
+            } => Some((welcome, minted_locally)),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn welcome_broadcast_reaches_every_member_and_dedupes() {
+    let conversation = "welcome-broadcast";
+    let users = bootstrap_joined_conversation(
+        &[ALICE, BOB],
+        conversation,
+        fast_test_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    let alice_session = users[0].0.lookup_entry(conversation).unwrap().unwrap();
+    let bob_session = users[1].0.lookup_entry(conversation).unwrap().unwrap();
+    let sessions = [&alice_session, &bob_session];
+
+    // Charlie mints a KP out of band; Bob — a non-creator — proposes the add.
+    let (mut charlie, _charlie_transport) = make_user(
+        CHARLIE,
+        fast_test_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    let charlie_kp = charlie.generate_key_package().unwrap();
+    bob_session
+        .write()
+        .unwrap()
+        .add_member(charlie_kp.as_bytes())
+        .unwrap();
+
+    // Drive both members until each surfaces a WelcomeReady; capture the
+    // in-group broadcast packet on the way for the dedup check below.
+    let mut welcomes: Vec<Vec<(MemberWelcome, bool)>> = vec![Vec::new(), Vec::new()];
+    let mut broadcast_packets = Vec::new();
+    for _ in 0..40 {
+        settle_for(Duration::from_millis(60));
+        for (i, s) in sessions.iter().enumerate() {
+            poll_once(s);
+            flush_conversation(s, &users[i].1);
+        }
+        let mut packets = Vec::new();
+        for (_, h) in &users {
+            packets.extend(h.lock().unwrap().drain_packets());
+        }
+        for p in &packets {
+            if predicate::is_member_welcome(p) {
+                broadcast_packets.push(p.clone());
+            }
+            for (u, _) in &users {
+                deliver(u, p);
+            }
+        }
+        for (i, s) in sessions.iter().enumerate() {
+            welcomes[i].extend(drain_welcomes(s));
+        }
+        if welcomes.iter().all(|w| !w.is_empty()) {
+            break;
+        }
+    }
+
+    assert!(
+        welcomes.iter().all(|w| w.len() == 1),
+        "each member surfaces exactly one WelcomeReady, got {:?}",
+        welcomes.iter().map(|w| w.len()).collect::<Vec<_>>()
+    );
+    assert!(
+        !broadcast_packets.is_empty(),
+        "the committer broadcasts the welcome in-group"
+    );
+
+    let minted_count = welcomes.iter().filter(|w| w[0].1).count();
+    assert_eq!(
+        minted_count, 1,
+        "exactly one member (the committing steward) mints the welcome"
+    );
+    assert_eq!(
+        welcomes[0][0].0.welcome_bytes, welcomes[1][0].0.welcome_bytes,
+        "committer and peer surface the same welcome bytes"
+    );
+
+    // Re-delivering the broadcast to the non-committer is a no-op: the
+    // welcome hash is already recorded, so no second event fires.
+    let non_committer = if welcomes[0][0].1 { 1 } else { 0 };
+    for p in &broadcast_packets {
+        deliver(&users[non_committer].0, p);
+    }
+    assert!(
+        drain_welcomes(sessions[non_committer]).is_empty(),
+        "duplicate broadcast must not re-emit WelcomeReady"
+    );
+
+    // Any member's copy completes the joiner: hand the non-committer's
+    // welcome to Charlie.
+    let (welcome, _) = &welcomes[non_committer][0];
+    assert_eq!(welcome.joiner_identities.len(), 1);
+    let joined = charlie.accept_welcome(welcome).expect("charlie joins");
+    assert_eq!(joined, conversation);
+    let charlie_session = charlie.lookup_entry(conversation).unwrap().unwrap();
+    assert_eq!(
+        charlie_session.read().unwrap().state(),
+        ConversationState::Working
+    );
+}

--- a/src/core/conversation/queues.rs
+++ b/src/core/conversation/queues.rs
@@ -122,6 +122,9 @@ pub struct ConversationQueues {
     /// "settled" check (see [`Self::is_settled`]); deterministic across nodes
     /// that apply the same commit.
     member_join_epoch: HashMap<Vec<u8>, u64>,
+    /// Hashes of recently-seen welcome broadcasts, so gossip duplicates
+    /// emit a single `WelcomeReady` event.
+    welcome_broadcast_hashes: VecDeque<CommitHash>,
 }
 
 impl ConversationQueues {
@@ -139,6 +142,7 @@ impl ConversationQueues {
             urgent_commit_target: None,
             early_candidates: Vec::new(),
             member_join_epoch: HashMap::new(),
+            welcome_broadcast_hashes: VecDeque::new(),
         }
     }
 
@@ -366,6 +370,20 @@ impl ConversationQueues {
             self.committed_batch_hashes.pop_front();
         }
         self.committed_batch_hashes.push_back(commit_hash);
+    }
+
+    /// Record a welcome broadcast's hash. Returns `true` when the hash is
+    /// new (process it) and `false` for a duplicate (drop it). Bounded the
+    /// same way as the committed-hash window.
+    pub(crate) fn record_welcome_broadcast(&mut self, hash: CommitHash) -> bool {
+        if self.welcome_broadcast_hashes.iter().any(|h| *h == hash) {
+            return false;
+        }
+        if self.welcome_broadcast_hashes.len() >= MAX_COMMITTED_HASHES {
+            self.welcome_broadcast_hashes.pop_front();
+        }
+        self.welcome_broadcast_hashes.push_back(hash);
+        true
     }
 
     // ─────────────────────────── Freeze Round ───────────────────────────

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -56,10 +56,16 @@ pub enum ConversationEvent {
     /// Conversation transitioned into `state`.
     PhaseChange(ConversationState),
 
-    /// Our merged commit added members. Carries the MLS welcome blob
-    /// and the encrypted `ConversationSync` payload bundled for atomic
-    /// delivery. The integrator owns delivery to each joiner.
-    WelcomeReady(MemberWelcome),
+    /// A merged commit added members. Carries the MLS welcome blob and the
+    /// encrypted `ConversationSync` payload bundled for atomic delivery.
+    /// Fires on every member — the committing steward mints it
+    /// (`minted_locally == true`) and broadcasts it to the group, so peers
+    /// receive the same welcome (`minted_locally == false`). The
+    /// application decides who delivers it to the joiners and how.
+    WelcomeReady {
+        welcome: MemberWelcome,
+        minted_locally: bool,
+    },
 
     /// A consensus session on this conversation resolved. Emitted before
     /// the protocol effects (commit candidate, freeze, score apply, …)

--- a/src/core/inbound.rs
+++ b/src/core/inbound.rs
@@ -12,7 +12,7 @@ use crate::{
     core::{
         conversation::ConversationQueues,
         error::CoreError,
-        freeze::buffer_commit_candidate,
+        freeze::{buffer_commit_candidate, compute_commit_hash},
         process_result::{NoopReason, ProcessResult},
     },
     mls_crypto::{DecryptResult, MlsService},
@@ -51,11 +51,27 @@ pub fn process_inbound<M: MlsService>(
     mls: &mut M,
     payload: &[u8],
 ) -> Result<ProcessResult, CoreError> {
-    // 1. Try plaintext CommitCandidate (sent as plaintext AppMessage)
-    if let Ok(app_message) = AppMessage::decode(payload)
-        && let Some(app_message::Payload::CommitCandidate(candidate)) = app_message.payload
-    {
-        return buffer_commit_candidate(conversation, mls, candidate);
+    // 1. Try the plaintext envelopes (sent as plaintext AppMessage):
+    //    CommitCandidate and MemberWelcome both have to be readable before
+    //    the receiver merges the commit they belong to.
+    if let Ok(app_message) = AppMessage::decode(payload) {
+        match app_message.payload {
+            Some(app_message::Payload::CommitCandidate(candidate)) => {
+                return buffer_commit_candidate(conversation, mls, candidate);
+            }
+            Some(app_message::Payload::MemberWelcome(welcome)) => {
+                if welcome.welcome_bytes.is_empty() {
+                    return Ok(ProcessResult::Noop(NoopReason::EmptyWelcomePayload));
+                }
+                if !conversation
+                    .record_welcome_broadcast(compute_commit_hash(&welcome.welcome_bytes))
+                {
+                    return Ok(ProcessResult::Noop(NoopReason::DuplicateWelcomeBroadcast));
+                }
+                return Ok(ProcessResult::WelcomeBroadcastReceived(Box::new(welcome)));
+            }
+            _ => {}
+        }
     }
 
     // 2. MLS-encrypted app messages only — use decrypt_application_only.

--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -10,8 +10,9 @@ use crate::{
     core::{CoreError, ScoreEvent, ScoreOp},
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, CommitCandidate, ConversationMessage, ConversationSync,
-        ConversationUpdateRequest, EmergencyCriteriaProposal, Outcome, ProposalAdded, UserVote,
-        ViolationEvidence, ViolationType, VotePayload, app_message, conversation_update_request,
+        ConversationUpdateRequest, EmergencyCriteriaProposal, MemberWelcome, Outcome,
+        ProposalAdded, UserVote, ViolationEvidence, ViolationType, VotePayload, app_message,
+        conversation_update_request,
     },
 };
 
@@ -50,6 +51,11 @@ pub enum ProcessResult {
     /// Conversation-sync message from the steward.
     ConversationSyncReceived(Box<ConversationSync>),
 
+    /// Welcome broadcast from the committing steward: every member learns
+    /// the welcome so the application decides who delivers it to the
+    /// joiners and how.
+    WelcomeBroadcastReceived(Box<MemberWelcome>),
+
     /// Nothing to do.
     Noop(NoopReason),
 }
@@ -86,6 +92,10 @@ pub enum NoopReason {
     /// Candidate arrived before its proposal was locally approved (consensus
     /// outcome still in flight). Stashed for replay once approval lands.
     CandidateStashedEarly,
+    /// Welcome broadcast carried no welcome bytes.
+    EmptyWelcomePayload,
+    /// Welcome broadcast hash was already seen — duplicate gossip delivery.
+    DuplicateWelcomeBroadcast,
 }
 
 // ── ViolationEvidence constructors ────────────────────────────────
@@ -212,6 +222,7 @@ impl_payload_from!(
     Vote                => app_message::Payload::Vote,
     ConversationSync    => app_message::Payload::ConversationSync,
     ProposalAdded       => app_message::Payload::ProposalAdded,
+    MemberWelcome       => app_message::Payload::MemberWelcome,
 );
 
 impl From<ConsensusEvent> for Outcome {

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -17,6 +17,9 @@ message AppMessage {
     ProposalAdded proposal_added = 7;
     CommitCandidate commit_candidate = 8;
     ConversationSync conversation_sync = 9;
+    // Plaintext broadcast of a freshly minted welcome so every member —
+    // not just the committing steward — can deliver it to the joiners.
+    MemberWelcome member_welcome = 10;
   }
 }
 

--- a/src/session/construct.rs
+++ b/src/session/construct.rs
@@ -20,6 +20,8 @@ use crate::{
         PeerScoringPlugin, ScoringConfig, StewardListConfig, StewardListPlugin,
     },
     member_id::MemberId,
+    mls_crypto::MlsService,
+    protos::de_mls::messages::v1::MemberWelcome,
     session::{Conversation, ConversationError, ConversationState, PhaseTimer},
 };
 
@@ -67,6 +69,28 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
         deps: ConversationDeps<P, CP>,
     ) -> Result<Self, ConversationError> {
         Self::build(conversation_id, deps, false)
+    }
+
+    /// Build a fully-joined conversation straight from a received
+    /// [`MemberWelcome`] — the whole joiner path in one call: attach MLS
+    /// from the welcome, complete the join, and replay the bundled
+    /// `ConversationSync` (steward list, timing, peer scores).
+    ///
+    /// Returns `Ok(None)` when the welcome doesn't address this member's
+    /// key package — ignore it. The conversation id comes from the welcome
+    /// itself, so the caller needs no prior knowledge of the conversation.
+    pub fn from_welcome(
+        deps: ConversationDeps<P, CP>,
+        welcome: &MemberWelcome,
+    ) -> Result<Option<Self>, ConversationError> {
+        let Some(mls) = deps.plugins.welcome_mls(&welcome.welcome_bytes)? else {
+            return Ok(None);
+        };
+        let conversation_id = mls.conversation_id().to_string();
+        let mut conversation = Self::join(&conversation_id, deps)?;
+        conversation.complete_join(mls)?;
+        conversation.apply_welcome_sync(&welcome.conversation_sync_bytes)?;
+        Ok(Some(conversation))
     }
 
     /// Shared construction body for [`Self::create`] / [`Self::join`].

--- a/src/session/display.rs
+++ b/src/session/display.rs
@@ -44,6 +44,7 @@ pub mod message_types {
     pub const PROPOSAL_ADDED: &str = "ProposalAdded";
     pub const COMMIT_CANDIDATE: &str = "CommitCandidate";
     pub const CONVERSATION_SYNC: &str = "ConversationSync";
+    pub const MEMBER_WELCOME: &str = "MemberWelcome";
     pub const UNKNOWN: &str = "Unknown";
 }
 
@@ -64,6 +65,7 @@ impl MessageType for app_message::Payload {
             app_message::Payload::ProposalAdded(_) => message_types::PROPOSAL_ADDED,
             app_message::Payload::CommitCandidate(_) => message_types::COMMIT_CANDIDATE,
             app_message::Payload::ConversationSync(_) => message_types::CONVERSATION_SYNC,
+            app_message::Payload::MemberWelcome(_) => message_types::MEMBER_WELCOME,
         }
     }
 }

--- a/src/session/inbound.rs
+++ b/src/session/inbound.rs
@@ -131,6 +131,15 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
         Ok(())
     }
 
+    pub fn apply_welcome_sync(&mut self, sync_bytes: &[u8]) -> Result<(), ConversationError> {
+        if sync_bytes.is_empty() {
+            return Ok(());
+        }
+        let result = self.core.process_inbound(sync_bytes)?;
+        self.dispatch_inbound_result(result)?;
+        Ok(())
+    }
+
     pub(crate) fn dispatch_inbound_result(
         &mut self,
         result: ProcessResult,

--- a/src/session/inbound.rs
+++ b/src/session/inbound.rs
@@ -183,6 +183,13 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
                 self.on_conversation_sync(*sync)?;
                 Ok(DispatchOutcome::Done)
             }
+            ProcessResult::WelcomeBroadcastReceived(welcome) => {
+                self.emit_event(ConversationEvent::WelcomeReady {
+                    welcome: *welcome,
+                    minted_locally: false,
+                });
+                Ok(DispatchOutcome::Done)
+            }
             ProcessResult::Noop(reason) => {
                 tracing::debug!(
                     conversation = %self.conversation_id,

--- a/src/session/poll.rs
+++ b/src/session/poll.rs
@@ -8,6 +8,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use prost::Message;
 use tracing::{error, info, warn};
 
 use crate::{
@@ -16,6 +17,7 @@ use crate::{
         FreezeOutcome, PeerScoringPlugin, ScoreEvent, ScoreOp, StewardListPlugin,
     },
     mls_crypto::MlsService,
+    protos::de_mls::messages::v1::AppMessage,
     session::{Conversation, ConversationError, ConversationState, DispatchOutcome},
 };
 
@@ -185,7 +187,14 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
                         let _ = self.reconcile_steward_list()?;
                         self.build_conversation_sync_payload()?.unwrap_or_default()
                     };
-                    self.emit_event(ConversationEvent::WelcomeReady(welcome));
+                    // Broadcast the welcome to the group so every member can deliver it to the
+                    // joiners, then surface it locally as freshly minted.
+                    let broadcast_payload = AppMessage::from(welcome.clone()).encode_to_vec();
+                    self.emit_event(ConversationEvent::WelcomeReady {
+                        welcome,
+                        minted_locally: true,
+                    });
+                    self.broadcast(broadcast_payload);
                 }
 
                 let outcome = match self.dispatch_inbound_result(result) {

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -8,12 +8,16 @@ mod common;
 
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
+use de_mls::member_id::MemberId;
+
 use de_mls::core::{
-    ConsensusPlugin, ConsensusServiceFor, ConversationEvent, ScoringConfig, StewardListConfig,
+    ConsensusPlugin, ConsensusServiceFor, ConversationEvent, ConversationPluginsFactory,
+    ScoringConfig, StewardListConfig,
 };
 use de_mls::defaults::{
     DefaultConsensusPlugin, DefaultConversationPluginsFactory, MemoryDeMlsStorage,
@@ -24,6 +28,7 @@ use de_mls::session::{Conversation, ConversationDeps, ConversationState};
 use common::wallet::WalletMemberId;
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 
 /// The shared, conversation-agnostic state an integrator keeps once: the
 /// plug-in factory, the consensus storage + signer, and the identity.
@@ -36,7 +41,11 @@ struct Integrator {
 
 impl Integrator {
     fn new() -> Self {
-        let signer = PrivateKeySigner::from_str(ALICE).expect("valid private key");
+        Self::with_key(ALICE)
+    }
+
+    fn with_key(private_key: &str) -> Self {
+        let signer = PrivateKeySigner::from_str(private_key).expect("valid private key");
         let member_id = WalletMemberId::from_address(signer.address());
         let credentials =
             Arc::new(MlsCredentials::from_member_id(&member_id).expect("credentials"));
@@ -52,9 +61,17 @@ impl Integrator {
 
     /// Fresh per-conversation deps drawn from the shared state. The
     /// consensus service clones the shared storage (scope-keyed) and gets
-    /// its own private event bus.
+    /// its own private event bus. The member id doubles as the `app_id` so
+    /// two integrators in one test don't echo-drop each other's packets.
     fn deps(
         &self,
+    ) -> ConversationDeps<'_, DefaultConsensusPlugin, DefaultConversationPluginsFactory> {
+        self.deps_with_config(de_mls::session::ConversationConfig::default())
+    }
+
+    fn deps_with_config(
+        &self,
+        config: de_mls::session::ConversationConfig,
     ) -> ConversationDeps<'_, DefaultConsensusPlugin, DefaultConversationPluginsFactory> {
         let consensus = ConsensusServiceFor::<DefaultConsensusPlugin>::new_with_components(
             self.consensus_storage.clone(),
@@ -66,8 +83,8 @@ impl Integrator {
             plugins: &self.plugins,
             consensus,
             identity: &self.member_id,
-            app_id: Arc::from(&[0u8; 16][..]),
-            config: de_mls::session::ConversationConfig::default(),
+            app_id: Arc::from(self.member_id.member_id_bytes()),
+            config,
             scoring_config: ScoringConfig::default(),
             steward_list_config: StewardListConfig::default(),
         }
@@ -108,4 +125,74 @@ fn join_builds_a_pending_join_session_without_user() {
         !conversation.is_steward(),
         "a pending joiner holds no steward list yet"
     );
+}
+
+/// Sub-second timers so the solo creator's bundled-YES consensus and the
+/// inactivity commit land within a few polling rounds.
+fn fast_config() -> de_mls::session::ConversationConfig {
+    de_mls::session::ConversationConfig {
+        commit_inactivity_duration: Duration::from_millis(50),
+        freeze_duration: Duration::from_millis(20),
+        voting_delay: Duration::from_millis(30),
+        election_voting_delay: Duration::from_millis(30),
+        consensus_timeout: Duration::from_millis(150),
+        proposal_expiration: Duration::from_millis(2000),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn from_welcome_joins_in_one_call() {
+    let alice = Integrator::new();
+    let bob = Integrator::with_key(BOB);
+
+    let mut creator =
+        Conversation::create("standalone-welcome", alice.deps_with_config(fast_config()))
+            .expect("create");
+
+    // Bob mints a key package out of band; Alice — the sole member — proposes
+    // the add, so her bundled YES resolves consensus on its own.
+    let bob_kp = bob.plugins.generate_key_package().expect("kp");
+    creator.add_member(bob_kp.as_bytes()).expect("add member");
+
+    // Drive the creator until the welcome is minted.
+    let mut welcome = None;
+    for _ in 0..40 {
+        std::thread::sleep(Duration::from_millis(30));
+        creator.poll();
+        for event in creator.drain_events() {
+            if let ConversationEvent::WelcomeReady {
+                welcome: w,
+                minted_locally: true,
+            } = event
+            {
+                welcome = Some(w);
+            }
+        }
+        if welcome.is_some() {
+            break;
+        }
+    }
+    let welcome = welcome.expect("creator mints a welcome");
+
+    // A welcome not addressed to us yields `None` — a fresh integrator that
+    // never minted the key package can't open it.
+    let bystander = Integrator::with_key(ALICE);
+    assert!(
+        Conversation::from_welcome(bystander.deps_with_config(fast_config()), &welcome)
+            .expect("from_welcome on a foreign welcome")
+            .is_none(),
+        "a welcome for someone else is ignored"
+    );
+
+    // The whole joiner path in one call: attach MLS, complete the join,
+    // apply the bundled sync.
+    let joined = Conversation::from_welcome(bob.deps_with_config(fast_config()), &welcome)
+        .expect("from_welcome")
+        .expect("welcome addresses bob");
+    assert_eq!(joined.id(), "standalone-welcome");
+    assert_eq!(joined.state(), ConversationState::Working);
+    assert_eq!(joined.members().expect("members").len(), 2);
+    let (epoch, _) = joined.epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 1, "joiner lands on the post-add epoch");
 }


### PR DESCRIPTION
The minted welcome used to exist only on the committing steward, so an inviter who wasn't the epoch steward had no way to deliver it to the joiner. The committing steward now broadcasts the `MemberWelcome` to the group as a plaintext envelope (same treatment as commit candidates, since peers may not have merged the commit yet), and `WelcomeReady { welcome, minted_locally }` fires on every member — the application decides who forwards it to the joiner and how. Gossip duplicates are deduped by welcome hash, and the gateway keeps its wire behavior by publishing only the locally minted copy.

The joiner side collapses to one call: `Conversation::from_welcome(deps, &welcome)` attaches MLS, completes the join, and applies the bundled `ConversationSync` (the conversation id comes from the welcome itself). `apply_welcome_sync` replaces the invented-sender sync replay, and the gateway's `accept_welcome` now takes the full `MemberWelcome`.

Known gaps: the welcome broadcast is unauthenticated; validating `joiner_identities` against the post-commit member set is a planned follow-up.