### PR TITLE
Add Membership change Event

### DIFF
--- a/src/core/process_result.rs
+++ b/src/core/process_result.rs
@@ -10,9 +10,9 @@ use crate::{
     core::{CoreError, ScoreEvent, ScoreOp},
     protos::de_mls::messages::v1::{
         AppMessage, BanRequest, CommitCandidate, ConversationMessage, ConversationSync,
-        ConversationUpdateRequest, EmergencyCriteriaProposal, MemberWelcome, Outcome,
-        ProposalAdded, UserVote, ViolationEvidence, ViolationType, VotePayload, app_message,
-        conversation_update_request,
+        ConversationUpdateRequest, EmergencyCriteriaProposal, EventMembershipChange, MemberWelcome,
+        Outcome, ProposalAdded, UserVote, ViolationEvidence, ViolationType, VotePayload,
+        app_message, conversation_update_request,
     },
 };
 
@@ -223,6 +223,7 @@ impl_payload_from!(
     ConversationSync    => app_message::Payload::ConversationSync,
     ProposalAdded       => app_message::Payload::ProposalAdded,
     MemberWelcome       => app_message::Payload::MemberWelcome,
+    EventMembershipChange => app_message::Payload::MembershipChange,
 );
 
 impl From<ConsensusEvent> for Outcome {
@@ -240,6 +241,9 @@ impl TryFrom<AppMessage> for ProcessResult {
     fn try_from(value: AppMessage) -> Result<Self, Self::Error> {
         match &value.payload {
             Some(app_message::Payload::ConversationMessage(_)) => {
+                Ok(ProcessResult::AppMessage(Box::new(value)))
+            }
+            Some(app_message::Payload::MembershipChange(_)) => {
                 Ok(ProcessResult::AppMessage(Box::new(value)))
             }
             Some(app_message::Payload::Proposal(proposal)) => {

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -20,6 +20,7 @@ message AppMessage {
     // Plaintext broadcast of a freshly minted welcome so every member —
     // not just the committing steward — can deliver it to the joiners.
     MemberWelcome member_welcome = 10;
+    EventMembershipChange membership_change = 11;
   }
 }
 
@@ -32,6 +33,16 @@ message ConversationMessage {
   bytes message = 1;
   string sender = 2;
   string conversation_id = 3;
+}
+
+message EventMembershipChange {
+  string conversation_id = 1;
+  string member = 2;
+  TypeMembershipChange change_type = 3;
+}
+
+enum TypeMembershipChange{
+  Add = 0;
 }
 
 message CommitCandidate {

--- a/src/session/display.rs
+++ b/src/session/display.rs
@@ -36,6 +36,7 @@ impl fmt::Display for MemberRole {
 /// String constants shared with the UI so string-keyed dispatch stays typo-safe.
 pub mod message_types {
     pub const CONVERSATION_MESSAGE: &str = "ConversationMessage";
+    pub const MEMBERSHIP_CHANGE: &str = "MembershipChange";
     pub const BAN_REQUEST: &str = "BanRequest";
     pub const PROPOSAL: &str = "Proposal";
     pub const VOTE: &str = "Vote";
@@ -57,6 +58,7 @@ impl MessageType for app_message::Payload {
     fn message_type(&self) -> &'static str {
         match self {
             app_message::Payload::ConversationMessage(_) => message_types::CONVERSATION_MESSAGE,
+            app_message::Payload::MembershipChange(_) => message_types::MEMBERSHIP_CHANGE,
             app_message::Payload::BanRequest(_) => message_types::BAN_REQUEST,
             app_message::Payload::Proposal(_) => message_types::PROPOSAL,
             app_message::Payload::Vote(_) => message_types::VOTE,

--- a/src/session/inbound.rs
+++ b/src/session/inbound.rs
@@ -21,8 +21,8 @@ use crate::{
     },
     mls_crypto::MlsService,
     protos::de_mls::messages::v1::{
-        AppMessage, ConversationMessage, ConversationSync, ConversationUpdateRequest, MemberInvite,
-        TimingConfig, conversation_update_request,
+        AppMessage, ConversationSync, ConversationUpdateRequest, EventMembershipChange,
+        MemberInvite, TimingConfig, TypeMembershipChange, conversation_update_request,
     },
     session::{
         Conversation, ConversationError, ConversationState,
@@ -284,11 +284,10 @@ impl<P: ConsensusPlugin, CP: ConversationPluginsFactory> Conversation<P, CP> {
     /// message, seed scoring with the current member set, and
     /// transition to Working.
     fn on_joined_conversation(&mut self) -> Result<(), ConversationError> {
-        let msg: AppMessage = ConversationMessage {
-            message: format!("User {} joined the conversation", self.member_id_display)
-                .into_bytes(),
-            sender: "SYSTEM".to_string(),
+        let msg: AppMessage = EventMembershipChange {
             conversation_id: self.conversation_id.clone(),
+            member: self.member_id_display().to_string(),
+            change_type: TypeMembershipChange::Add as i32,
         }
         .into();
         let conversation_id = self.conversation_id.clone();


### PR DESCRIPTION
## Problem

The library returns spurious`AppMessage::ConversationMessage`'s. 

When a client joins a conversation, a ConversationMessage is broadcast to all members informing them who has joined. 

This causes 2 issues:
- No mechanism to separate Membership Update events from legitment Content.
- Tests fail, because N messages sent by the Sender, does not result in N messages received by the Recipient.

## Solution

This PR adds a new message type under AppMessage, specifically to capture membership updates. 