### PR TITLE
feat(steward): sponsor/commit takeover and gateway pending-join slots

### DIFF
--- a/crates/de_mls_gateway/src/forwarder.rs
+++ b/crates/de_mls_gateway/src/forwarder.rs
@@ -39,9 +39,10 @@ pub(crate) async fn load_member_info(
     conversation_id: &str,
 ) -> anyhow::Result<Vec<MemberInfo>> {
     let entry = lookup_conversation(user, conversation_id).await?;
-    let conversation = entry
+    let slot = entry
         .read()
         .map_err(|_| UserError::LockPoisoned("conversation"))?;
+    let conversation = slot.live_ref()?;
     let member_bytes = conversation.members()?;
     let scores = conversation.member_scores();
     let roles = conversation.member_roles().unwrap_or_default();
@@ -80,7 +81,7 @@ pub(crate) async fn push_consensus_state(
     let Ok(entry) = lookup_conversation(user, conversation_id).await else {
         return;
     };
-    let conversation = match entry.read() {
+    let slot = match entry.read() {
         Ok(s) => s,
         Err(_) => {
             tracing::warn!(
@@ -89,6 +90,10 @@ pub(crate) async fn push_consensus_state(
             );
             return;
         }
+    };
+    // Pending join — no live conversation to report on yet.
+    let Ok(conversation) = slot.live_ref() else {
+        return;
     };
     let proposals = conversation.approved_proposals_for_current_epoch();
     let _ = evt_tx.unbounded_send(AppEvent::CurrentEpochProposals {
@@ -126,7 +131,11 @@ pub(crate) async fn push_member_scores(
         return;
     };
     let is_steward = match entry.read() {
-        Ok(s) => s.is_steward(),
+        Ok(slot) => match slot.live_ref() {
+            Ok(conversation) => conversation.is_steward(),
+            // Pending join — nothing to report yet.
+            Err(_) => return,
+        },
         Err(_) => {
             tracing::warn!(
                 conversation = %conversation_id,
@@ -187,12 +196,17 @@ impl Gateway<WakuDeliveryService> {
                 {
                     // `accept_welcome` completes the join and applies the
                     // bundled ConversationSync in one step.
-                    if let Err(e) = user.write().await.accept_welcome(&mw) {
-                        tracing::warn!(
-                            group = %conversation_id,
-                            error = %e,
-                            "accept_welcome failed"
-                        );
+                    match user.write().await.accept_welcome(&mw) {
+                        Ok(_) => {}
+                        // The welcome is broadcast to every member on the welcome
+                        // subtopic; only the addressed joiner can open it. Everyone
+                        // else gets `WelcomeNotForUs` — expected, not a failure.
+                        Err(UserError::WelcomeNotForUs) => {
+                            tracing::debug!(group = %conversation_id, "welcome not addressed to us");
+                        }
+                        Err(e) => {
+                            tracing::warn!(group = %conversation_id, error = %e, "accept_welcome failed");
+                        }
                     }
                     continue;
                 }
@@ -211,7 +225,13 @@ impl Gateway<WakuDeliveryService> {
                     user.read().await.handle_inbound(inbound)
                 };
                 if let Err(e) = result {
-                    tracing::error!(group = %conversation_id, error = %e, "inbound handling failed");
+                    if matches!(e, UserError::ConversationNotFound) {
+                        // No live conversation here (a pending join, or one we
+                        // left) — we can't process this traffic. Benign.
+                        tracing::debug!(group = %conversation_id, "inbound dropped: no live conversation");
+                    } else {
+                        tracing::error!(group = %conversation_id, error = %e, "inbound handling failed");
+                    }
                 }
 
                 // Push refreshed approved queue + epoch history + members.

--- a/crates/de_mls_gateway/src/group.rs
+++ b/crates/de_mls_gateway/src/group.rs
@@ -6,10 +6,25 @@ use de_mls_ds::WakuDeliveryService;
 use de_mls_ui_protocol::v1::MemberInfo;
 
 use crate::{
-    Gateway, UserRef,
-    forwarder::{display_batch, load_member_info, lookup_conversation},
+    ConversationRef, Gateway, UserRef,
+    forwarder::{display_batch, load_member_info},
     user::UserError,
 };
+
+/// State string surfaced for a conversation whose welcome has not yet
+/// arrived. Distinct from the library's [`de_mls::ConversationState`] values,
+/// which only exist once the conversation is live.
+const PENDING_JOIN_STATE: &str = "PendingJoin";
+
+/// Where a conversation id resolves in the gateway registry.
+enum Located {
+    /// A live conversation handle.
+    Live(ConversationRef),
+    /// A registered join still waiting for its welcome.
+    Pending,
+    /// No slot for this id.
+    Missing,
+}
 
 impl Gateway<WakuDeliveryService> {
     pub async fn create_conversation(&self, conversation_id: String) -> anyhow::Result<()> {
@@ -34,10 +49,13 @@ impl Gateway<WakuDeliveryService> {
         tracing::info!(group = %conversation_id, "joining group");
         let core = self.core();
         let user_ref = self.user()?;
-        // A joiner holds no conversation until a welcome arrives: it subscribes
-        // to the topics and announces its key package, then waits. The welcome
-        // is ingested by the delivery forwarder via `User::accept_welcome`,
-        // which builds and registers the conversation in `Working`.
+        // A joiner holds no live conversation until a welcome arrives. We first
+        // register a pending-join slot so the conversation lists and reports as
+        // "joining" right away, then subscribe to the topics and announce our
+        // key package. The welcome is ingested by the delivery forwarder via
+        // `User::accept_welcome`, which fills the slot with the `Working`
+        // conversation.
+        user_ref.read().await.begin_pending_join(&conversation_id)?;
         core.topics.add_many(&conversation_id)?;
         let key_package = user_ref.read().await.generate_key_package()?;
         user_ref
@@ -78,6 +96,15 @@ impl Gateway<WakuDeliveryService> {
 
             if !joined {
                 tracing::debug!(group = %group_name_clone, "join timed out waiting for welcome");
+                // Drop the pending slot so the abandoned join stops listing /
+                // reporting as "joining" (no-op if the welcome raced in).
+                if let Err(e) = user_clone
+                    .read()
+                    .await
+                    .abandon_pending_join(&group_name_clone)
+                {
+                    tracing::warn!(group = %group_name_clone, error = %e, "abandon pending join failed");
+                }
                 return;
             }
 
@@ -187,24 +214,49 @@ impl Gateway<WakuDeliveryService> {
         }
     }
 
-    pub async fn get_steward_status(&self, conversation_id: String) -> anyhow::Result<bool> {
+    /// Resolve a conversation id to a live handle, a pending join, or nothing.
+    async fn locate(&self, conversation_id: &str) -> anyhow::Result<Located> {
         let user_ref = self.user()?;
-        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
-        let is_steward = entry
+        let Some(entry) = user_ref.read().await.lookup_entry(conversation_id)? else {
+            return Ok(Located::Missing);
+        };
+        let pending = entry
             .read()
             .map_err(|_| UserError::LockPoisoned("conversation"))?
-            .is_steward();
-        Ok(is_steward)
+            .is_pending();
+        Ok(if pending {
+            Located::Pending
+        } else {
+            Located::Live(entry)
+        })
+    }
+
+    pub async fn get_steward_status(&self, conversation_id: String) -> anyhow::Result<bool> {
+        match self.locate(&conversation_id).await? {
+            Located::Live(entry) => Ok(entry
+                .read()
+                .map_err(|_| UserError::LockPoisoned("conversation"))?
+                .live_ref()?
+                .is_steward()),
+            // A joining member isn't a steward yet.
+            Located::Pending => Ok(false),
+            Located::Missing => Err(UserError::ConversationNotFound.into()),
+        }
     }
 
     pub async fn get_group_state(&self, conversation_id: String) -> anyhow::Result<String> {
-        let user_ref = self.user()?;
-        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
-        let state = entry
-            .read()
-            .map_err(|_| UserError::LockPoisoned("conversation"))?
-            .state();
-        Ok(state.to_string())
+        match self.locate(&conversation_id).await? {
+            Located::Live(entry) => {
+                let state = entry
+                    .read()
+                    .map_err(|_| UserError::LockPoisoned("conversation"))?
+                    .live_ref()?
+                    .state();
+                Ok(state.to_string())
+            }
+            Located::Pending => Ok(PENDING_JOIN_STATE.to_string()),
+            Located::Missing => Err(UserError::ConversationNotFound.into()),
+        }
     }
 
     /// Get current epoch proposals for the given group
@@ -212,17 +264,28 @@ impl Gateway<WakuDeliveryService> {
         &self,
         conversation_id: String,
     ) -> anyhow::Result<Vec<(String, String)>> {
-        let user_ref = self.user()?;
-        let entry = lookup_conversation(&user_ref, &conversation_id).await?;
-        let proposals = entry
-            .read()
-            .map_err(|_| UserError::LockPoisoned("conversation"))?
-            .approved_proposals_for_current_epoch();
-        Ok(display_batch(&proposals))
+        match self.locate(&conversation_id).await? {
+            Located::Live(entry) => {
+                let proposals = entry
+                    .read()
+                    .map_err(|_| UserError::LockPoisoned("conversation"))?
+                    .live_ref()?
+                    .approved_proposals_for_current_epoch();
+                Ok(display_batch(&proposals))
+            }
+            // No epoch yet — the joiner has no proposals to show.
+            Located::Pending => Ok(Vec::new()),
+            Located::Missing => Err(UserError::ConversationNotFound.into()),
+        }
     }
 
     pub async fn members(&self, conversation_id: String) -> anyhow::Result<Vec<MemberInfo>> {
-        load_member_info(&self.user()?, &conversation_id).await
+        match self.locate(&conversation_id).await? {
+            Located::Live(_) => load_member_info(&self.user()?, &conversation_id).await,
+            // No roster until we hold the welcome.
+            Located::Pending => Ok(Vec::new()),
+            Located::Missing => Err(UserError::ConversationNotFound.into()),
+        }
     }
 
     /// Get epoch history for a group (past batches of approved proposals).

--- a/crates/de_mls_gateway/src/lib.rs
+++ b/crates/de_mls_gateway/src/lib.rs
@@ -307,7 +307,11 @@ impl Gateway<WakuDeliveryService> {
                         _ => continue,
                     };
                     let events = match entry.read() {
-                        Ok(g) => g.drain_events(),
+                        Ok(slot) => match slot.live_ref() {
+                            Ok(conversation) => conversation.drain_events(),
+                            // Pending join — no conversation to drain yet.
+                            Err(_) => continue,
+                        },
                         Err(_) => {
                             tracing::warn!(
                                 conversation = %name,
@@ -326,7 +330,10 @@ impl Gateway<WakuDeliveryService> {
                     // by direct conversation calls in the polling / handler paths
                     // (commit candidates, auto-votes, …).
                     let outbound = match entry.read() {
-                        Ok(g) => g.drain_outbound(),
+                        Ok(slot) => slot
+                            .live_ref()
+                            .map(|c| c.drain_outbound())
+                            .unwrap_or_default(),
                         Err(_) => Vec::new(),
                     };
                     if !outbound.is_empty()

--- a/crates/de_mls_gateway/src/user/inbound.rs
+++ b/crates/de_mls_gateway/src/user/inbound.rs
@@ -3,13 +3,11 @@
 //! de-mls carries no transport subtopic: the integrator routes its own
 //! channels here. Conversation traffic (chat / vote / commit / sync — the
 //! envelope self-identifies) goes to [`User::handle_inbound`]; a joiner's
-//! key-package announcement goes to [`User::receive_key_package`], which any
-//! `Working` member turns into an `add_member` proposal. Raw MLS welcomes
-//! enter through [`User::accept_welcome`].
+//! key-package announcement goes to [`User::receive_key_package`], which the
+//! epoch steward relays as an Add proposal. Raw MLS welcomes enter through
+//! [`User::accept_welcome`].
 
-use de_mls::{
-    ConsensusPlugin, ConversationState, DispatchOutcome, protos::de_mls::messages::v1::MemberInvite,
-};
+use de_mls::{ConsensusPlugin, DispatchOutcome, protos::de_mls::messages::v1::MemberInvite};
 use prost::Message;
 
 use openmls_traits::signatures::Signer;
@@ -44,12 +42,20 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry_arc = self
             .lookup_entry(&inbound.conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        let outcome = entry_arc.write_or_err("conversation")?.process_inbound(
-            self.plugins.conversation_plugins.provider(),
-            &inbound.sender,
-            &inbound.payload,
-            &self.signer,
-        )?;
+        let outcome = {
+            let mut slot = entry_arc.write_or_err("conversation")?;
+            // A pending-join slot has no live conversation yet — it can't process
+            // conversation traffic. Dropping it is benign, not a failure.
+            let Ok(conversation) = slot.live_mut() else {
+                return Ok(());
+            };
+            conversation.process_inbound(
+                self.plugins.conversation_plugins.provider(),
+                &inbound.sender,
+                &inbound.payload,
+                &self.signer,
+            )?
+        };
         if matches!(outcome, DispatchOutcome::LeaveRequested) {
             self.finalize_self_leave(&inbound.conversation_id)?;
         }
@@ -58,11 +64,14 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
     }
 
     /// Ingest a joiner's key-package announcement: decode the `MemberInvite`
-    /// and, if we are a `Working` member of the conversation, open an Add
-    /// proposal for the joiner via [`de_mls::Conversation::add_member`].
-    /// Self-echoes are dropped before the registry lookup (same rationale as
+    /// and hand it to [`de_mls::Conversation::sponsor_member`], which relays it
+    /// as an Add proposal only if we are the epoch steward — de-mls owns the
+    /// steward-only-relay and unbundled-vote policy. (An explicit invite via
+    /// [`User::add_member`] stays open to any member and bundles YES: that is
+    /// one deliberate, endorsed action, not a broadcast fan-out.) Self-echoes
+    /// are dropped before the registry lookup (same rationale as
     /// [`Self::handle_inbound`]); an announcement for a conversation we don't
-    /// hold — or that we are not yet `Working` in — is silently ignored.
+    /// hold — or aren't yet joined into — is silently ignored.
     pub fn receive_key_package(&self, inbound: Inbound) -> Result<(), UserError> {
         if inbound.sender == self.app_id {
             return Ok(());
@@ -75,11 +84,12 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             Err(_) => return Ok(()),
         };
         {
-            let mut conversation = entry_arc.write_or_err("conversation")?;
-            if conversation.state() != ConversationState::Working {
+            let mut slot = entry_arc.write_or_err("conversation")?;
+            // Not yet joined ourselves (pending slot) — nothing to relay.
+            let Ok(conversation) = slot.live_mut() else {
                 return Ok(());
-            }
-            conversation.add_member(
+            };
+            conversation.sponsor_member(
                 self.plugins.conversation_plugins.provider(),
                 &invite.key_package_bytes,
                 &self.signer,

--- a/crates/de_mls_gateway/src/user/lifecycle.rs
+++ b/crates/de_mls_gateway/src/user/lifecycle.rs
@@ -65,7 +65,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             config,
             self.member_id.member_id_bytes(),
         )?;
-        self.register_built(conversation_id, conversation)?;
+        self.install_conversation(conversation_id, conversation)?;
         Ok(())
     }
 }
@@ -86,6 +86,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
 
         let LeaveOutcome::LeaveInitiated = entry_arc
             .write_or_err("conversation")?
+            .live_mut()?
             .leave(self.plugins.conversation_plugins.provider(), &self.signer)?;
         self.flush(&entry_arc)?;
         Ok(())

--- a/crates/de_mls_gateway/src/user/mod.rs
+++ b/crates/de_mls_gateway/src/user/mod.rs
@@ -36,4 +36,6 @@ pub use error::UserError;
 pub use inbound::Inbound;
 pub(crate) use lock::LockExt;
 pub use plugins::UserPlugins;
-pub use state::{ConversationEntry, ConversationLifecycle, GatewayConversation, User};
+pub use state::{
+    ConversationEntry, ConversationLifecycle, ConversationSlot, GatewayConversation, User,
+};

--- a/crates/de_mls_gateway/src/user/registry.rs
+++ b/crates/de_mls_gateway/src/user/registry.rs
@@ -1,10 +1,12 @@
 //! Registry CRUD on the `User` side: conversation lookup.
 
+use std::sync::{Arc, RwLock};
+
 use de_mls::ConsensusPlugin;
 
 use openmls_traits::signatures::Signer;
 
-use crate::user::{ConversationEntry, User, UserError};
+use crate::user::{ConversationEntry, ConversationSlot, User, UserError};
 
 impl<P: ConsensusPlugin, Sig: Signer> User<P, Sig> {
     /// Look up a conversation. Returns `Ok(None)` when no entry is
@@ -23,7 +25,9 @@ impl<P: ConsensusPlugin, Sig: Signer> User<P, Sig> {
             .cloned())
     }
 
-    /// Names of every conversation registered on this `User`.
+    /// Names of every conversation registered on this `User` — both live and
+    /// still-joining. A pending-join slot is listed so the integrator can show
+    /// a joining conversation before its welcome arrives.
     pub fn list_conversations(&self) -> Result<Vec<String>, UserError> {
         Ok(self
             .conversations
@@ -32,5 +36,46 @@ impl<P: ConsensusPlugin, Sig: Signer> User<P, Sig> {
             .keys()
             .cloned()
             .collect())
+    }
+
+    /// Register a pending-join slot: we have announced a key package and await
+    /// the welcome. The slot holds no live [`de_mls::Conversation`] yet, so the
+    /// conversation lists and reports as "joining" until
+    /// [`Self::accept_welcome`] fills it in. Errors with
+    /// [`UserError::ConversationAlreadyExists`] if a slot already exists.
+    pub fn begin_pending_join(&self, conversation_id: &str) -> Result<(), UserError> {
+        let mut conversations = self
+            .conversations
+            .write()
+            .map_err(|_| UserError::LockPoisoned("conversation registry"))?;
+        if conversations.contains_key(conversation_id) {
+            return Err(UserError::ConversationAlreadyExists);
+        }
+        conversations.insert(
+            conversation_id.to_string(),
+            Arc::new(RwLock::new(ConversationSlot::pending())),
+        );
+        Ok(())
+    }
+
+    /// Abandon a pending join that never received its welcome: drop the slot
+    /// only if it is still pending. A slot that went live in the meantime (the
+    /// welcome raced in) is left untouched. No-op if the slot is gone.
+    pub fn abandon_pending_join(&self, conversation_id: &str) -> Result<(), UserError> {
+        let mut conversations = self
+            .conversations
+            .write()
+            .map_err(|_| UserError::LockPoisoned("conversation registry"))?;
+        let Some(entry) = conversations.get(conversation_id).cloned() else {
+            return Ok(());
+        };
+        if entry
+            .read()
+            .map_err(|_| UserError::LockPoisoned("conversation"))?
+            .is_pending()
+        {
+            conversations.remove(conversation_id);
+        }
+        Ok(())
     }
 }

--- a/crates/de_mls_gateway/src/user/state.rs
+++ b/crates/de_mls_gateway/src/user/state.rs
@@ -38,10 +38,57 @@ pub enum ConversationLifecycle {
 /// call from the User's factory.
 pub type GatewayConversation<C> = Conversation<C, DefaultPeerScoring, DefaultStewardList>;
 
-/// Single registry entry: one `Arc<RwLock<Conversation>>` per conversation.
-/// Cloned out of the registry under the outer read lock, then locked
-/// independently — writes on one conversation don't block reads on another.
-pub type ConversationEntry<C> = Arc<RwLock<GatewayConversation<C>>>;
+/// One registry slot: a conversation the user is part of or joining. While a
+/// join is in flight the live handle is `None` — a key package has been
+/// announced and we await the welcome — and [`Self::accept_welcome`] fills it
+/// in. Holding a slot from join-time keeps the registry the single source of
+/// truth: a joining conversation lists and reports as "joining" without a
+/// parallel pending set. This is the gateway's per-conversation wrapper over
+/// the transport-free library handle.
+pub struct ConversationSlot<C: ConsensusPlugin> {
+    conversation: Option<GatewayConversation<C>>,
+}
+
+impl<C: ConsensusPlugin> ConversationSlot<C> {
+    /// A join in progress — no live conversation yet.
+    pub(crate) fn pending() -> Self {
+        Self { conversation: None }
+    }
+
+    /// A live conversation (created by us, or joined via a welcome).
+    pub(crate) fn live(conversation: GatewayConversation<C>) -> Self {
+        Self {
+            conversation: Some(conversation),
+        }
+    }
+
+    /// `true` while the welcome has not yet arrived (slot present, no handle).
+    pub fn is_pending(&self) -> bool {
+        self.conversation.is_none()
+    }
+
+    /// Borrow the live conversation, or [`UserError::ConversationNotFound`]
+    /// while the join is still pending.
+    pub fn live_ref(&self) -> Result<&GatewayConversation<C>, UserError> {
+        self.conversation
+            .as_ref()
+            .ok_or(UserError::ConversationNotFound)
+    }
+
+    /// Mutably borrow the live conversation, or
+    /// [`UserError::ConversationNotFound`] while pending.
+    pub fn live_mut(&mut self) -> Result<&mut GatewayConversation<C>, UserError> {
+        self.conversation
+            .as_mut()
+            .ok_or(UserError::ConversationNotFound)
+    }
+}
+
+/// Single registry entry: one `Arc<RwLock<ConversationSlot>>` per
+/// conversation. Cloned out of the registry under the outer read lock, then
+/// locked independently — writes on one conversation don't block reads on
+/// another.
+pub type ConversationEntry<C> = Arc<RwLock<ConversationSlot<C>>>;
 
 /// Per-user registry of conversations. Each entry's inner per-conversation
 /// lock guards per-conversation reads/mutations so a write on conversation
@@ -65,7 +112,8 @@ pub struct User<P: ConsensusPlugin, Sig: Signer> {
     /// consensus context, the key-package provider, and the three default
     /// configs cloned into newly-created conversations.
     pub(crate) plugins: UserPlugins<P>,
-    /// Conversation handles keyed by conversation id.
+    /// Conversation slots keyed by conversation id. A slot may be live or a
+    /// pending join (welcome not yet received) — see [`ConversationSlot`].
     pub(crate) conversations: ConversationRegistry<P>,
     /// User-level conversation lifecycle events: `Created(name)` /
     /// `Removed(name)`. Integrators drain via
@@ -118,10 +166,12 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             return Err(UserError::WelcomeNotForUs);
         };
         let conversation_id = conversation.id().to_string();
-        if self.lookup_entry(&conversation_id)?.is_some() {
+        // The welcome landed: fill the pending-join slot (or insert a live one
+        // if we accepted without a prior `join_group`). A `None` return means
+        // the conversation is already live — an idempotent re-delivered welcome.
+        let Some(entry_arc) = self.install_conversation(&conversation_id, conversation)? else {
             return Ok(conversation_id);
-        }
-        let entry_arc = self.register_built(&conversation_id, conversation)?;
+        };
         self.flush(&entry_arc)?;
         Ok(conversation_id)
     }
@@ -184,11 +234,14 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("conversation")?.send_message(
-            self.plugins.conversation_plugins.provider(),
-            message,
-            &self.signer,
-        )?;
+        entry
+            .write_or_err("conversation")?
+            .live_mut()?
+            .send_message(
+                self.plugins.conversation_plugins.provider(),
+                message,
+                &self.signer,
+            )?;
         self.flush(&entry)?;
         Ok(())
     }
@@ -223,6 +276,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             .ok_or(UserError::ConversationNotFound)?;
         let outcome = entry
             .write_or_err("conversation")?
+            .live_mut()?
             .poll(self.plugins.conversation_plugins.provider(), &self.signer);
         self.flush(&entry)?;
         Ok(outcome)
@@ -234,7 +288,10 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.drain_events())
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .drain_events())
     }
 
     /// Earliest pending deadline on `conversation_id` relative to now,
@@ -244,7 +301,10 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.next_wakeup_in())
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .next_wakeup_in())
     }
 
     /// Propose adding the holder of `key_package_bytes` to
@@ -261,7 +321,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("conversation")?.add_member(
+        entry.write_or_err("conversation")?.live_mut()?.add_member(
             self.plugins.conversation_plugins.provider(),
             key_package_bytes,
             &self.signer,
@@ -284,7 +344,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("conversation")?.vote(
+        entry.write_or_err("conversation")?.live_mut()?.vote(
             self.plugins.conversation_plugins.provider(),
             proposal_id,
             vote,
@@ -301,11 +361,14 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("conversation")?.remove_member(
-            self.plugins.conversation_plugins.provider(),
-            member_id,
-            &self.signer,
-        )?;
+        entry
+            .write_or_err("conversation")?
+            .live_mut()?
+            .remove_member(
+                self.plugins.conversation_plugins.provider(),
+                member_id,
+                &self.signer,
+            )?;
         self.flush(&entry)?;
         Ok(())
     }
@@ -324,12 +387,15 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        entry.write_or_err("conversation")?.initiate_proposal(
-            self.plugins.conversation_plugins.provider(),
-            request,
-            creator_vote,
-            &self.signer,
-        )?;
+        entry
+            .write_or_err("conversation")?
+            .live_mut()?
+            .initiate_proposal(
+                self.plugins.conversation_plugins.provider(),
+                request,
+                creator_vote,
+                &self.signer,
+            )?;
         self.flush(&entry)?;
         Ok(())
     }
@@ -345,7 +411,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.state())
+        Ok(entry.read_or_err("conversation")?.live_ref()?.state())
     }
 
     /// `true` if the local user is on the current steward list for
@@ -354,7 +420,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.is_steward())
+        Ok(entry.read_or_err("conversation")?.live_ref()?.is_steward())
     }
 
     /// MLS epoch + reelection retry round for `conversation_id`. Mirrors
@@ -363,21 +429,27 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.epoch_and_retry()?)
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .epoch_and_retry()?)
     }
 
     pub fn members(&self, conversation_id: &str) -> Result<Vec<Vec<u8>>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.members()?)
+        Ok(entry.read_or_err("conversation")?.live_ref()?.members()?)
     }
 
     pub fn member_scores(&self, conversation_id: &str) -> Result<Vec<(Vec<u8>, i64)>, UserError> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.member_scores())
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .member_scores())
     }
 
     pub fn member_score(
@@ -388,7 +460,10 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.member_score(member_id))
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .member_score(member_id))
     }
 
     pub fn member_roles(
@@ -398,7 +473,10 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.member_roles()?)
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .member_roles()?)
     }
 
     /// Identities with an in-flight self-leave request. Mirrors
