### PR TITLE
fix(freeze): RFC commit-validation and freeze-path hardening

### DIFF
--- a/src/conversation/config.rs
+++ b/src/conversation/config.rs
@@ -60,6 +60,12 @@ pub struct ConversationConfig {
     /// RFC §Inactivity Timer #2: shorter inactivity window applied during
     /// Layer 2 / Layer 3 recovery so retries don't burn a full epoch.
     pub recovery_inactivity_duration: Duration,
+    /// RFC §Inactivity Timer #3 (voting): how long a backup steward waits before
+    /// re-driving buffered membership updates that haven't opened a consensus
+    /// session. `Duration::ZERO` (the default) derives it from
+    /// `commit_inactivity_duration + recovery_inactivity_duration`; set a
+    /// non-zero value to tune it independently. See [`Self::voting_inactivity_window`].
+    pub voting_inactivity_duration: Duration,
     /// How long a proposal stays active before expiring (RFC §Creating Voting Proposal).
     pub proposal_expiration: Duration,
     pub consensus_timeout: Duration,
@@ -99,6 +105,8 @@ impl Default for ConversationConfig {
             commit_inactivity_duration: DEFAULT_COMMIT_INACTIVITY_DURATION,
             freeze_duration: DEFAULT_COMMIT_INACTIVITY_DURATION / 2,
             recovery_inactivity_duration: DEFAULT_RECOVERY_INACTIVITY_DURATION,
+            // Zero → derived from commit + recovery (see `voting_inactivity_window`).
+            voting_inactivity_duration: Duration::ZERO,
             proposal_expiration: DEFAULT_PROPOSAL_EXPIRATION,
             consensus_timeout: DEFAULT_CONSENSUS_TIMEOUT,
             pending_update_max_epochs: DEFAULT_PENDING_UPDATE_MAX_EPOCHS,
@@ -114,6 +122,17 @@ impl Default for ConversationConfig {
 }
 
 impl ConversationConfig {
+    /// Effective RFC §Inactivity Timer #3 window: the explicit
+    /// `voting_inactivity_duration` when set, otherwise
+    /// `commit_inactivity_duration + recovery_inactivity_duration`.
+    pub fn voting_inactivity_window(&self) -> Duration {
+        if self.voting_inactivity_duration.is_zero() {
+            self.commit_inactivity_duration + self.recovery_inactivity_duration
+        } else {
+            self.voting_inactivity_duration
+        }
+    }
+
     /// Auto-vote delay for the given proposal kind.
     pub fn voting_delay_for(&self, kind: ProposalKind) -> Duration {
         if kind.is_steward_election() {
@@ -135,6 +154,10 @@ impl ConversationConfig {
         apply_nonzero_ms(
             &mut self.recovery_inactivity_duration,
             timing.recovery_inactivity_duration_ms,
+        );
+        apply_nonzero_ms(
+            &mut self.voting_inactivity_duration,
+            timing.voting_inactivity_duration_ms,
         );
         apply_nonzero_ms(&mut self.proposal_expiration, timing.proposal_expiration_ms);
         apply_nonzero_ms(&mut self.consensus_timeout, timing.consensus_timeout_ms);
@@ -158,6 +181,7 @@ impl From<&ConversationConfig> for TimingConfig {
             commit_inactivity_duration_ms: config.commit_inactivity_duration.as_millis() as u64,
             freeze_duration_ms: config.freeze_duration.as_millis() as u64,
             recovery_inactivity_duration_ms: config.recovery_inactivity_duration.as_millis() as u64,
+            voting_inactivity_duration_ms: config.voting_inactivity_duration.as_millis() as u64,
             proposal_expiration_ms: config.proposal_expiration.as_millis() as u64,
             consensus_timeout_ms: config.consensus_timeout.as_millis() as u64,
         }
@@ -174,6 +198,7 @@ mod tests {
             commit_inactivity_duration: Duration::from_millis(100),
             freeze_duration: Duration::from_millis(200),
             recovery_inactivity_duration: Duration::from_millis(300),
+            voting_inactivity_duration: Duration::from_millis(600),
             proposal_expiration: Duration::from_millis(400),
             consensus_timeout: Duration::from_millis(500),
             ..ConversationConfig::default()
@@ -192,6 +217,29 @@ mod tests {
         );
         assert_eq!(applied.proposal_expiration, Duration::from_millis(400));
         assert_eq!(applied.consensus_timeout, Duration::from_millis(500));
+        assert_eq!(
+            applied.voting_inactivity_duration,
+            Duration::from_millis(600)
+        );
+    }
+
+    /// Zero (the default) derives the window from commit + recovery; a non-zero
+    /// value overrides it.
+    #[test]
+    fn voting_inactivity_window_derives_when_zero() {
+        let derived = ConversationConfig {
+            commit_inactivity_duration: Duration::from_secs(60),
+            recovery_inactivity_duration: Duration::from_secs(5),
+            voting_inactivity_duration: Duration::ZERO,
+            ..ConversationConfig::default()
+        };
+        assert_eq!(derived.voting_inactivity_window(), Duration::from_secs(65));
+
+        let explicit = ConversationConfig {
+            voting_inactivity_duration: Duration::from_secs(12),
+            ..derived
+        };
+        assert_eq!(explicit.voting_inactivity_window(), Duration::from_secs(12));
     }
 
     #[test]
@@ -206,6 +254,7 @@ mod tests {
             commit_inactivity_duration_ms: 0,
             freeze_duration_ms: 250,
             recovery_inactivity_duration_ms: 0,
+            voting_inactivity_duration_ms: 0,
             proposal_expiration_ms: 0,
         };
         config.apply_timing(&timing);

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -278,11 +278,11 @@ where
     /// proposals get mirrored into the pending-update buffer so a future
     /// epoch steward can retry if this round fails.
     ///
-    /// RFC §"Partial Freeze Semantics" asks that lower-priority proposals
-    /// from peers be DROPPED during an active emergency, not merely locally
-    /// blocked. We don't drop today — the RFC's Δ-synchrony assumption keeps
-    /// divergence windows small. Consensus-service-level priority gating is
-    /// tracked as a backlog item in `docs/ROADMAP.md`.
+    /// RFC §"Partial Freeze Semantics": while an emergency proposal is
+    /// unfinalized, lower-priority proposals from peers MUST be dropped — not
+    /// buffered, forwarded to consensus, or surfaced for a vote — so they
+    /// cannot land before the emergency resolves. The emergency itself (and
+    /// any higher-priority proposal) is never blocked.
     fn on_incoming_proposal(&mut self, proposal: Proposal) -> Result<(), ConversationError> {
         let decoded = match ConversationUpdateRequest::decode(proposal.payload.as_slice()) {
             Ok(req) => Some(req),
@@ -295,6 +295,21 @@ where
                 None
             }
         };
+        let kind = decoded
+            .as_ref()
+            .map(ProposalKind::of)
+            .unwrap_or(ProposalKind::Commit);
+
+        if self.queues.partial_freeze_blocks(kind) {
+            tracing::debug!(
+                conversation = %self.conversation_id,
+                proposal_id = proposal.proposal_id,
+                ?kind,
+                "dropping lower-priority proposal: active emergency partial-freeze"
+            );
+            return Ok(());
+        }
+
         if let Some(req) = decoded.as_ref() {
             let current_epoch = self.mls().current_epoch()?;
             match &req.payload {
@@ -311,10 +326,6 @@ where
         }
         let proposal_id = proposal.proposal_id;
         let expected_voters = proposal.expected_voters_count;
-        let kind = decoded
-            .as_ref()
-            .map(ProposalKind::of)
-            .unwrap_or(ProposalKind::Commit);
 
         let scope = self.conversation_id.clone();
         self.services

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -774,6 +774,7 @@ mod conversation_sync_tests {
             proposal_expiration_ms: 3_600_000,
             consensus_timeout_ms: 30_000,
             recovery_inactivity_duration_ms: 5_000,
+            voting_inactivity_duration_ms: 65_000,
         }
     }
 

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -323,8 +323,7 @@ where
                 return Ok(());
             }
         };
-        let delay =
-            self.config.commit_inactivity_duration + self.config.recovery_inactivity_duration;
+        let delay = self.config.voting_inactivity_window();
         if Instant::now() < anchor + delay {
             return Ok(());
         }

--- a/src/events.rs
+++ b/src/events.rs
@@ -18,7 +18,7 @@ use crate::{
 pub enum ConversationEvent {
     /// A decrypted message addressed to the group's chat stream. The payload is
     /// either a `ConversationMessage` (text a member sent) or an
-    /// `EventMembershipChange` (a system notice that someone joined or left) —
+    /// `EventMembershipChange` (a system notice that someone joined) —
     /// both belong in the same stream, so the application renders whichever it
     /// finds. Proposals, votes, and ban requests are not chat traffic; they
     /// surface through [`Self::VoteRequested`] and the membership and consensus

--- a/src/freeze/apply.rs
+++ b/src/freeze/apply.rs
@@ -8,7 +8,9 @@ use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
 
 use crate::{
     CommitHash, ConversationError, ConversationQueues, FreezeFinalizeResult, FreezeOutcome,
-    ProcessResult, ScoreEvent, ScoreOp, StewardListService,
+    ProcessResult,
+    ScoreEvent::{self, MisbehavingCommit},
+    ScoreOp, StewardListService,
     conversation::BufferedCommitCandidate,
     freeze::round::RoundContext,
     mls_crypto::{MlsProposalOutput, MlsService, StagedCandidateResult},
@@ -32,13 +34,9 @@ enum CandidateOutcome {
     Drop(Option<ScoreOp>),
 }
 
-/// Walk `sorted` best-first; the first candidate that applies wins. Rejected
-/// candidates score a local penalty — no ECP (RFC §Peer Scoring allows direct
-/// local scoring for observable violations).
-///
-/// `own_commit_discarded` enforces MLS's one-pending-commit rule: the first
-/// incoming attempt wipes our own pending commit, so a later lower-priority
-/// local candidate has nothing to apply.
+/// Walk `sorted` best-first; the first candidate that applies wins.
+/// Rejected candidates score a local penalty
+/// (RFC §Peer Scoring allows direct local scoring for observable violations).
 pub(super) fn apply_in_priority_order<Pr>(
     provider: &Pr,
     conversation: &mut ConversationQueues,
@@ -53,28 +51,12 @@ where
     <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
 {
     let mut score_ops: Vec<ScoreOp> = Vec::new();
-    let mut own_commit_discarded = false;
-    let conversation_id = conversation.name().to_owned();
 
     let mut remaining = sorted.into_iter();
     while let Some(chosen) = remaining.next() {
         let apply_result = if chosen.is_local_candidate {
-            if own_commit_discarded {
-                tracing::debug!(
-                    conversation = %conversation_id,
-                    "own pending commit is discarded; skipping local candidate"
-                );
-                continue;
-            }
             apply_local_candidate(provider, conversation, mls, chosen, ctx)?
         } else {
-            if !own_commit_discarded && steward.is_steward(self_member_id) {
-                // A failure here leaves an old pending commit in MLS and
-                // would sabotage every subsequent staging attempt — bubble
-                // the error out of the round instead of pressing on.
-                mls.discard_own_commit(provider)?;
-                own_commit_discarded = true;
-            }
             apply_incoming_candidate(provider, conversation, mls, steward, chosen, ctx)?
         };
 
@@ -91,7 +73,6 @@ where
                     ctx,
                     remaining,
                     steward,
-                    &conversation_id,
                 );
                 return Ok(FreezeFinalizeResult {
                     outcome,
@@ -103,12 +84,12 @@ where
         }
     }
 
-    // No candidate applied. Drop any local pending commit that wasn't
-    // merged or discarded along an incoming-wins path — leaving it
-    // behind would break the next MLS encrypt.
-    if !own_commit_discarded {
-        mls.discard_own_commit(provider)?;
-    }
+    // Defensive cleanup — normally a no-op. A local candidate always wins once
+    // reached, so reaching here means none was in the round: either we built no
+    // commit, or we built one that wasn't buffered (per-round cap / duplicate
+    // hash). In that last case a stray pending commit lingers in MLS and would
+    // block the next operation (only one pending commit allowed), so clear it.
+    mls.discard_own_commit(provider)?;
     conversation.clear_freeze_round();
     Ok(FreezeFinalizeResult {
         outcome: FreezeOutcome::NoCandidate,
@@ -129,15 +110,13 @@ fn record_winner_scores(
     ctx: &RoundContext,
     losers: impl Iterator<Item = BufferedCommitCandidate>,
     sl_service: &StewardListService,
-    conversation_id: &str,
 ) {
     score_ops.push(ScoreOp {
         member_id: committer.to_vec(),
         event: ScoreEvent::SuccessfulCommit,
     });
 
-    // `epoch_steward_id` was resolved through `steward_eligibility`, so
-    // `expected` can't be a queued-removal target — no extra guard needed.
+    // `epoch_steward_id` was resolved through `steward_eligibility`
     if let Some(expected) = ctx.epoch_steward_id.as_deref()
         && expected != committer
         && expected != self_member_id
@@ -156,10 +135,10 @@ fn record_winner_scores(
                 event: ScoreEvent::HonestCommitAttempt,
             });
         } else {
-            tracing::debug!(
-                conversation = %conversation_id,
-                "dropping HonestCommitAttempt: claimed user not on steward list"
-            );
+            score_ops.push(ScoreOp {
+                member_id: claimed,
+                event: MisbehavingCommit,
+            });
         }
     }
 }
@@ -207,8 +186,9 @@ where
 /// Stage, validate, and merge a candidate authored by another steward.
 /// `Drop` (with penalty) on any failed check; `Terminal(Applied)` on merge.
 ///
-/// Caller must have discarded any own pending commit first — MLS allows
-/// only one per conversation.
+/// Staging coexists with our own pending commit — OpenMLS only needs the single
+/// pending slot free at *merge* time, so this discards our own commit right
+/// before merging the winning remote.
 fn apply_incoming_candidate<Pr>(
     provider: &Pr,
     conversation: &mut ConversationQueues,
@@ -261,6 +241,11 @@ where
         return Ok(CandidateOutcome::Drop(violation.target_score_op()));
     }
 
+    // The remote wins. Clear our own pending commit (if any) before applying it:
+    // de-mls's split staging flow doesn't auto-clear it, and a leftover would
+    // block the next MLS operation. Safe — the staged remote is held separately
+    // and survives this discard (see `discard_own_then_merge_remote_*` test).
+    mls.discard_own_commit(provider)?;
     mls.merge_staged_commit(provider)?;
     let committed_batch =
         finalize_committed_batch(conversation, chosen.commit_hash, mls.current_epoch()?);
@@ -426,10 +411,9 @@ fn action_projection_from_mls(action: &MlsProposalOutput) -> (u8, &[u8]) {
 /// RFC §"de-MLS Objects": any steward-list member may commit to preserve
 /// liveness. Epoch-steward priority is about *selection*, not authorization.
 ///
-/// `None` also covers "no list yet" (joiner pre-sync), "list exhausted"
-/// (re-election in progress), and "Layer-3 recovery_mode active" (RFC
-/// §Anti-Deadlock: any member MAY commit to restore liveness; mirrors
-/// the relaxed gate in `create_commit_candidate`).
+/// `None` also covers "no list yet" (joiner pre-sync) and "Layer-3
+/// recovery_mode active" (RFC §Anti-Deadlock: any member MAY commit to restore
+/// liveness; mirrors the relaxed gate in `create_commit_candidate`).
 fn check_commit_sender_authorized(
     conversation: &ConversationQueues,
     sl_service: &StewardListService,
@@ -440,9 +424,6 @@ fn check_commit_sender_authorized(
         return None;
     }
     sl_service.current_list()?;
-    if sl_service.is_exhausted(ctx.current_epoch) {
-        return None;
-    }
     if sl_service.is_steward(commit_sender) {
         return None;
     }
@@ -450,7 +431,7 @@ fn check_commit_sender_authorized(
         conversation = conversation.name(),
         "violation: commit from unauthorized sender"
     );
-    Some(ViolationEvidence::broken_commit(
+    Some(ViolationEvidence::misbehaving_commit(
         commit_sender.to_vec(),
         ctx.current_epoch,
         "commit from unauthorized sender (not on the steward list)",
@@ -481,4 +462,160 @@ fn finalize_committed_batch(
     conversation.note_member_joins(&snapshot, current_epoch);
     conversation.clear_freeze_round();
     snapshot
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StewardListConfig;
+
+    fn ctx_at(epoch: u64, in_recovery: bool) -> RoundContext {
+        RoundContext {
+            mls_count: 1,
+            self_remove_pending: false,
+            current_epoch: epoch,
+            in_recovery,
+            epoch_steward_id: None,
+        }
+    }
+
+    fn list_over_two_epochs() -> (StewardListService, Vec<u8>, Vec<u8>) {
+        let mut sl = StewardListService::empty(StewardListConfig::new(2, 2).unwrap());
+        let alice = vec![1u8; 20];
+        let bob = vec![2u8; 20];
+        // Installed for epochs [0, 2) → exhausted at epoch 2, members still known.
+        sl.install_list(0, &[alice.clone(), bob.clone()], 2, 0)
+            .unwrap();
+        assert!(sl.is_exhausted(2), "list [0,2) is exhausted at epoch 2");
+        (sl, alice, bob)
+    }
+
+    /// Regression guard: an exhausted list (Layer-2 re-election window) must still
+    /// verify the committer against its members — it does NOT grant the Layer-3
+    /// "any member may commit" permission. A steward's superseding commit passes;
+    /// a non-steward's is rejected.
+    #[test]
+    fn exhausted_list_still_gates_on_membership() {
+        let (sl, alice, _bob) = list_over_two_epochs();
+        let carol = vec![3u8; 20]; // not on the list
+        let queues = ConversationQueues::new("g");
+        let ctx = ctx_at(2, false);
+
+        assert!(
+            check_commit_sender_authorized(&queues, &sl, &alice, &ctx).is_none(),
+            "on-list steward stays authorized when the list is exhausted"
+        );
+        assert!(
+            check_commit_sender_authorized(&queues, &sl, &carol, &ctx).is_some(),
+            "non-steward commit must be rejected even when the list is exhausted"
+        );
+    }
+
+    /// Layer 3: recovery mode is the one gate that opens for any sender.
+    #[test]
+    fn recovery_mode_authorizes_any_sender() {
+        let (sl, _alice, _bob) = list_over_two_epochs();
+        let queues = ConversationQueues::new("g");
+        let ctx = ctx_at(2, true);
+        assert!(
+            check_commit_sender_authorized(&queues, &sl, &[9u8; 20], &ctx).is_none(),
+            "recovery mode authorizes any member"
+        );
+    }
+
+    /// High-level apply-loop behaviour and the regression guard for the
+    /// lost-own-commit lag: when a higher-priority remote candidate fails, our
+    /// own lower-priority local candidate still applies — it is no longer
+    /// discarded out from under us. Under the old pre-discard this returned
+    /// `NoCandidate`.
+    #[test]
+    fn local_candidate_applies_after_a_higher_priority_remote_fails() {
+        use crate::freeze::round::compute_commit_hash;
+        use crate::mls_crypto::MlsCommitInput;
+        use crate::test_fixtures::{TEST_SUITE, make_creator_mls, steward_service_steward};
+        use openmls::credentials::{BasicCredential, CredentialWithKey};
+        use openmls::key_packages::KeyPackage;
+        use openmls::prelude::tls_codec::Serialize as _;
+        use openmls_basic_credential::SignatureKeyPair;
+
+        let (mut mls, provider, signer) = make_creator_mls(b"alice");
+        let alice = b"alice".to_vec();
+        let steward = steward_service_steward(&alice);
+
+        // Alice's real own commit candidate (add bob).
+        let bob_kp = {
+            let s = SignatureKeyPair::new(TEST_SUITE.signature_algorithm()).unwrap();
+            let cred = CredentialWithKey {
+                credential: BasicCredential::new(b"bob".to_vec()).into(),
+                signature_key: s.to_public_vec().into(),
+            };
+            KeyPackage::builder()
+                .build(TEST_SUITE, &provider, &s, cred)
+                .unwrap()
+                .key_package()
+                .tls_serialize_detached()
+                .unwrap()
+        };
+        let artifacts = mls
+            .create_commit_candidate(&provider, &signer, &[MlsCommitInput::Add(bob_kp)])
+            .unwrap();
+        let local = BufferedCommitCandidate {
+            candidate_msg: CommitCandidate {
+                conversation_id: b"test-conversation".to_vec(),
+                mls_proposals: artifacts.proposals.clone(),
+                commit_message: artifacts.commit.clone(),
+                steward_member_id: alice.clone(),
+            },
+            commit_hash: compute_commit_hash(&artifacts.commit),
+            is_local_candidate: true,
+            welcome_bytes: artifacts.welcome.clone(),
+            joiner_identities: vec![b"bob".to_vec()],
+        };
+
+        // A higher-priority remote that fails staging (garbage commit).
+        let failing_remote = BufferedCommitCandidate {
+            candidate_msg: CommitCandidate {
+                conversation_id: b"test-conversation".to_vec(),
+                mls_proposals: vec![],
+                commit_message: vec![0xFFu8; 64],
+                steward_member_id: alice.clone(),
+            },
+            commit_hash: compute_commit_hash(&[0xFFu8; 64]),
+            is_local_candidate: false,
+            welcome_bytes: None,
+            joiner_identities: vec![],
+        };
+
+        let epoch_before = mls.current_epoch().unwrap();
+        let mut conversation = ConversationQueues::new("test-conversation");
+        let ctx = RoundContext {
+            mls_count: 1,
+            self_remove_pending: false,
+            current_epoch: epoch_before,
+            in_recovery: false,
+            epoch_steward_id: Some(alice.clone()),
+        };
+
+        // Remote first (higher priority), our local second.
+        let result = apply_in_priority_order(
+            &provider,
+            &mut conversation,
+            &mut mls,
+            &steward,
+            vec![failing_remote, local],
+            &ctx,
+            &alice,
+        )
+        .unwrap();
+
+        assert!(
+            matches!(result.outcome, FreezeOutcome::Applied { .. }),
+            "own local commit applied after the higher-priority remote failed"
+        );
+        assert_eq!(mls.current_epoch().unwrap(), epoch_before + 1);
+        assert!(
+            mls.is_member(b"bob"),
+            "our own commit (add bob) was applied"
+        );
+    }
 }

--- a/src/mls_crypto/service.rs
+++ b/src/mls_crypto/service.rs
@@ -512,3 +512,186 @@ impl MlsService {
         Ok(kind)
     }
 }
+
+#[cfg(test)]
+mod stage_preserves_own_tests {
+    use super::*;
+    use crate::test_fixtures::{TEST_SUITE, TestProvider, make_creator_mls};
+    use openmls::credentials::{BasicCredential, CredentialWithKey};
+    use openmls::key_packages::KeyPackage;
+    use openmls::prelude::tls_codec::Serialize as _;
+    use openmls_basic_credential::SignatureKeyPair;
+
+    fn member_key_package(
+        provider: &TestProvider,
+        member_id: &[u8],
+    ) -> (Vec<u8>, SignatureKeyPair) {
+        let signer = SignatureKeyPair::new(TEST_SUITE.signature_algorithm()).unwrap();
+        let credential = CredentialWithKey {
+            credential: BasicCredential::new(member_id.to_vec()).into(),
+            signature_key: signer.to_public_vec().into(),
+        };
+        let kp = KeyPackage::builder()
+            .build(TEST_SUITE, provider, &signer, credential)
+            .unwrap()
+            .key_package()
+            .tls_serialize_detached()
+            .unwrap();
+        (kp, signer)
+    }
+
+    fn fresh_key_package(provider: &TestProvider, member_id: &[u8]) -> Vec<u8> {
+        member_key_package(provider, member_id).0
+    }
+
+    /// A *failed* remote-commit stage must leave our own pending commit intact.
+    /// OpenMLS only clears the own pending commit when a remote is *successfully*
+    /// processed, so a remote that never processes (malformed / stale / wrong
+    /// group → `Abort`) does not touch it. This is the evidence that the
+    /// lost-own-commit lag is caused by de-mls's explicit pre-discard in
+    /// `apply_in_priority_order`, not by the act of staging a failing remote.
+    #[test]
+    fn failed_remote_stage_preserves_own_pending_commit() {
+        let (mut mls, provider, signer) = make_creator_mls(b"alice");
+
+        // Build a real own pending commit (Add bob) — what a backup steward holds
+        // when the epoch steward's candidate arrives.
+        let bob_kp = fresh_key_package(&provider, b"bob");
+        mls.create_commit_candidate(&provider, &signer, &[MlsCommitInput::Add(bob_kp)])
+            .expect("own commit candidate");
+        let epoch_before = mls.current_epoch().unwrap();
+
+        // Stage an invalid remote commit (garbage). It must not apply, and must
+        // not disturb our own pending commit.
+        let staged = mls.stage_remote_commit(&provider, &[], &[0xFFu8; 64]);
+        assert!(
+            matches!(staged, Ok(StagedCandidateResult::Aborted) | Err(_)),
+            "garbage remote commit must not stage"
+        );
+
+        // Our own pending commit should still merge cleanly → it survived.
+        mls.merge_own_commit(&provider)
+            .expect("own pending commit survived a failed remote stage");
+        assert_eq!(
+            mls.current_epoch().unwrap(),
+            epoch_before + 1,
+            "own commit applied after the failed remote, epoch advanced"
+        );
+    }
+
+    /// The discriminating experiment, and the key enabler for the reorder fix:
+    /// staging a *valid* remote commit while our own commit is pending succeeds,
+    /// and crucially does NOT clear our own — OpenMLS clears the own pending
+    /// commit only when a remote is *merged* (applied), not when it's staged.
+    /// So we can stage + validate any remote, and if we reject it
+    /// (`discard_staged_commit`), our own commit is still there to apply. The
+    /// explicit `discard_own_commit` pre-discard in `apply_in_priority_order` is
+    /// therefore unnecessary and is the sole cause of the lost-own-commit lag.
+    #[test]
+    fn own_commit_survives_staging_then_rejecting_a_valid_remote() {
+        let (mut alice, provider_a, signer_a) = make_creator_mls(b"alice");
+        let provider_b = TestProvider::default();
+        let (bob_kp, bob_signer) = member_key_package(&provider_b, b"bob");
+
+        // Alice adds bob and merges → alice + bob synced at the same epoch.
+        let artifacts = alice
+            .create_commit_candidate(&provider_a, &signer_a, &[MlsCommitInput::Add(bob_kp)])
+            .expect("add bob");
+        alice.merge_own_commit(&provider_a).unwrap();
+        let welcome = artifacts.welcome.expect("welcome for bob");
+        let mut bob = MlsService::new_from_welcome(&provider_b, &welcome)
+            .expect("open welcome")
+            .expect("welcome addressed to bob");
+        let synced_epoch = alice.current_epoch().unwrap();
+        assert_eq!(synced_epoch, bob.current_epoch().unwrap());
+
+        // Bob builds a valid commit (add carol) — a genuine remote candidate.
+        let carol_kp = fresh_key_package(&provider_b, b"carol");
+        let bob_artifacts = bob
+            .create_commit_candidate(&provider_b, &bob_signer, &[MlsCommitInput::Add(carol_kp)])
+            .expect("bob commit");
+
+        // Alice builds her OWN commit (add dave) → alice now has a pending commit.
+        let dave_kp = fresh_key_package(&provider_a, b"dave");
+        alice
+            .create_commit_candidate(&provider_a, &signer_a, &[MlsCommitInput::Add(dave_kp)])
+            .expect("alice own commit");
+
+        // Stage bob's valid remote commit while alice's own is still pending.
+        let staged = alice
+            .stage_remote_commit(&provider_a, &bob_artifacts.proposals, &bob_artifacts.commit)
+            .expect("stage bob's commit");
+        assert!(
+            matches!(staged, StagedCandidateResult::Staged { .. }),
+            "a valid remote stages even while our own commit is pending, got {staged:?}"
+        );
+
+        // Reject the remote (as the round would for a losing/invalid candidate)
+        // — this must NOT take our own pending commit with it.
+        alice.discard_staged_commit(&provider_a).unwrap();
+
+        // Our own commit is still pending and applies cleanly.
+        alice
+            .merge_own_commit(&provider_a)
+            .expect("own pending commit survived staging + rejecting a valid remote");
+        assert_eq!(alice.current_epoch().unwrap(), synced_epoch + 1);
+    }
+
+    /// The surgical fix shape: in de-mls's split staging flow, merging a remote
+    /// does NOT auto-clear our own pending commit (it lingers). So the reorder is
+    /// "discard our own *right before* merging the winning remote" — which
+    /// preserves our own across rejected remotes but cleans it up before applying
+    /// a winner. This test pins that exact sequence: stage → discard own → merge
+    /// remote → our own is gone and the remote applied.
+    #[test]
+    fn discard_own_then_merge_remote_applies_remote_and_clears_own() {
+        let (mut alice, provider_a, signer_a) = make_creator_mls(b"alice");
+        let provider_b = TestProvider::default();
+        let (bob_kp, bob_signer) = member_key_package(&provider_b, b"bob");
+
+        let artifacts = alice
+            .create_commit_candidate(&provider_a, &signer_a, &[MlsCommitInput::Add(bob_kp)])
+            .expect("add bob");
+        alice.merge_own_commit(&provider_a).unwrap();
+        let welcome = artifacts.welcome.expect("welcome for bob");
+        let mut bob = MlsService::new_from_welcome(&provider_b, &welcome)
+            .expect("open welcome")
+            .expect("welcome addressed to bob");
+        let synced_epoch = alice.current_epoch().unwrap();
+
+        // Bob builds a valid commit; alice builds her own → alice has a pending commit.
+        let carol_kp = fresh_key_package(&provider_b, b"carol");
+        let bob_artifacts = bob
+            .create_commit_candidate(&provider_b, &bob_signer, &[MlsCommitInput::Add(carol_kp)])
+            .expect("bob commit");
+        let dave_kp = fresh_key_package(&provider_a, b"dave");
+        alice
+            .create_commit_candidate(&provider_a, &signer_a, &[MlsCommitInput::Add(dave_kp)])
+            .expect("alice own commit");
+
+        // Stage bob's remote (own survives), then — the fix — discard our own
+        // right before merging the winning remote.
+        alice
+            .stage_remote_commit(&provider_a, &bob_artifacts.proposals, &bob_artifacts.commit)
+            .expect("stage bob's commit");
+        alice
+            .discard_own_commit(&provider_a)
+            .expect("discard own before merging the winning remote");
+        alice
+            .merge_staged_commit(&provider_a)
+            .expect("merge the remote after discarding own");
+        assert_eq!(alice.current_epoch().unwrap(), synced_epoch + 1);
+
+        // The remote applied (carol added) and our own was discarded, not
+        // applied (dave absent).
+        let members = alice.members().unwrap();
+        assert!(
+            members.iter().any(|m| m == b"carol"),
+            "the remote commit (add carol) applied"
+        );
+        assert!(
+            !members.iter().any(|m| m == b"dave"),
+            "our own commit (add dave) was discarded before the merge, not applied"
+        );
+    }
+}

--- a/src/peer_scoring/types.rs
+++ b/src/peer_scoring/types.rs
@@ -34,8 +34,8 @@ pub enum ScoreEvent {
     /// Lost a commit race with the same proposals but different MLS entropy —
     /// honest participation (RFC: MUST NOT be misbehavior).
     HonestCommitAttempt,
-    /// Competing commit with a different proposal set than the selected one
-    /// (RFC: MUST be misbehavior).
+    /// Wrongdoing caught after staging that isn't a broken commit or proposal —
+    /// e.g. a committer who isn't on the steward list. Milder penalty.
     MisbehavingCommit,
 }
 
@@ -63,7 +63,9 @@ pub fn default_score_deltas() -> HashMap<ScoreEvent, i64> {
         // Commit selection
         (ScoreEvent::SuccessfulCommit, 10),
         (ScoreEvent::HonestCommitAttempt, 5),
-        (ScoreEvent::MisbehavingCommit, -30),
+        // Milder than a broken commit/proposal: wrongdoing such as committing
+        // while not on the steward list, caught after staging.
+        (ScoreEvent::MisbehavingCommit, -10),
     ])
 }
 

--- a/src/process_result.rs
+++ b/src/process_result.rs
@@ -124,6 +124,19 @@ impl ViolationEvidence {
         }
     }
 
+    /// Wrongdoing that isn't a broken commit or broken proposal — e.g. a
+    /// committer who isn't on the steward list. Scored locally (never filed as
+    /// an ECP) with a milder penalty than the broken-commit/proposal cases.
+    pub fn misbehaving_commit(target: Vec<u8>, epoch: u64, payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            violation_type: ViolationType::MisbehavingCommit as i32,
+            target_member_id: target,
+            evidence_payload: payload.into(),
+            epoch,
+            creator_member_id: Vec::new(),
+        }
+    }
+
     /// Layer 3 anti-deadlock signal — on YES the steward gate relaxes so
     /// any member can produce the recovery commit. No specific target.
     pub fn deadlock(epoch: u64) -> Self {
@@ -168,6 +181,7 @@ impl ViolationEvidence {
             Ok(ViolationType::BrokenCommit) => Some(ScoreEvent::BrokenCommit),
             Ok(ViolationType::BrokenMlsProposal) => Some(ScoreEvent::BrokenMlsProposal),
             Ok(ViolationType::CensorshipInactivity) => Some(ScoreEvent::CensorshipInactivity),
+            Ok(ViolationType::MisbehavingCommit) => Some(ScoreEvent::MisbehavingCommit),
             Ok(ViolationType::ScoreBelowThreshold)
             | Ok(ViolationType::Deadlock)
             | Ok(ViolationType::ViolationUnspecified)

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -160,6 +160,7 @@ message TimingConfig {
   uint64 proposal_expiration_ms = 3;
   uint64 consensus_timeout_ms = 4;
   uint64 recovery_inactivity_duration_ms = 5; // RFC §Inactivity Timer #2
+  uint64 voting_inactivity_duration_ms = 6;   // RFC §Inactivity Timer #3 (0 = derive from #1+#2)
 }
 
 enum Outcome {

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -91,6 +91,7 @@ enum ViolationType {
   CENSORSHIP_INACTIVITY = 3; // Steward didn't commit within threshold_duration
   SCORE_BELOW_THRESHOLD = 4; // Member's peer score dropped to/below removal threshold
   DEADLOCK = 5;              // Layer 3: re-election retries exhausted; any member may commit
+  MISBEHAVING_COMMIT = 6;    // Wrongdoing that isn't a broken commit/proposal (e.g. committer not on the steward list);
 }
 
 message ViolationEvidence {

--- a/tests/protocol_freeze.rs
+++ b/tests/protocol_freeze.rs
@@ -11,6 +11,7 @@ use de_mls::{ConversationState, StewardListConfig};
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 
 #[test]
 fn freeze_cycle_emits_phases_in_order() {
@@ -107,6 +108,67 @@ fn deadlock_ecp_force_freezes_the_group() {
         h.member(0).saw_phase(ConversationState::Freezing)
             && h.member(1).saw_phase(ConversationState::Freezing)
     });
+}
+
+/// RFC §Partial Freeze Semantics: while an emergency proposal is unfinalized, a
+/// lower-priority proposal arriving from a peer MUST be dropped — not buffered
+/// or surfaced for a vote. A `RemoveMember` normally lands in the pending-update
+/// buffer; under an active emergency it must not. The emergency is delivered to
+/// BOB only, so BOB freezes while CHARLIE (the proposer) does not.
+#[test]
+fn active_emergency_drops_incoming_lower_priority_proposal() {
+    let mut h = TestHarness::<3>::bootstrap(
+        [ALICE, BOB, CHARLIE],
+        "pf1",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    // Quiesce residual bootstrap traffic.
+    for i in 0..3 {
+        let _ = h.member_mut(i).take_outbound();
+    }
+
+    let target_a = vec![0xA1u8; 20];
+    let target_b = vec![0xB2u8; 20];
+
+    // Baseline (no emergency yet): CHARLIE's RemoveMember reaches BOB and lands
+    // in the pending-update buffer.
+    h.member_mut(2).remove_member(&target_a);
+    let baseline = h.member_mut(2).take_outbound();
+    for o in &baseline {
+        h.member_mut(1).deliver_raw(&o.sender, &o.payload);
+    }
+    assert_eq!(
+        h.member(1).pending_update_count(),
+        1,
+        "baseline: a remove proposal is buffered when no emergency is active"
+    );
+
+    // ALICE raises an emergency; deliver it to BOB only, so BOB's partial freeze
+    // is active while CHARLIE's is not.
+    let epoch = h.epoch();
+    let ecp = ViolationEvidence::deadlock(epoch)
+        .with_creator(b"alice-creator".to_vec())
+        .into_update_request()
+        .unwrap();
+    h.member_mut(0).initiate_proposal(ecp, CreatorVote::Yes);
+    let ecp_out = h.member_mut(0).take_outbound();
+    for o in &ecp_out {
+        h.member_mut(1).deliver_raw(&o.sender, &o.payload);
+    }
+
+    // Under the active emergency, a second lower-priority remove proposal must be
+    // dropped: the pending-update buffer stays unchanged (would be 2 otherwise).
+    h.member_mut(2).remove_member(&target_b);
+    let frozen = h.member_mut(2).take_outbound();
+    for o in &frozen {
+        h.member_mut(1).deliver_raw(&o.sender, &o.payload);
+    }
+    assert_eq!(
+        h.member(1).pending_update_count(),
+        1,
+        "lower-priority proposal must be dropped during an active emergency"
+    );
 }
 
 /// `needle` appears in `haystack` in order (intervening elements allowed).


### PR DESCRIPTION
Section-by-section RFC-conformance fixes in the freeze / commit-validation path.

Partial freeze: incoming lower-priority proposals are dropped while an emergency ECP is unfinalized instead of being fed to consensus — the local half of the RFC's "MUST be dropped".

Commit validation: an unauthorized (not-on-list) committer is now scored MisbehavingCommit (−10) rather than the harsher BrokenCommit; the exhausted-list authorization relaxation is removed (an exhausted list is a Layer-2 re-election state, not the Layer-3 "any member may commit" gate); and the freeze-apply loop no longer pre-discards our own commit before staging remotes — it discards only just before merging a winning remote, so a rejected higher-priority remote no longer strands our own candidate (a lag/fork risk).

Inactivity timer: the buffered-update re-drive gets its own configurable voting_inactivity_duration, defaulting to Duration::ZERO which derives the previous commit + recovery window (no behavior change unless set).

Includes MLS-behavior experiments pinning the own-pending-commit semantics the reorder relies on, plus unit and integration tests.
