### PR TITLE
refactor(api)!: fold steward config and regroup constructor/method params

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,17 @@ use de_mls::defaults::{DefaultConsensusPlugin, InMemoryPeerScoreStorage};
 // *storage* backend. `consensus` is a `ConsensusPlugin` instance you hold and
 // pass by reference; `scoring` is a `PeerScoringService` built over the storage
 // (see `de_mls::defaults::DefaultPeerScoring`). The steward roster is
-// library-owned — you pass only a `StewardListConfig`. Create a conversation
-// you steward, or join one from a welcome:
+// library-owned — you set its size bounds on `config` (a `ConversationConfig`).
+// Create a conversation you steward, or join one from a welcome:
 let mut convo: Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage> =
-    Conversation::create(id, &provider, credential, suite, &signer,
-                         scoring, steward_config, &consensus, app_id, config, member_id)?;
+    Conversation::create(id, member_id, &provider, credential, suite, &signer,
+                         &consensus, scoring, app_id, config)?;
 
-// let joined = Conversation::join(&provider, welcome_bytes, sync_bytes, …, &signer)?;  // Ok(None) = not for us
+// let joined = Conversation::join(member_id, &provider, &signer,
+//                                 welcome_bytes, sync_bytes, …)?;  // Ok(None) = not for us
 
 // Drive it once per wakeup cycle, then drain its products:
-convo.process_inbound(&provider, &sender, &payload, &signer)?; // feed inbound bytes
+convo.process_inbound(&provider, &signer, &sender, &payload)?; // feed inbound bytes
 convo.poll(&provider, &signer);                                // tick timers / freeze / commits
 for event in convo.drain_events()   { /* AppMessage, WelcomeReady, PhaseChange, … */ }
 for out   in convo.drain_outbound() { /* publish out.payload on your transport */ }
@@ -64,8 +65,8 @@ reports its next deadline via `next_wakeup_in()`, advancing when you call
 
 Default implementations (consensus over `hashgraph-like-consensus` and
 in-memory peer-score storage) live in `de_mls::defaults` — adopt them
-wholesale or swap either. The steward list is library-owned; you configure it
-with a `StewardListConfig`.
+wholesale or swap either. The steward list is library-owned; you set its size
+bounds via `ConversationConfig`'s `steward_list` field.
 
 A complete, runnable construction — creator and joiner built straight from
 direct arguments — is in
@@ -110,10 +111,10 @@ write.
 ## Steward list
 
 Who may commit each epoch — the steward roster and its epoch/backup rotation —