@@ -412,6 +490,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             .ok_or(UserError::ConversationNotFound)?;
         Ok(entry
             .read_or_err("conversation")?
+            .live_ref()?
             .pending_leave_member_ids()?)
     }
 
@@ -421,7 +500,10 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
         let entry = self
             .lookup_entry(conversation_id)?
             .ok_or(UserError::ConversationNotFound)?;
-        Ok(entry.read_or_err("conversation")?.pending_update_count())
+        Ok(entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .pending_update_count())
     }
 
     /// Approved proposals for the current epoch. Mirrors
@@ -435,6 +517,7 @@ impl<P: ConsensusPlugin, Sig: Signer + Clone> User<P, Sig> {
             .ok_or(UserError::ConversationNotFound)?;
         Ok(entry
             .read_or_err("conversation")?
+            .live_ref()?
             .approved_proposals_for_current_epoch())
     }
 }
@@ -446,31 +529,40 @@ impl<P: ConsensusPlugin, Sig: Signer> User<P, Sig> {
         self.member_id.member_id_bytes()
     }
 
-    /// Insert an already-built [`Conversation`] into the registry, emit the
-    /// `Created` lifecycle event, and return the registry entry. Errors with
-    /// [`UserError::ConversationAlreadyExists`] if an entry races in under the
-    /// write lock. Shared by the creator path and the welcome-driven join.
-    pub(crate) fn register_built(
+    /// Install an already-built [`Conversation`] into its slot: fill an
+    /// existing pending-join slot, or insert a new live one. Emits the
+    /// `Created` lifecycle event when the conversation first becomes
+    /// addressable and returns its registry entry. Returns `Ok(None)` if the
+    /// slot is already live — an idempotent re-delivered welcome for a
+    /// conversation we already joined. Shared by the creator path and the
+    /// welcome-driven join.
+    pub(crate) fn install_conversation(
         &self,
         conversation_id: &str,
         conversation: GatewayConversation<P>,
-    ) -> Result<ConversationEntry<P>, UserError> {
-        let entry = Arc::new(RwLock::new(conversation));
-        {
+    ) -> Result<Option<ConversationEntry<P>>, UserError> {
+        let entry = {
             let mut conversations = self
                 .conversations
                 .write()
                 .map_err(|_| UserError::LockPoisoned("conversation registry"))?;
-            if conversations.contains_key(conversation_id) {
-                return Err(UserError::ConversationAlreadyExists);
+            conversations
+                .entry(conversation_id.to_string())
+                .or_insert_with(|| Arc::new(RwLock::new(ConversationSlot::pending())))
+                .clone()
+        };
+        {
+            let mut slot = entry.write_or_err("conversation")?;
+            if !slot.is_pending() {
+                return Ok(None);
             }
-            conversations.insert(conversation_id.to_string(), entry.clone());
+            *slot = ConversationSlot::live(conversation);
         }
         // The conversation already buffered its opening `PhaseChange`; record the
         // lifecycle event so integrators draining
         // [`Self::drain_lifecycle_events`] discover the conversation.
         self.emit_lifecycle(ConversationLifecycle::Created(conversation_id.to_string()));
-        Ok(entry)
+        Ok(Some(entry))
     }
 
     /// Append a [`ConversationLifecycle`] event to the pending-events buffer
@@ -492,7 +584,10 @@ impl<P: ConsensusPlugin, Sig: Signer> User<P, Sig> {
     /// (When `User` moves out of the library, the integrator drains and
     /// publishes directly instead.)
     pub(crate) fn flush(&self, entry: &ConversationEntry<P>) -> Result<(), UserError> {
-        let outbound = entry.read_or_err("conversation")?.drain_outbound();
+        let outbound = entry
+            .read_or_err("conversation")?
+            .live_ref()?
+            .drain_outbound();
         if outbound.is_empty() {
             return Ok(());
         }

--- a/crates/de_mls_gateway/tests/app_message_roundtrip.rs
+++ b/crates/de_mls_gateway/tests/app_message_roundtrip.rs
@@ -43,6 +43,8 @@ fn chat_message_delivered_to_peer_as_app_message_event() {
     let chat = bob_session
         .read()
         .unwrap()
+        .live_ref()
+        .unwrap()
         .drain_events()
         .into_iter()
         .find_map(|e| match e {

--- a/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
+++ b/crates/de_mls_gateway/tests/common/conversation_fixtures.rs
@@ -8,7 +8,7 @@
 
 #![allow(dead_code)]
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -17,7 +17,7 @@ use de_mls::{ConversationConfig, StewardListConfig};
 use de_mls_ds::{
     DeliveryService, DeliveryServiceError, OutboundPacket, SharedDeliveryService, WELCOME_SUBTOPIC,
 };
-use de_mls_gateway::user::{GatewayConversation, Inbound, User};
+use de_mls_gateway::user::{Inbound, User};
 use openmls_basic_credential::SignatureKeyPair;
 
 use crate::common::wallet::user_from_private_key;
@@ -27,8 +27,6 @@ use crate::common::wallet::user_from_private_key;
 pub type TransportHandle = Arc<Mutex<CapturingTransport>>;
 
 pub type TestUser = User<DefaultConsensusPlugin, SignatureKeyPair>;
-pub type TestConversation = GatewayConversation<DefaultConsensusPlugin>;
-pub type ConversationArc = Arc<RwLock<TestConversation>>;
 
 /// Test transport that captures every outbound packet for later inspection
 /// instead of sending. `subscribe` is a no-op — tests deliver inbound
@@ -214,18 +212,6 @@ pub fn poll_once(user: &TestUser, conversation: &str) {
     let _ = user.poll_conversation(conversation);
 }
 
-/// Flush a session's pull-buffered outbound into its user's transport handle
-/// so the relay (which drains the handle) picks it up. The session is
-/// pull-only — direct session calls in tests buffer here instead of sending;
-/// this stands in for the integrator's drain-and-publish.
-pub fn flush_conversation(session: &ConversationArc, transport: &TransportHandle) {
-    let outbound = session.read().unwrap().drain_outbound();
-    let mut t = transport.lock().unwrap();
-    for out in outbound {
-        t.publish(out.into()).expect("capture publish");
-    }
-}
-
 /// Flush every conversation's pull-buffered outbound on `user` into its
 /// transport handle. Uniform stand-in for the integrator's drain — relay
 /// loops call this for each user before draining the handles, regardless of
@@ -234,7 +220,11 @@ pub fn flush_user(user: &TestUser, transport: &TransportHandle) {
     let mut t = transport.lock().unwrap();
     for name in user.list_conversations().unwrap_or_default() {
         if let Ok(Some(session)) = user.lookup_entry(&name) {
-            for out in session.read().unwrap().drain_outbound() {
+            let guard = session.read().unwrap();
+            let Ok(conversation) = guard.live_ref() else {
+                continue;
+            };
+            for out in conversation.drain_outbound() {
                 t.publish(out.into()).expect("capture publish");
             }
         }

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -104,6 +104,13 @@ pub(crate) struct Timing {
     /// on consecutive polling ticks that observe the same progress. Reset to
     /// `None` when the conversation leaves `Freezing`.
     pub(crate) last_freeze_progress: Option<(usize, usize)>,
+    /// Anchor for the backup-steward proposal takeover: set when an
+    /// unproposed buffered membership update first appears with no live
+    /// proposal for it. A backup steward proposes the buffered update once
+    /// this is older than the recovery window — the epoch steward had its
+    /// chance and stayed silent. Cleared when the buffer is drained or nothing
+    /// is left to propose.
+    pub(crate) buffered_propose_anchor: Option<Instant>,
 }
 
 impl Timing {
@@ -115,6 +122,7 @@ impl Timing {
             pending_auto_votes: HashMap::new(),
             pending_consensus_timeouts: HashMap::new(),
             last_freeze_progress: None,
+            buffered_propose_anchor: None,
         }
     }
 }

--- a/src/conversation/messaging.rs
+++ b/src/conversation/messaging.rs
@@ -78,12 +78,11 @@ where
         Ok(())
     }
 
-    /// Start a `MemberInvite` consensus round for the given TLS-encoded key
-    /// package. Parses the key package, extracts the member id, and submits a
-    /// proposal with a bundled YES vote. The resulting welcome fires as
-    /// [`crate::ConversationEvent::WelcomeReady`] for the integrator to
-    /// deliver out of band. No-op when the key package addresses the local
-    /// member or someone already in the group.
+    /// Invite a joiner whose key package the caller supplies out of band,
+    /// endorsing the add by bundling a YES vote at submit. Any member may call.
+    /// Errors unless the conversation is `Working`.
+    ///
+    /// See [`Self::sponsor_member`] for the non-endorsing steward relay.
     pub fn add_member<Pr>(
         &mut self,
         provider: &Pr,
@@ -98,6 +97,72 @@ where
         if state != ConversationState::Working {
             return Err(ConversationError::ConversationBlocked(state.to_string()));
         }
+        self.propose_add(provider, key_package_bytes, CreatorVote::Yes, signer)
+    }
+
+    /// Relay a joiner that announced its own key package, without endorsing it:
+    /// the proposal is submitted unbundled ([`CreatorVote::Deferred`]) and this
+    /// member votes on it like any other. Only the primary epoch steward relays
+    /// immediately, so a single Add proposal is opened per joiner. Every other
+    /// member records the announcement in the pending-update buffer instead —
+    /// a backup proposes it from there if the epoch steward stays silent past
+    /// the recovery window (drained by `poll`), so an offline epoch steward
+    /// doesn't strand the join. No-op outside `Working`.
+    ///
+    /// See [`Self::add_member`] for the endorsing out-of-band invite.
+    pub fn sponsor_member<Pr>(
+        &mut self,
+        provider: &Pr,
+        key_package_bytes: &[u8],
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        if self.current_state() != ConversationState::Working {
+            return Ok(());
+        }
+        if self.is_epoch_steward()? {
+            return self.propose_add(provider, key_package_bytes, CreatorVote::Deferred, signer);
+        }
+        self.buffer_announced_add(key_package_bytes)
+    }
+
+    /// Record an announced joiner in the pending-update buffer (the same buffer
+    /// every member keeps for membership changes seen on the wire). Lets a
+    /// backup steward propose the Add later if the epoch steward never does.
+    /// Skips our own key package and members already in the group.
+    fn buffer_announced_add(&mut self, key_package_bytes: &[u8]) -> Result<(), ConversationError> {
+        let (kp_bytes, member_id) = key_package_bytes_from_tls(key_package_bytes.to_vec())?;
+        if member_id == *self.member_id_bytes() || self.mls().is_member(&member_id) {
+            return Ok(());
+        }
+        let epoch = self.mls().current_epoch()?;
+        self.queues.insert_pending_update(
+            ConversationUpdateRequest::member_invite(MemberInvite {
+                key_package_bytes: kp_bytes,
+                member_id,
+            }),
+            epoch,
+        );
+        Ok(())
+    }
+
+    /// Shared body of [`Self::add_member`] / [`Self::sponsor_member`]: parse the
+    /// key package, skip our own and already-present members, and open the Add
+    /// proposal with the caller-chosen vote mode.
+    fn propose_add<Pr>(
+        &mut self,
+        provider: &Pr,
+        key_package_bytes: &[u8],
+        creator_vote: CreatorVote,
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
         let (kp_bytes, member_id) = key_package_bytes_from_tls(key_package_bytes.to_vec())?;
         // Don't propose our own key package.
         if member_id == *self.member_id_bytes() {
@@ -118,7 +183,7 @@ where
                 key_package_bytes: kp_bytes,
                 member_id,
             }),
-            CreatorVote::Yes,
+            creator_vote,
             signer,
         )?;
         Ok(())

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -6,7 +6,10 @@
 //! `poll()` once per wakeup cycle and reacts to the returned [`PollOutcome`].
 
 use std::error::Error as StdError;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use openmls_traits::signatures::Signer;
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
@@ -67,6 +70,14 @@ where
                 error = %e,
                 "advance_freeze error in poll"
             ),
+        }
+
+        if let Err(e) = self.drive_buffered_proposals(provider, signer) {
+            warn!(
+                conversation = %self.conversation_id,
+                error = %e,
+                "buffered-proposal drive error in poll"
+            );
         }
 
         if let Err(e) = self.start_freeze_on_inactivity(provider, signer) {
@@ -265,6 +276,63 @@ where
         }
     }
 
+    /// Drive the backup-steward proposal takeover. The epoch steward sponsors
+    /// announced joiners immediately; everyone else only buffers them. If the
+    /// epoch steward stays silent, the join would stall — so here a backup
+    /// steward drains the buffer once the recovery window passes, mirroring the
+    /// commit takeover (primary leads, backup follows after `recovery`).
+    ///
+    /// No-op outside `Working`; deferred while approved work is pending (the
+    /// commit path owns that, and the next epoch advance drains the buffer);
+    /// the epoch steward drains immediately; plain members never drain.
+    fn drive_buffered_proposals<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        let idle = self.current_state() != ConversationState::Working
+            || self.queues.approved_proposals_count() > 0
+            || self.actionable_buffered_updates()?.is_empty();
+        if idle {
+            self.timing.buffered_propose_anchor = None;
+            return Ok(());
+        }
+
+        // The epoch steward is responsible now — propose without waiting.
+        if self.is_epoch_steward()? {
+            self.timing.buffered_propose_anchor = None;
+            return self.drain_buffered_updates(provider, signer);
+        }
+        // Only a steward can take over; a plain member just keeps its backup copy.
+        if !self.is_steward() {
+            return Ok(());
+        }
+
+        // Backup steward: give the epoch steward the recovery window first.
+        let anchor = match self.timing.buffered_propose_anchor {
+            Some(a) => a,
+            None => {
+                self.timing.buffered_propose_anchor = Some(Instant::now());
+                return Ok(());
+            }
+        };
+        let delay =
+            self.config.commit_inactivity_duration + self.config.recovery_inactivity_duration;
+        if Instant::now() < anchor + delay {
+            return Ok(());
+        }
+        self.timing.buffered_propose_anchor = None;
+        info!(
+            conversation = %self.conversation_id,
+            "backup steward proposing buffered updates: epoch steward silent past recovery window"
+        );
+        self.drain_buffered_updates(provider, signer)
+    }
+
     /// Steward-inactivity freeze entry: once the inactivity timer fires with
     /// approved work pending, start the freeze round and transition into
     /// `Freezing`. Stewards build their own commit candidate too;
@@ -292,8 +360,16 @@ where
             self.is_in_recovery_mode() || self.services.steward_list.next_retry_round() > 0;
         let inactivity = if in_recovery {
             self.config.recovery_inactivity_duration
-        } else {
+        } else if self.is_epoch_steward()? {
+            // The primary steward leads: it commits at the commit-inactivity
+            // deadline.
             self.config.commit_inactivity_duration
+        } else {
+            // Backups (and non-stewards) wait an extra recovery window. In the
+            // normal case the primary's commit candidate pulls them into freeze
+            // first, so they never self-drive it; only a silent primary lets
+            // this longer deadline fire and a backup step in.
+            self.config.commit_inactivity_duration + self.config.recovery_inactivity_duration
         };
         let Some(event) = self.check_steward_inactivity(proposal_count, inactivity) else {
             return Ok(());

--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -65,6 +65,25 @@ where
         self.services.steward_list.is_steward(&self.self_member_id)
     }
 
+    /// `true` if the local member is the **primary** steward designated for the
+    /// current epoch — the one that should commit and sponsor joiners first.
+    /// Unlike [`Self::is_steward`] (true for any member on the list, backups
+    /// included), this is true for exactly one member per epoch, so it gates the
+    /// single-actor paths: backups defer to the primary and only step in after
+    /// the recovery window. Eligibility is the same live rotation
+    /// [`Self::member_roles`] uses, so all members agree on who it is.
+    pub fn is_epoch_steward(&self) -> Result<bool, ConversationError> {
+        let mls = self.mls();
+        let epoch = mls.current_epoch()?;
+        let members = mls.members()?;
+        let eligible = self.queues.steward_eligibility(&members);
+        let (epoch_steward, _backup) = self
+            .services
+            .steward_list
+            .epoch_and_backup(epoch, &eligible);
+        Ok(epoch_steward == Some(self.self_member_id.as_ref()))
+    }
+
     /// Identity bytes of every current member of this conversation, as
     /// reported by MLS.
     pub fn members(&self) -> Result<Vec<Vec<u8>>, ConversationError> {

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -205,6 +205,17 @@ impl ConversationQueues {
         &self.approved_proposals
     }
 
+    /// Member ids targeted by an in-flight proposal — either still voting or
+    /// already approved. A buffered update whose target is in this set is
+    /// already covered by a live proposal and must not be re-proposed.
+    pub fn active_proposal_targets(&self) -> HashSet<&[u8]> {
+        self.voting_proposals
+            .values()
+            .chain(self.approved_proposals.values())
+            .filter_map(target_member_id_of)
+            .collect()
+    }
+
     /// True iff `approved_proposals` carries any `RemoveMember(member_id)`,
     /// regardless of source. Used by `steward_eligibility` to skip a member
     /// whose removal is queued — MLS forbids them from committing it

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -211,8 +211,9 @@ where
     }
 
     /// On epoch advance, the new live epoch steward drains the pending-update
-    /// buffer into voting proposals. Skips entries already covered by the
-    /// current voting/approved queues so we don't double-propose.
+    /// buffer into voting proposals. A backup steward reaches the same drain
+    /// from `poll` once the recovery window passes (see
+    /// [`Self::drain_buffered_updates`]).
     pub(crate) fn process_buffered_updates<Pr>(
         &mut self,
         provider: &Pr,
@@ -222,71 +223,67 @@ where
         Pr: OpenMlsProvider,
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
-        let (current_epoch, to_propose, conversation_id): (
-            u64,
-            Vec<ConversationUpdateRequest>,
-            String,
-        ) = {
-            let (current_epoch, members) = {
-                let mls = self.mls();
-                (mls.current_epoch()?, mls.members()?)
-            };
-            let self_member_id: &[u8] = &self.self_member_id;
-            let eligible = self.queues.steward_eligibility(&members);
-            let is_live = self
-                .services
-                .steward_list
-                .epoch_steward(current_epoch, &eligible)
-                .is_some_and(|es| es == self_member_id);
-            if !is_live {
-                return Ok(());
-            }
+        if !self.is_epoch_steward()? {
+            return Ok(());
+        }
+        self.drain_buffered_updates(provider, signer)
+    }
 
-            // Collect buffered updates whose target isn't already in an
-            // active proposal queue. Both the voting and approved queues
-            // live on `ConversationQueues`.
-            let approved = self.queues.approved_proposals();
-            let approved_targets: std::collections::HashSet<&[u8]> =
-                approved.values().filter_map(target_member_id_of).collect();
-            let members_set = member_set(&members);
+    /// Buffered membership updates still needing a proposal: not already
+    /// covered by a live (voting or approved) proposal, and still valid — an
+    /// Add for a non-member or a Remove for a current member.
+    pub(crate) fn actionable_buffered_updates(
+        &self,
+    ) -> Result<Vec<ConversationUpdateRequest>, ConversationError> {
+        let members = self.mls().members()?;
+        let members_set = member_set(&members);
+        let active = self.queues.active_proposal_targets();
+        Ok(self
+            .queues
+            .pending_updates()
+            .iter()
+            .filter(|(id, _)| !active.contains(id.as_slice()))
+            .filter(|(id, p)| {
+                // Drop Add for already-member and Remove for non-member.
+                let is_member = members_set.contains(id.as_slice());
+                match p.request.payload.as_ref() {
+                    Some(conversation_update_request::Payload::MemberInvite(_)) => !is_member,
+                    Some(conversation_update_request::Payload::RemoveMember(_)) => is_member,
+                    _ => false,
+                }
+            })
+            .map(|(_, p)| p.request.clone())
+            .collect())
+    }
 
-            let to_propose: Vec<ConversationUpdateRequest> = self
-                .queues
-                .pending_updates()
-                .iter()
-                .filter(|(id, _)| !approved_targets.contains(id.as_slice()))
-                .filter(|(id, p)| {
-                    // Drop Add for already-member and Remove for non-member.
-                    let is_member = members_set.contains(id.as_slice());
-                    match p.request.payload.as_ref() {
-                        Some(conversation_update_request::Payload::MemberInvite(_)) => !is_member,
-                        Some(conversation_update_request::Payload::RemoveMember(_)) => is_member,
-                        _ => false,
-                    }
-                })
-                .map(|(_, p)| p.request.clone())
-                .collect();
-            (current_epoch, to_propose, self.conversation_id.clone())
-        };
-
+    /// Promote every actionable buffered update to a voting proposal
+    /// (`CreatorVote::Deferred` — the proposer relays peer intent, it doesn't
+    /// endorse). Callers gate *who* drains: the epoch steward immediately via
+    /// [`Self::process_buffered_updates`], a backup after the recovery window
+    /// via `poll`. This just performs the drain.
+    pub(crate) fn drain_buffered_updates<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        let to_propose = self.actionable_buffered_updates()?;
         if to_propose.is_empty() {
             return Ok(());
         }
-
         info!(
-            conversation = %conversation_id,
-            epoch = current_epoch,
+            conversation = %self.conversation_id,
             count = to_propose.len(),
             "promoting buffered updates to proposals"
         );
-
-        // Buffered updates inherit the same vote request path as fresh
-        // steward-auto-propose — the steward still decides per proposal.
         for request in to_propose {
             if let Err(e) = self.initiate_proposal(provider, request, CreatorVote::Deferred, signer)
             {
                 info!(
-                    conversation = %conversation_id,
+                    conversation = %self.conversation_id,
                     error = %e,
                     "buffered proposal deferred"
                 );

--- a/src/freeze/apply.rs
+++ b/src/freeze/apply.rs
@@ -379,8 +379,15 @@ fn validate_commit_candidate(
         .filter_map(action_projection_from_request)
         .collect();
     let mut actual: Vec<(u8, &[u8])> = mls_actions.iter().map(action_projection_from_mls).collect();
+    // Dedup by (kind, member): RFC §Consensus Types lets any member create a
+    // Commit proposal, so several finalized proposals may name the same
+    // membership change. The steward commits that change once, so the MLS
+    // actions carry one entry where the voted set carries duplicates — not a
+    // violation. Both sides are compared as deduplicated sets.
     expected.sort();
+    expected.dedup();
     actual.sort();
+    actual.dedup();
 
     if expected == actual {
         return Ok(None);

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -559,7 +559,10 @@ impl Member {
             return;
         }
         let invite = MemberInvite::decode(packet.payload.as_slice()).expect("decode key package");
-        let _ = convo.add_member(
+        // Mirror the integrator: an announced joiner is relayed via
+        // `sponsor_member` (epoch steward proposes; others buffer for backup
+        // takeover), not the explicit any-member `add_member`.
+        let _ = convo.sponsor_member(
             &self.integ.provider,
             &invite.key_package_bytes,
             &self.integ.signer,
@@ -708,6 +711,13 @@ impl<const N: usize> TestHarness<N> {
         for member in &mut self.members {
             member.deliver_key_package(packet);
         }
+    }
+
+    /// Deliver a key-package announcement to a single member — models an
+    /// announcement that only some members observed (e.g. the epoch steward
+    /// missed it, so a backup must carry the join).
+    pub fn deliver_key_package_to(&mut self, index: usize, packet: &Outbound) {
+        self.members[index].deliver_key_package(packet);
     }
 
     pub fn conversation_id(&self) -> &str {

--- a/tests/protocol_steward.rs
+++ b/tests/protocol_steward.rs
@@ -7,7 +7,7 @@ mod common;
 use std::time::Duration;
 
 use common::harness::{TestHarness, fast_config};
-use de_mls::StewardListConfig;
+use de_mls::{ConversationConfig, StewardListConfig};
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -82,4 +82,49 @@ fn assert_no_election_storm<const N: usize>(h: &TestHarness<N>) {
         h.members().iter().all(|m| m.retry_round() == 0),
         "retry_round stays 0 — no election fires for unsettled members"
     );
+}
+
+#[test]
+fn backup_steward_proposes_buffered_joiner_when_epoch_steward_silent() {
+    // sn_max = 5 ≥ membership at every size here, so the steward list is always
+    // the full roster and growing back to 3 fires no subset election — the test
+    // isolates the backup *proposal* takeover, not election.
+    let cfg = ConversationConfig {
+        recovery_inactivity_duration: Duration::from_millis(100),
+        ..fast_config()
+    };
+    let mut h = TestHarness::<3>::bootstrap(
+        [ALICE, BOB, CHARLIE],
+        "bk",
+        cfg.clone(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    // Evict member 2 so we can re-announce it as a fresh joiner.
+    let target = 2usize;
+    let target_id = h.member(target).member_id_bytes().to_vec();
+    let driver = (0..3).find(|&i| i != target).unwrap();
+    h.member_mut(driver).remove_member(&target_id);
+    h.process_until("target evicted", |h| h.member(driver).member_count() == 2);
+
+    // Identify the two remaining stewards' roles.
+    let epoch_steward = (0..3)
+        .filter(|&i| i != target)
+        .find(|&i| h.member(i).convo().is_epoch_steward().unwrap())
+        .expect("an epoch steward exists among the remaining two");
+    let backup = (0..3)
+        .find(|&i| i != target && i != epoch_steward)
+        .expect("a backup steward exists");
+
+    // The joiner announces, but only the backup observes it — the epoch steward
+    // never sees the announcement, so it never sponsors. Without the backup
+    // takeover the join would stall forever; with it, the backup proposes the
+    // buffered Add after the recovery window and the live epoch steward commits.
+    h.member_mut(target).rejoin("bk", cfg.clone());
+    let announcement = h.member_mut(target).announce_key_package("bk");
+    h.deliver_key_package_to(backup, &announcement);
+
+    h.process_until("backup carries the join to completion", |h| {
+        h.member(backup).member_count() == 3 && h.member(target).member_count() == 3
+    });
 }


### PR DESCRIPTION
Fixes the multi-member join failures the desktop POC hit once a third member joined.

Membership proposals are split by intent: `add_member` stays the explicit invite (any member, bundled YES), while a new `sponsor_member` relays a joiner that announced its own key package — only the epoch steward proposes it (unbundled, voting like everyone), so a single Add is opened per joiner instead of one per member. Commit validation now deduplicates membership changes by target, since the RFC allows several members to raise the same Add and the steward commits it once.

Steward liveness is symmetric: the epoch steward leads, and a backup steward takes over after the recovery window — for commits (already present) and now for proposals, by draining the existing per-member pending-update buffer from `poll` when the primary stays silent. An offline epoch steward no longer strands a join, with no reelection.

The gateway models a joining conversation as a `ConversationSlot { Option<Conversation> }`: it lists and reports as `PendingJoin` from join-time until its welcome lands, instead of erroring as `ConversationNotFound`. Pending-window inbound and broadcast-welcome non-addressees are quieted to `debug`.