### PR TITLE
Externally defined MlsGroupCreateConfig

### DIFF
--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -11,7 +11,7 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 
 use openmls::credentials::CredentialWithKey;
-use openmls::prelude::Ciphersuite;
+use openmls::group::MlsGroupCreateConfig;
 use openmls_traits::signatures::Signer;
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
 
@@ -40,7 +40,7 @@ where
         member_id: &[u8],
         provider: &Pr,
         credential: CredentialWithKey,
-        ciphersuite: Ciphersuite,
+        group_config: &MlsGroupCreateConfig,
         signer: &impl Signer,
         consensus: &C,
         scoring: PeerScoringService<Sc>,
@@ -55,7 +55,7 @@ where
             conversation_id.to_string(),
             provider,
             credential,
-            ciphersuite,
+            group_config,
             signer,
         )?;
         Self::assemble(

--- a/src/mls_crypto/service.rs
+++ b/src/mls_crypto/service.rs
@@ -19,12 +19,13 @@ use openmls::group::{
 };
 use openmls::key_packages::KeyPackageIn;
 use openmls::prelude::{
-    Ciphersuite, ContentType, DeserializeBytes, MlsMessageBodyIn, MlsMessageIn,
-    ProcessedMessageContent, ProtocolMessage, ProtocolVersion,
+    ContentType, DeserializeBytes, MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent,
+    ProtocolMessage, ProtocolVersion,
 };
 use openmls_traits::storage::StorageProvider;
 use openmls_traits::{OpenMlsProvider, signatures::Signer};
 use prost::Message;
+use tracing::warn;
 
 use crate::{
     mls_crypto::{
@@ -59,21 +60,22 @@ impl MlsService {
         conversation_id: String,
         provider: &Pr,
         credential: CredentialWithKey,
-        ciphersuite: Ciphersuite,
+        group_create_config: &MlsGroupCreateConfig,
         signer: &impl Signer,
     ) -> Result<Self, MlsError>
     where
         Pr: OpenMlsProvider,
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
-        let config = MlsGroupCreateConfig::builder()
-            .ciphersuite(ciphersuite)
-            .use_ratchet_tree_extension(true)
-            .build();
+        if !group_create_config.use_ratchet_tree_extension() {
+            // DeMLS assumes the ratchet tree extension is being used.
+            // Specifically the MlsGroupJoinConfig requires this extension
+            warn!("Supplied mls config does not use ratchet tree extension");
+        }
         let group = MlsGroup::new_with_group_id(
             provider,
             signer,
-            &config,
+            group_create_config,
             GroupId::from_slice(conversation_id.as_bytes()),
             credential,
         )?;

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -11,6 +11,7 @@
 use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use openmls::credentials::{BasicCredential, CredentialWithKey};
+use openmls::group::MlsGroupCreateConfig;
 use openmls::prelude::Ciphersuite;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -66,7 +67,9 @@ pub(crate) fn make_creator_mls(member_id: &[u8]) -> (TestMls, TestProvider, Sign
         "test-conversation".to_string(),
         &provider,
         credential,
-        TEST_SUITE,
+        &MlsGroupCreateConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build(),
         &signer,
     )
     .expect("create creator mls");

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -37,9 +37,9 @@ use de_mls::protos::de_mls::messages::v1::{
 use de_mls::{Conversation, ConversationConfig, CreatorVote, MemberRole, Outbound, PollOutcome};
 use de_mls::{ConversationEvent, ConversationState, ScoringConfig, StewardListConfig};
 
+use crate::common::test_mls_group_config;
 use crate::common::{
-    MintedKeyPackage, TEST_SUITE, make_scoring, mint_key_package, test_credential,
-    wallet::WalletMemberId,
+    MintedKeyPackage, make_scoring, mint_key_package, test_credential, wallet::WalletMemberId,
 };
 
 /// Per-conversation MLS service stack the harness runs.
@@ -143,6 +143,7 @@ impl Member {
     ) -> Self {
         let mut config = config;
         config.steward_list = steward_list_config.clone();
+        let mls_group_config = test_mls_group_config();
         let integ = Integrator::new(private_key, steward_list_config);
         let scoring = integ.scoring();
         let convo = Conversation::create(
@@ -150,7 +151,7 @@ impl Member {
             integ.member_id.member_id_bytes(),
             &integ.provider,
             integ.credential.clone(),
-            TEST_SUITE,
+            &mls_group_config,
             &integ.signer,
             &integ.consensus,
             scoring,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,14 +12,11 @@ pub mod wallet;
 use de_mls::defaults::{DefaultPeerScoring, InMemoryPeerScoreStorage};
 use de_mls::{PeerScoringService, ScoringConfig, default_score_deltas};
 use openmls::credentials::{BasicCredential, CredentialWithKey};
+use openmls::group::MlsGroupCreateConfig;
 use openmls::key_packages::KeyPackage;
-use openmls::prelude::Ciphersuite;
 use openmls::prelude::tls_codec::Serialize as _;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
-
-/// Ciphersuite the test fixtures pin.
-pub const TEST_SUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
 /// OpenMLS provider the tests run: the reference `OpenMlsRustCrypto`.
 pub type TestProvider = OpenMlsRustCrypto;
@@ -27,12 +24,20 @@ pub type TestProvider = OpenMlsRustCrypto;
 /// Build a fresh credential + signer for `member_id` (the integrator-side
 /// "credentials" the library no longer owns).
 pub fn test_credential(member_id: &[u8]) -> (CredentialWithKey, SignatureKeyPair) {
-    let signer = SignatureKeyPair::new(TEST_SUITE.signature_algorithm()).expect("signer");
+    let config = test_mls_group_config();
+    let signer = SignatureKeyPair::new(config.ciphersuite().signature_algorithm()).expect("signer");
     let credential = CredentialWithKey {
         credential: BasicCredential::new(member_id.to_vec()).into(),
         signature_key: signer.to_public_vec().into(),
     };
     (credential, signer)
+}
+
+// Build a default Group create configuration, which enables ratchet tree extension
+pub fn test_mls_group_config() -> MlsGroupCreateConfig {
+    MlsGroupCreateConfig::builder()
+        .use_ratchet_tree_extension(true)
+        .build()
 }
 
 /// A minted key package plus the owner's `member_id` — the (bytes, id) bundle
@@ -61,8 +66,9 @@ pub fn mint_key_package(
     signer: &SignatureKeyPair,
 ) -> MintedKeyPackage {
     let member_id = credential.credential.serialized_content().to_vec();
+    let config = test_mls_group_config();
     let bundle = KeyPackage::builder()
-        .build(TEST_SUITE, provider, signer, credential.clone())
+        .build(config.ciphersuite(), provider, signer, credential.clone())
         .expect("key package");
     let bytes = bundle
         .key_package()

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -20,9 +20,11 @@ use de_mls::{Conversation, ConversationState};
 use de_mls::{ConversationEvent, ScoringConfig};
 
 use common::{
-    MintedKeyPackage, TEST_SUITE, TestProvider, make_scoring, mint_key_package, test_credential,
+    MintedKeyPackage, TestProvider, make_scoring, mint_key_package, test_credential,
     wallet::WalletMemberId,
 };
+
+use crate::common::test_mls_group_config;
 
 /// Per-conversation stack the standalone tests build.
 type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage>;
@@ -85,7 +87,7 @@ fn create_builds_a_working_steward_session_without_user() {
         integrator.member_id.member_id_bytes(),
         &integrator.provider,
         integrator.credential.clone(),
-        TEST_SUITE,
+        &test_mls_group_config(),
         &integrator.signer,
         &integrator.consensus,
         integrator.scoring(),
@@ -137,7 +139,7 @@ fn join_completes_in_one_call() {
         alice.member_id.member_id_bytes(),
         &alice.provider,
         alice.credential.clone(),
-        TEST_SUITE,
+        &test_mls_group_config(),
         &alice.signer,
         &alice.consensus,
         alice.scoring(),


### PR DESCRIPTION
## Problem
`Conversation::create` makes assumptions about the configuration used to create groups. This limits future changes to the underlying MLS Group. Specifically in the use of additional extensions.

## Changes
This PR adjusts the `Conversation::create` to accept a MlsGroupCreateConfig so that it can be modified as necessary. 

Notes:

- DeMLS requires the ratchet tree information to be embedded in the Welcome messages. This PR throws a warning if this is not configured, rather than automatically setting the parameter.
- Remove all references to Ciphersuite in tests; use GroupCreateConfig instead, and access the Ciphersuite where needed.
- Uses Default Ciphersuite rather than explicitly setting it to the default value. 