-is fully library-owned. You pass only a `StewardListConfig` (the `sn_min` /
-`sn_max` size bounds) at construction; de-mls generates the list, validates
-election proposals, runs the election through consensus, and rotates the epoch
-steward.
+is fully library-owned. You set only its size bounds (`sn_min` / `sn_max`, the
+`steward_list` field on `ConversationConfig`); de-mls generates the list,
+validates election proposals, runs the election through consensus, and rotates
+the epoch steward.
 
 Generation is deterministic and normative: every member derives the identical
 roster by sorting on `SHA256(epoch ‖ retry_round ‖ member_id ‖

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -154,9 +154,9 @@ where
     pub fn vote<Pr>(
         &mut self,
         provider: &Pr,
+        signer: &impl Signer,
         proposal_id: u32,
         vote: bool,
-        signer: &impl Signer,
     ) -> Result<(), ConversationError>
     where
         Pr: OpenMlsProvider,

--- a/src/conversation/config.rs
+++ b/src/conversation/config.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::DEFAULT_MAX_RETRIES;
 use crate::ProposalKind;
+use crate::StewardListConfig;
 use crate::protos::de_mls::messages::v1::TimingConfig;
 
 /// Wall-clock window the steward waits before batching approved proposals
@@ -43,9 +44,10 @@ pub const DEFAULT_MAX_CONSENSUS_SESSIONS: usize = 10;
 /// runaway growth when freeze recovery preserves work across failed cycles.
 pub const DEFAULT_COMMIT_BATCH_MAX: usize = 50;
 
-/// Per-conversation timing config. Plug-in domains (scoring, steward list)
-/// own their own configs on the respective plug-ins — see
-/// [`crate::ScoringConfig`] and [`crate::StewardListConfig`].
+/// Per-conversation timing and policy config, fixed at conversation creation.
+/// Peer scoring keeps its own config on the [`PeerScoringService`](crate::PeerScoringService)
+/// the integrator builds; the steward-list bounds live here (the list is
+/// library-owned) as the nested [`steward_list`](Self::steward_list).
 #[derive(Debug, Clone)]
 pub struct ConversationConfig {
     /// RFC §Inactivity Timer #1: how long the epoch steward has to commit
@@ -86,6 +88,9 @@ pub struct ConversationConfig {
     /// Max MLS proposals the steward packs into one commit batch. See
     /// [`DEFAULT_COMMIT_BATCH_MAX`].
     pub commit_batch_max: usize,
+    /// Steward-list size bounds (`sn_min` / `sn_max`). The roster itself is
+    /// library-owned; this is the only steward knob the integrator sets.
+    pub steward_list: StewardListConfig,
 }
 
 impl Default for ConversationConfig {
@@ -103,6 +108,7 @@ impl Default for ConversationConfig {
             liveness_criteria_yes: DEFAULT_LIVENESS_CRITERIA_YES,
             max_consensus_sessions: DEFAULT_MAX_CONSENSUS_SESSIONS,
             commit_batch_max: DEFAULT_COMMIT_BATCH_MAX,
+            steward_list: StewardListConfig::default(),
         }
     }
 }

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -37,15 +37,15 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn create<Pr>(
         conversation_id: &str,
+        member_id: &[u8],
         provider: &Pr,
         credential: CredentialWithKey,
         ciphersuite: Ciphersuite,
         signer: &impl Signer,
-        scoring: PeerScoringService<Sc>,
         consensus: &C,
+        scoring: PeerScoringService<Sc>,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
-        member_id: &[u8],
     ) -> Result<Self, ConversationError>
     where
         Pr: OpenMlsProvider,
@@ -83,15 +83,15 @@ where
     /// prior knowledge of the conversation.
     #[allow(clippy::too_many_arguments)]
     pub fn join<Pr>(
+        member_id: &[u8],
         provider: &Pr,
+        signer: &impl Signer,
         welcome_bytes: &[u8],
         conversation_sync_bytes: &[u8],
-        scoring: PeerScoringService<Sc>,
         consensus: &C,
+        scoring: PeerScoringService<Sc>,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
-        member_id: &[u8],
-        signer: &impl Signer,
     ) -> Result<Option<Self>, ConversationError>
     where
         Pr: OpenMlsProvider,

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -20,7 +20,7 @@ use hashgraph_like_consensus::{events::ConsensusEventBus, service::ConsensusServ
 use crate::{
     ConsensusPlugin, Conversation, ConversationConfig, ConversationError, ConversationEvent,
     ConversationQueues, ConversationServices, ConversationStateMachine, PeerScoreStorage,
-    PeerScoringService, StewardListConfig, StewardListService, consensus::outcome_bus::OutcomeBus,
+    PeerScoringService, StewardListService, consensus::outcome_bus::OutcomeBus,
     mls_crypto::MlsService,
 };
 
@@ -42,7 +42,6 @@ where
         ciphersuite: Ciphersuite,
         signer: &impl Signer,
         scoring: PeerScoringService<Sc>,
-        steward_config: StewardListConfig,
         consensus: &C,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
@@ -63,7 +62,6 @@ where
             conversation_id,
             mls,
             scoring,
-            steward_config,
             consensus,
             app_id,
             config,
@@ -89,7 +87,6 @@ where
         welcome_bytes: &[u8],
         conversation_sync_bytes: &[u8],
         scoring: PeerScoringService<Sc>,
-        steward_config: StewardListConfig,
         consensus: &C,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
@@ -108,7 +105,6 @@ where
             &conversation_id,
             mls,
             scoring,
-            steward_config,
             consensus,
             app_id,
             config,
@@ -131,7 +127,6 @@ where
         conversation_id: &str,
         mls: MlsService,
         mut scoring: PeerScoringService<Sc>,
-        steward_config: StewardListConfig,
         consensus: &C,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
@@ -144,7 +139,7 @@ where
         // The conversation id is the deterministic-sort salt every member must
         // share; the library owns it so creator and joiner agree on every
         // elected list.
-        let mut steward_list = StewardListService::empty(steward_config);
+        let mut steward_list = StewardListService::empty(config.steward_list.clone());
         steward_list.set_conversation_id(conversation_id.as_bytes());
         steward_list.set_max_retries(config.max_reelection_attempts);
         // Creator path: bootstrap the list with self as sole steward at

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -176,9 +176,9 @@ where
     pub fn process_inbound<Pr>(
         &mut self,
         provider: &Pr,
+        signer: &impl Signer,
         sender: &[u8],
         payload: &[u8],
-        signer: &impl Signer,
     ) -> Result<DispatchOutcome, ConversationError>
     where
         Pr: OpenMlsProvider,

--- a/src/conversation/messaging.rs
+++ b/src/conversation/messaging.rs
@@ -46,8 +46,8 @@ where
     pub fn send_message<Pr>(
         &mut self,
         provider: &Pr,
-        message: Vec<u8>,
         signer: &impl Signer,
+        message: Vec<u8>,
     ) -> Result<(), ConversationError>
     where
         Pr: OpenMlsProvider,
@@ -84,9 +84,9 @@ where
     pub fn add_member<Pr>(
         &mut self,
         provider: &Pr,
-        key_package_bytes: &[u8],
-        joiner_id: &[u8],
         signer: &impl Signer,
+        joiner_id: &[u8],
+        key_package_bytes: &[u8],
     ) -> Result<(), ConversationError>
     where
         Pr: OpenMlsProvider,
@@ -122,9 +122,9 @@ where
     pub fn sponsor_member<Pr>(
         &mut self,
         provider: &Pr,
-        key_package_bytes: &[u8],
-        joiner_id: &[u8],
         signer: &impl Signer,
+        joiner_id: &[u8],
+        key_package_bytes: &[u8],
     ) -> Result<(), ConversationError>
     where
         Pr: OpenMlsProvider,
@@ -202,8 +202,8 @@ where
     pub fn remove_member<Pr>(
         &mut self,
         provider: &Pr,
-        member_id: &[u8],
         signer: &impl Signer,
+        member_id: &[u8],
     ) -> Result<(), ConversationError>
     where
         Pr: OpenMlsProvider,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,12 @@
 //! // Build a conversation from direct arguments: the OpenMLS provider,
 //! // credential + ciphersuite, the plug-in instances, and a consensus service.
 //! let mut conversation = Conversation::create(
-//!     "de-mls-test", provider, credential, ciphersuite, &signer,
-//!     scoring, steward, consensus, app_id, config, member_id,
+//!     "de-mls-test", member_id, provider, credential, ciphersuite, &signer,
+//!     consensus, scoring, app_id, config,
 //! )?;
 //!
 //! // Send a chat message — buffered, never auto-sent.
-//! conversation.send_message(b"Hello, world!".to_vec(), &signer)?;
+//! conversation.send_message(provider, &signer, b"Hello, world!".to_vec())?;
 //!
 //! // Drain outbound and publish it on your own transport.
 //! for out in conversation.drain_outbound() { /* publish */ }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -141,6 +141,8 @@ impl Member {
         config: ConversationConfig,
         steward_list_config: StewardListConfig,
     ) -> Self {
+        let mut config = config;
+        config.steward_list = steward_list_config.clone();
         let integ = Integrator::new(private_key, steward_list_config);
         let scoring = integ.scoring();
         let convo = Conversation::create(
@@ -150,7 +152,6 @@ impl Member {
             TEST_SUITE,
             &integ.signer,
             scoring,
-            integ.steward_list_config.clone(),
             &integ.consensus,
             integ.app_id(),
             config.clone(),
@@ -175,6 +176,8 @@ impl Member {
         config: ConversationConfig,
         steward_list_config: StewardListConfig,
     ) -> Self {
+        let mut config = config;
+        config.steward_list = steward_list_config.clone();
         let integ = Integrator::new(private_key, steward_list_config);
         Self {
             integ,
@@ -567,7 +570,6 @@ impl Member {
             &welcome.welcome_bytes,
             &welcome.conversation_sync_bytes,
             scoring,
-            self.integ.steward_list_config.clone(),
             &self.integ.consensus,
             self.integ.app_id(),
             self.pending_config.clone(),

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -392,7 +392,7 @@ impl Member {
         self.convo
             .as_mut()
             .expect("member has joined")
-            .send_message(&self.integ.provider, message, &self.integ.signer)
+            .send_message(&self.integ.provider, &self.integ.signer, message)
             .expect("send message");
     }
 
@@ -402,9 +402,9 @@ impl Member {
             .expect("member has joined")
             .add_member(
                 &self.integ.provider,
-                key_package.as_bytes(),
-                key_package.member_id(),
                 &self.integ.signer,
+                key_package.member_id(),
+                key_package.as_bytes(),
             )
             .expect("add member");
     }
@@ -413,7 +413,7 @@ impl Member {
         self.convo
             .as_mut()
             .expect("member has joined")
-            .remove_member(&self.integ.provider, member_id, &self.integ.signer)
+            .remove_member(&self.integ.provider, &self.integ.signer, member_id)
             .expect("remove member");
     }
 
@@ -422,7 +422,7 @@ impl Member {
         self.convo
             .as_mut()
             .expect("member has joined")
-            .vote(&self.integ.provider, proposal_id, vote, &self.integ.signer)
+            .vote(&self.integ.provider, &self.integ.signer, proposal_id, vote)
             .expect("vote");
     }
 
@@ -455,7 +455,7 @@ impl Member {
     pub fn deliver_raw(&mut self, sender: &[u8], payload: &[u8]) {
         if let Some(convo) = self.convo.as_mut() {
             let _ =
-                convo.process_inbound(&self.integ.provider, sender, payload, &self.integ.signer);
+                convo.process_inbound(&self.integ.provider, &self.integ.signer, sender, payload);
         }
     }
 
@@ -519,9 +519,9 @@ impl Member {
         if let Some(convo) = self.convo.as_mut() {
             let _ = convo.process_inbound(
                 &self.integ.provider,
+                &self.integ.signer,
                 &packet.sender,
                 &packet.payload,
-                &self.integ.signer,
             );
         }
     }
@@ -545,9 +545,9 @@ impl Member {
         // takeover), not the explicit any-member `add_member`.
         let _ = convo.sponsor_member(
             &self.integ.provider,
-            &invite.key_package_bytes,
-            &invite.member_id,
             &self.integ.signer,
+            &invite.member_id,
+            &invite.key_package_bytes,
         );
     }
 

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -147,15 +147,15 @@ impl Member {
         let scoring = integ.scoring();
         let convo = Conversation::create(
             conversation_id,
+            integ.member_id.member_id_bytes(),
             &integ.provider,
             integ.credential.clone(),
             TEST_SUITE,
             &integ.signer,
-            scoring,
             &integ.consensus,
+            scoring,
             integ.app_id(),
             config.clone(),
-            integ.member_id.member_id_bytes(),
         )
         .expect("create conversation");
         Self {
@@ -566,15 +566,15 @@ impl Member {
         // `join` opens the welcome internally; only the addressed joiner gets
         // `Some`.
         match Conversation::join(
+            self.integ.member_id.member_id_bytes(),
             &self.integ.provider,
+            &self.integ.signer,
             &welcome.welcome_bytes,
             &welcome.conversation_sync_bytes,
-            scoring,
             &self.integ.consensus,
+            scoring,
             self.integ.app_id(),
             self.pending_config.clone(),
-            self.integ.member_id.member_id_bytes(),
-            &self.integ.signer,
         ) {
             Ok(Some(convo)) => {
                 self.convo = Some(convo);

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -17,7 +17,7 @@ use openmls_basic_credential::SignatureKeyPair;
 
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
 use de_mls::{Conversation, ConversationState};
-use de_mls::{ConversationEvent, ScoringConfig, StewardListConfig};
+use de_mls::{ConversationEvent, ScoringConfig};
 
 use common::{
     MintedKeyPackage, TEST_SUITE, TestProvider, make_scoring, mint_key_package, test_credential,
@@ -64,10 +64,6 @@ impl Integrator {
         make_scoring(&ScoringConfig::default())
     }
 
-    fn steward(&self) -> StewardListConfig {
-        StewardListConfig::default()
-    }
-
     /// Mint a single-use key package into this integrator's reused provider,
     /// which thereby holds the private keys for the matching welcome.
     fn mint_key_package(&self) -> MintedKeyPackage {
@@ -91,7 +87,6 @@ fn create_builds_a_working_steward_session_without_user() {
         TEST_SUITE,
         &integrator.signer,
         integrator.scoring(),
-        integrator.steward(),
         &integrator.consensus,
         integrator.app_id(),
         de_mls::ConversationConfig::default(),
@@ -144,7 +139,6 @@ fn join_completes_in_one_call() {
         TEST_SUITE,
         &alice.signer,
         alice.scoring(),
-        alice.steward(),
         &alice.consensus,
         alice.app_id(),
         fast_config(),
@@ -192,7 +186,6 @@ fn join_completes_in_one_call() {
         &welcome.welcome_bytes,
         &welcome.conversation_sync_bytes,
         bystander.scoring(),
-        bystander.steward(),
         &bystander.consensus,
         bystander.app_id(),
         fast_config(),
@@ -213,7 +206,6 @@ fn join_completes_in_one_call() {
         &welcome.welcome_bytes,
         &welcome.conversation_sync_bytes,
         bob.scoring(),
-        bob.steward(),
         &bob.consensus,
         bob.app_id(),
         fast_config(),

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -152,9 +152,9 @@ fn join_completes_in_one_call() {
     creator
         .add_member(
             &alice.provider,
-            bob_kp.as_bytes(),
-            bob_kp.member_id(),
             &alice.signer,
+            bob_kp.member_id(),
+            bob_kp.as_bytes(),
         )
         .expect("add member");
 

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -82,15 +82,15 @@ fn create_builds_a_working_steward_session_without_user() {
     let integrator = Integrator::new();
     let conversation: TestConversation = Conversation::create(
         "standalone",
+        integrator.member_id.member_id_bytes(),
         &integrator.provider,
         integrator.credential.clone(),
         TEST_SUITE,
         &integrator.signer,
-        integrator.scoring(),
         &integrator.consensus,
+        integrator.scoring(),
         integrator.app_id(),
         de_mls::ConversationConfig::default(),
-        integrator.member_id.member_id_bytes(),
     )
     .expect("create");
 
@@ -134,15 +134,15 @@ fn join_completes_in_one_call() {
 
     let mut creator: TestConversation = Conversation::create(
         "standalone-welcome",
+        alice.member_id.member_id_bytes(),
         &alice.provider,
         alice.credential.clone(),
         TEST_SUITE,
         &alice.signer,
-        alice.scoring(),
         &alice.consensus,
+        alice.scoring(),
         alice.app_id(),
         fast_config(),
-        alice.member_id.member_id_bytes(),
     )
     .expect("create");
 
@@ -182,15 +182,15 @@ fn join_completes_in_one_call() {
     // never minted the key package can't open it.
     let bystander = Integrator::with_key(ALICE);
     let bystander_join: Option<TestConversation> = Conversation::join(
+        bystander.member_id.member_id_bytes(),
         &bystander.provider,
+        &bystander.signer,
         &welcome.welcome_bytes,
         &welcome.conversation_sync_bytes,
-        bystander.scoring(),
         &bystander.consensus,
+        bystander.scoring(),
         bystander.app_id(),
         fast_config(),
-        bystander.member_id.member_id_bytes(),
-        &bystander.signer,
     )
     .expect("join is not an error for the wrong addressee");
     assert!(
@@ -202,15 +202,15 @@ fn join_completes_in_one_call() {
     // run the join side-effects, apply the bundled sync. Only the addressed
     // joiner — holding the KP provider — gets `Some`.
     let joined: TestConversation = Conversation::join(
+        bob.member_id.member_id_bytes(),
         &bob.provider,
+        &bob.signer,
         &welcome.welcome_bytes,
         &welcome.conversation_sync_bytes,
-        bob.scoring(),
         &bob.consensus,
+        bob.scoring(),
         bob.app_id(),
         fast_config(),
-        bob.member_id.member_id_bytes(),
-        &bob.signer,
     )
     .expect("join")
     .expect("welcome addresses bob");


### PR DESCRIPTION
Three ergonomic API changes plus a README refresh, following the mls-crypto collapse (#124).

`StewardListConfig` folds into `ConversationConfig` as a nested `steward_list` field. The steward roster is library-owned, so its size bounds are pure config always set at creation — unlike consensus and scoring, which carry caller state — so it belongs in the config bag, and `create`/`join` take one fewer argument.

`create`/`join` parameters are regrouped to read identity-first and mirror each other: `conversation_id` (create only), `member_id`, the MLS inputs (`provider`/`credential`/`ciphersuite`/`signer`), the plugins (`consensus`, `scoring`), then `app_id` + `config`.

The driving methods — `add_member`, `sponsor_member`, `remove_member`, `send_message`, `vote`, `process_inbound` — now lead with `(provider, signer)`, then the operation's ids and payload, matching the existing `poll`/`leave` shape so every call site starts the same way. Constructors keep their own ordering by design.

Breaking for downstream integrators on all three: steward bounds move into `ConversationConfig`, and the constructor and method parameter orders change.
