### PR TITLE
chore: bump version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "de-mls"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "alloy",
  "hashgraph-like-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "de-mls"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Decentralized MLS — end-to-end encrypted group messaging with consensus-based membership management over gossipsub-like networks"


### PR DESCRIPTION
Major release over the published 3.0.0 (crates.io, 2026-05-20). Everything since is a breaking reshape: the library-ized `Conversation` API, the provider-by-reference engine, and the multi-member join fixes (add_member/sponsor_member split, backup-steward takeover, commit-validation dedup).

v4.0.0 is the baseline for de-mls-poc and libchat to pin.