### PR TITLE
feat!: caller-owned WallClock time source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "hashgraph-like-consensus"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b6328e1ba3b6ff66e24a018b40c6ea61a3105607755ac378003b57de7bc19d"
+checksum = "cba53b85cc33f28262bbd9c258bbbf3f3b66501ef7cc2b7137712215fdf7cbf5"
 dependencies = [
  "alloy",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1.44"
 indexmap = "2.14.0"
 prost = "0.14"
 
-hashgraph-like-consensus = "0.5.1"
+hashgraph-like-consensus = "0.6.0"
 
 [dev-dependencies]
 alloy = { version = "2.0.5", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ use de_mls::defaults::{DefaultConsensusPlugin, InMemoryPeerScoreStorage};
 // (see `de_mls::defaults::DefaultPeerScoring`). The steward roster is
 // library-owned — you set its size bounds on `config` (a `ConversationConfig`).
 // Create a conversation you steward, or join one from a welcome:
+// The third generic is the time source: `SystemClock` (the default) in
+// production, `MockClock` for virtual-time tests.
 let mut convo: Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage> =
     Conversation::create(id, member_id, &provider, credential, suite, &signer,
-                         &consensus, scoring, app_id, config)?;
+                         &consensus, scoring, SystemClock::new(), app_id, config)?;
 
 // let joined = Conversation::join(member_id, &provider, &signer,
 //                                 welcome_bytes, sync_bytes, …)?;  // Ok(None) = not for us

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ use de_mls::defaults::{DefaultConsensusPlugin, InMemoryPeerScoreStorage};
 // pass by reference; `scoring` is a `PeerScoringService` built over the storage
 // (see `de_mls::defaults::DefaultPeerScoring`). The steward roster is
 // library-owned — you set its size bounds on `config` (a `ConversationConfig`).
+// The third generic is the time source: a `WallClock` impl you provide —
+// wrap `SystemTime` in production, use `MockClock` for virtual-time tests.
 // Create a conversation you steward, or join one from a welcome:
-// The third generic is the time source: `SystemClock` (the default) in
-// production, `MockClock` for virtual-time tests.
-let mut convo: Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage> =
+let mut convo: Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, _> =
     Conversation::create(id, member_id, &provider, credential, suite, &signer,
-                         &consensus, scoring, SystemClock::new(), app_id, config)?;
+                         &consensus, scoring, clock, app_id, config)?;
 
 // let joined = Conversation::join(member_id, &provider, &signer,
 //                                 welcome_bytes, sync_bytes, …)?;  // Ok(None) = not for us

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -18,11 +18,11 @@ use crate::{
     },
 };
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Handle one resolved decision: tell the integrator, update the proposal
     /// queues via [`apply_consensus_result`], then run the follow-up it asks

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -11,16 +11,18 @@ use tracing::{error, info};
 
 use crate::{
     ConsensusApplyResult, ConsensusPlugin, Conversation, ConversationError, ConversationEvent,
-    ConversationState, PeerScoreStorage, ScoreOp, apply_consensus_result, emergency_score_ops,
+    ConversationState, PeerScoreStorage, ScoreOp, WallClock, apply_consensus_result,
+    emergency_score_ops,
     protos::de_mls::messages::v1::{
         ConversationUpdateRequest, StewardElectionProposal, conversation_update_request,
     },
 };
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Handle one resolved decision: tell the integrator, update the proposal
     /// queues via [`apply_consensus_result`], then run the follow-up it asks

--- a/src/consensus/plugin.rs
+++ b/src/consensus/plugin.rs
@@ -42,9 +42,9 @@ pub trait ConsensusPlugin {
 /// The consensus engine de-mls runs per conversation: the integrator's storage
 /// and signer over de-mls's fixed scope key and outcome bus. Built inside
 /// [`crate::Conversation::create`] / `join`.
-pub type ConsensusEngine<C> = ConsensusService<
+pub type ConsensusEngine<Cp> = ConsensusService<
     ScopeID,
-    <C as ConsensusPlugin>::ConsensusStorage,
+    <Cp as ConsensusPlugin>::ConsensusStorage,
     OutcomeBus,
-    <C as ConsensusPlugin>::Signer,
+    <Cp as ConsensusPlugin>::Signer,
 >;

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -207,11 +207,26 @@ where
 
         for (proposal_id, vote) in auto_votes_due {
             if let Err(e) = self.broadcast_vote(provider, proposal_id, vote, signer) {
-                tracing::debug!(
-                    proposal_id,
-                    error = %e,
-                    "auto-vote skipped (already voted or session resolved)"
-                );
+                match e {
+                    ConversationError::Consensus(
+                        ConsensusError::UserAlreadyVoted
+                        | ConsensusError::SessionNotActive
+                        | ConsensusError::SessionNotFound,
+                    ) => tracing::debug!(
+                        proposal_id,
+                        error = %e,
+                        "auto-vote skipped: already voted or session resolved"
+                    ),
+                    ConversationError::Consensus(ConsensusError::ProposalExpired) => {
+                        tracing::warn!(
+                            proposal_id,
+                            error = %e,
+                            "auto-vote dropped: proposal expired before the vote fired; \
+                             possible clock skew"
+                        )
+                    }
+                    _ => tracing::warn!(proposal_id, error = %e, "auto-vote failed"),
+                }
             }
         }
         for proposal_id in timeouts_due {

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -52,11 +52,11 @@ struct ProposalParams {
     liveness_criteria_yes: bool,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     // ── Public API ───────────────────────────────────────────────────
 

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -27,6 +27,7 @@ use crate::{
     PeerScoreStorage, ProposalKind, WallClock,
     protos::de_mls::messages::v1::{AppMessage, ConversationUpdateRequest},
     self_leave_proposal_id,
+    wall_clock::WallClockExt,
 };
 
 /// The creator's intent at proposal submit time.
@@ -183,7 +184,7 @@ where
         Pr: OpenMlsProvider,
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
-        let now = self.clock.now();
+        let now = self.clock.timestamp();
         let auto_votes_due: Vec<(u32, bool)> = self
             .timing
             .pending_auto_votes

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -8,7 +8,7 @@
 //! service and return a wire message for the caller to broadcast.
 
 use std::error::Error as StdError;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use hashgraph_like_consensus::{
     error::ConsensusError,
@@ -24,7 +24,7 @@ use tracing::info;
 
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationEvent, ConversationState,
-    PeerScoreStorage, ProposalKind,
+    PeerScoreStorage, ProposalKind, WallClock,
     protos::de_mls::messages::v1::{AppMessage, ConversationUpdateRequest},
     self_leave_proposal_id,
 };
@@ -52,10 +52,11 @@ struct ProposalParams {
     liveness_criteria_yes: bool,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     // ── Public API ───────────────────────────────────────────────────
 
@@ -113,10 +114,12 @@ where
                 // have the proposal yet, so a Vote-only message would be
                 // undeliverable.
                 let scope = self.conversation_id.clone();
+                let now = self.clock.now().as_secs();
                 let proposal = self.services.consensus.cast_vote_and_get_proposal(
                     &scope,
                     proposal_id,
                     true,
+                    now,
                 )?;
                 info!(
                     conversation = %self.conversation_id,
@@ -180,7 +183,7 @@ where
         Pr: OpenMlsProvider,
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
-        let now = std::time::Instant::now();
+        let now = self.clock.now();
         let auto_votes_due: Vec<(u32, bool)> = self
             .timing
             .pending_auto_votes
@@ -285,7 +288,12 @@ where
         let proposal_id = vote.proposal_id;
         let outcome_applied_locally = self.queues.is_consensus_outcome_applied(proposal_id);
         let scope = self.conversation_id.clone();
-        match self.services.consensus.process_incoming_vote(&scope, vote) {
+        let now = self.clock.now().as_secs();
+        match self
+            .services
+            .consensus
+            .process_incoming_vote(&scope, vote, now)
+        {
             Ok(()) => Ok(()),
             Err(ConsensusError::SessionNotActive) => {
                 tracing::debug!(
@@ -364,11 +372,11 @@ where
         if !still_active {
             return;
         }
-        match self
-            .services
-            .consensus
-            .handle_consensus_timeout(&scope, proposal_id)
-        {
+        match self.services.consensus.handle_consensus_timeout(
+            &scope,
+            proposal_id,
+            self.clock.now().as_secs(),
+        ) {
             Ok(_) => {}
             Err(ConsensusError::SessionNotFound) | Err(ConsensusError::SessionNotActive) => {
                 let resolved_locally = self.queues.is_consensus_outcome_applied(proposal_id);
@@ -412,10 +420,11 @@ where
             conversation = %self.conversation_id,
             proposal_id, choice, "vote cast"
         );
+        let now = self.clock.now().as_secs();
         let vote_msg = self
             .services
             .consensus
-            .cast_vote(&scope, proposal_id, vote)?;
+            .cast_vote(&scope, proposal_id, vote, now)?;
 
         let payload = self
             .mls_mut()
@@ -445,6 +454,7 @@ where
             &scope,
             create_request,
             Some(ConsensusConfig::gossipsub().with_timeout(params.consensus_timeout)?),
+            self.clock.now().as_secs(),
         )?;
 
         info!(
@@ -472,7 +482,7 @@ where
         let request = ConversationUpdateRequest::remove_member(self_member_id.to_vec());
         let payload = request.encode_to_vec();
 
-        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let now = self.clock.now().as_secs();
         let expiration = now.saturating_add(params.proposal_expiration.as_secs());
 
         let proposal_id = self_leave_proposal_id(self_member_id);
@@ -489,14 +499,14 @@ where
             liveness_criteria_yes: params.liveness_criteria_yes,
         };
 
-        let yes_vote = build_vote(&proposal, true, self.services.consensus.signer())?;
+        let yes_vote = build_vote(&proposal, true, self.services.consensus.signer(), now)?;
         proposal.votes.push(yes_vote);
 
         let scope = self.conversation_id.clone();
         match self
             .services
             .consensus
-            .process_incoming_proposal(&scope, proposal.clone())
+            .process_incoming_proposal(&scope, proposal.clone(), now)
         {
             Ok(()) => {
                 info!(

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -34,8 +34,10 @@ where
     /// local member installed as sole steward at epoch 0. The library seeds a
     /// fresh MLS group into `provider` (which it does not retain) from
     /// `credential` and `ciphersuite`. `member_id` names the local member — the
-    /// opaque id bytes the protocol matches on. `clock` is the caller-owned
-    /// time source every deadline is measured against.
+    /// opaque id bytes the protocol matches on. `clock` moves in and becomes
+    /// the conversation's time source — every deadline is measured against
+    /// it; a shared clock (e.g. [`crate::MockClock`]) stays drivable through
+    /// a clone the caller keeps.
     #[allow(clippy::too_many_arguments)]
     pub fn create<Pr>(
         conversation_id: &str,
@@ -84,8 +86,10 @@ where
     /// packages — the "not for us" branch, not an error.
     ///
     /// The conversation id comes from the MLS group, so the caller needs no
-    /// prior knowledge of the conversation. `clock` is the caller-owned
-    /// time source every deadline is measured against.
+    /// prior knowledge of the conversation. `clock` moves in and becomes
+    /// the conversation's time source — every deadline is measured against
+    /// it; a shared clock (e.g. [`crate::MockClock`]) stays drivable through
+    /// a clone the caller keeps.
     #[allow(clippy::too_many_arguments)]
     pub fn join<Pr>(
         member_id: &[u8],

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -24,11 +24,11 @@ use crate::{
     mls_crypto::MlsService,
 };
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Create a brand-new conversation we steward. Starts in `Working` with the
     /// local member installed as sole steward at epoch 0. The library seeds a
@@ -44,9 +44,9 @@ where
         credential: CredentialWithKey,
         group_config: &MlsGroupCreateConfig,
         signer: &impl Signer,
-        consensus: &C,
+        consensus: &Cp,
         scoring: PeerScoringService<Sc>,
-        clock: T,
+        clock: Wc,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
     ) -> Result<Self, ConversationError>
@@ -93,9 +93,9 @@ where
         signer: &impl Signer,
         welcome_bytes: &[u8],
         conversation_sync_bytes: &[u8],
-        consensus: &C,
+        consensus: &Cp,
         scoring: PeerScoringService<Sc>,
-        clock: T,
+        clock: Wc,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
     ) -> Result<Option<Self>, ConversationError>
@@ -134,8 +134,8 @@ where
         conversation_id: &str,
         mls: MlsService,
         mut scoring: PeerScoringService<Sc>,
-        consensus: &C,
-        clock: T,
+        consensus: &Cp,
+        clock: Wc,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
         is_creation: bool,

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -84,7 +84,8 @@ where
     /// packages — the "not for us" branch, not an error.
     ///
     /// The conversation id comes from the MLS group, so the caller needs no
-    /// prior knowledge of the conversation.
+    /// prior knowledge of the conversation. `clock` is the caller-owned
+    /// time source every deadline is measured against.
     #[allow(clippy::too_many_arguments)]
     pub fn join<Pr>(
         member_id: &[u8],

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -20,20 +20,22 @@ use hashgraph_like_consensus::{events::ConsensusEventBus, service::ConsensusServ
 use crate::{
     ConsensusPlugin, Conversation, ConversationConfig, ConversationError, ConversationEvent,
     ConversationQueues, ConversationServices, ConversationStateMachine, PeerScoreStorage,
-    PeerScoringService, StewardListService, consensus::outcome_bus::OutcomeBus,
+    PeerScoringService, StewardListService, WallClock, consensus::outcome_bus::OutcomeBus,
     mls_crypto::MlsService,
 };
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Create a brand-new conversation we steward. Starts in `Working` with the
     /// local member installed as sole steward at epoch 0. The library seeds a
     /// fresh MLS group into `provider` (which it does not retain) from
     /// `credential` and `ciphersuite`. `member_id` names the local member — the
-    /// opaque id bytes the protocol matches on.
+    /// opaque id bytes the protocol matches on. `clock` is the caller-owned
+    /// time source every deadline is measured against.
     #[allow(clippy::too_many_arguments)]
     pub fn create<Pr>(
         conversation_id: &str,
@@ -44,6 +46,7 @@ where
         signer: &impl Signer,
         consensus: &C,
         scoring: PeerScoringService<Sc>,
+        clock: T,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
     ) -> Result<Self, ConversationError>
@@ -63,6 +66,7 @@ where
             mls,
             scoring,
             consensus,
+            clock,
             app_id,
             config,
             true,
@@ -90,6 +94,7 @@ where
         conversation_sync_bytes: &[u8],
         consensus: &C,
         scoring: PeerScoringService<Sc>,
+        clock: T,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
     ) -> Result<Option<Self>, ConversationError>
@@ -106,6 +111,7 @@ where
             mls,
             scoring,
             consensus,
+            clock,
             app_id,
             config,
             false,
@@ -128,6 +134,7 @@ where
         mls: MlsService,
         mut scoring: PeerScoringService<Sc>,
         consensus: &C,
+        clock: T,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
         is_creation: bool,
@@ -177,6 +184,7 @@ where
             services,
             state_machine,
             config,
+            clock,
             Arc::from(member_id),
             app_id,
         );

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -9,7 +9,7 @@ use std::error::Error as StdError;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use openmls_traits::storage::StorageProvider;
@@ -21,7 +21,7 @@ use crate::{
     CommitRoundResult, ConsensusEngine, ConsensusPlugin, ConversationConfig, ConversationError,
     ConversationEvent, ConversationQueues, ConversationState, ConversationStateMachine,
     OperatingMode, Outbound, PeerScoreStorage, PeerScoringService, PhaseTimer, ProcessResult,
-    ProposalKind, StewardListService,
+    ProposalKind, StewardListService, SystemClock, Timestamp, WallClock,
     consensus::outcome_bus::OutcomeReceiver,
     decode_inbound_payload, finalize_commit_round, member_set,
     mls_crypto::{CommitArtifacts, MlsCommitInput, MlsService},
@@ -45,7 +45,7 @@ pub enum LeaveOutcome {
 /// resolution; fired by [`Conversation::tick_deadlines`].
 #[derive(Debug, Clone, Copy)]
 pub struct AutoVoteEntry {
-    pub fire_at: Instant,
+    pub fire_at: Timestamp,
     pub vote: bool,
 }
 
@@ -86,7 +86,7 @@ pub(crate) struct Timing {
     /// Registered when a proposal opens (own or incoming peer); fired by
     /// `tick_deadlines` which calls `consensus.handle_consensus_timeout`.
     /// Removed when the consensus session resolves naturally via `handle_consensus_outcome`.
-    pub(crate) pending_consensus_timeouts: HashMap<u32, Instant>,
+    pub(crate) pending_consensus_timeouts: HashMap<u32, Timestamp>,
     /// Last commit-round progress snapshot emitted as `ConversationEvent::CommitRoundProgress`.
     /// `poll()` compares the current `(received, expected)` against this and
     /// emits a new event only when the count changes, avoiding repeated events
@@ -99,13 +99,13 @@ pub(crate) struct Timing {
     /// this is older than the recovery window — the epoch steward had its
     /// chance and stayed silent. Cleared when the buffer is drained or nothing
     /// is left to propose.
-    pub(crate) buffered_propose_anchor: Option<Instant>,
+    pub(crate) buffered_propose_anchor: Option<Timestamp>,
     /// Anchor for the backup-steward sync re-send takeover: set when a backup
     /// first sees an unanswered `ConversationSyncRequest`. A backup re-sends the
     /// sync once this is older than the recovery window — the epoch steward
     /// stayed silent. Cleared when a `ConversationSync` is observed or the
     /// takeover no longer applies.
-    pub(crate) sync_resend_anchor: Option<Instant>,
+    pub(crate) sync_resend_anchor: Option<Timestamp>,
 }
 
 impl Timing {
@@ -123,11 +123,15 @@ impl Timing {
     }
 }
 
-pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage> {
+pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage, T: WallClock = SystemClock> {
     /// Conversation name. Identifies this conversation in the integrator's
     /// registry and is used to construct scope keys for consensus operations.
     /// Read via [`Conversation::conversation_id`].
     pub(crate) conversation_id: String,
+    /// Caller-owned time source. Every deadline anchor and the consensus
+    /// wire timestamps derive from `clock.now()`; the library reads no
+    /// other clock.
+    pub(crate) clock: T,
     pub(crate) queues: ConversationQueues,
     /// Per-conversation MLS service, plug-in instances, and consensus wiring.
     pub(crate) services: ConversationServices<C, Sc>,
@@ -161,25 +165,29 @@ pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage> {
     pending_outbound: Mutex<Vec<Outbound>>,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Build a fresh conversation around an already-assembled `services`
     /// bundle (MLS service seeded, plug-ins configured, consensus receiver
     /// subscribed). The time-driven `timing` state starts from defaults.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         conversation_id: String,
         queues: ConversationQueues,
         services: ConversationServices<C, Sc>,
         state_machine: ConversationStateMachine,
         config: ConversationConfig,
+        clock: T,
         self_member_id: Arc<[u8]>,
         app_id: Arc<[u8]>,
     ) -> Self {
         Self {
             conversation_id,
+            clock,
             queues,
             services,
             state_machine,
@@ -527,7 +535,7 @@ where
     /// inactivity). Forward to an external scheduler that calls `poll()` on
     /// fire; extra/early wakeups are no-ops.
     pub fn next_wakeup_in(&self) -> Option<Duration> {
-        let now = Instant::now();
+        let now = self.clock.now();
         let earliest = self
             .timing
             .pending_consensus_timeouts
@@ -544,7 +552,7 @@ where
     /// inactivity check in `check_steward_inactivity`) all gate on the phase
     /// timer; this surfaces the same wall-clock target so an external
     /// scheduler can wake us at the right time.
-    fn phase_deadline(&self) -> Option<Instant> {
+    fn phase_deadline(&self) -> Option<Timestamp> {
         let anchor = self.timing.phase_timer.started_at()?;
         let cfg = &self.config;
         match self.current_state() {
@@ -606,7 +614,7 @@ where
         self.timing.pending_auto_votes.insert(
             proposal_id,
             AutoVoteEntry {
-                fire_at: Instant::now() + delay,
+                fire_at: self.clock.now() + delay,
                 vote,
             },
         );
@@ -646,9 +654,10 @@ where
     /// Register a consensus-session timeout. Fires `delay` from now via
     /// `tick_deadlines`; removed naturally on consensus resolution.
     pub(crate) fn register_consensus_timeout(&mut self, proposal_id: u32, delay: Duration) {
+        let fire_at = self.clock.now() + delay;
         self.timing
             .pending_consensus_timeouts
-            .insert(proposal_id, Instant::now() + delay);
+            .insert(proposal_id, fire_at);
     }
 
     /// Drop the pending consensus timeout for `proposal_id`. Called from
@@ -673,7 +682,8 @@ where
     /// from any other state.
     pub(crate) fn start_freezing(&mut self) -> Option<ConversationState> {
         if self.state_machine.start_freezing() {
-            self.timing.phase_timer.start();
+            let now = self.clock.now();
+            self.timing.phase_timer.start(now);
             info!(state = "Freezing", "state transition");
             Some(ConversationState::Freezing)
         } else {
@@ -700,7 +710,8 @@ where
     /// `Some(Freezing)` on transition; `None` from any other state.
     pub(crate) fn reopen_recovery_window(&mut self) -> Option<ConversationState> {
         if self.state_machine.reopen_freezing() {
-            self.timing.phase_timer.start();
+            let now = self.clock.now();
+            self.timing.phase_timer.start(now);
             info!(state = "Freezing", "state transition (recovery retry)");
             Some(ConversationState::Freezing)
         } else {
@@ -714,7 +725,7 @@ where
             && self
                 .timing
                 .phase_timer
-                .elapsed_since_anchor(self.config.freeze_duration)
+                .elapsed_since_anchor(self.clock.now(), self.config.freeze_duration)
     }
 
     /// Drives the "steward waited too long to commit" transition into
@@ -730,8 +741,9 @@ where
         if self.current_state() != ConversationState::Working || approved_proposals_count == 0 {
             return None;
         }
+        let now = self.clock.now();
         if self.timing.phase_timer.started_at().is_none() {
-            self.timing.phase_timer.start();
+            self.timing.phase_timer.start(now);
             info!(
                 approved = approved_proposals_count,
                 inactivity_ms = inactivity_duration.as_millis() as u64,
@@ -742,7 +754,7 @@ where
         if !self
             .timing
             .phase_timer
-            .elapsed_since_anchor(inactivity_duration)
+            .elapsed_since_anchor(now, inactivity_duration)
         {
             return None;
         }
@@ -757,8 +769,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
     use openmls_basic_credential::SignatureKeyPair;
 
     use super::*;
@@ -772,7 +782,8 @@ mod tests {
     use crate::{PeerScoringService, ScoringConfig, StewardListService};
     use std::collections::HashMap;
 
-    type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage>;
+    type TestConversation =
+        Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, crate::MockClock>;
 
     /// Build a conversation with a real creator-side MLS service and the given
     /// steward roster, returning it alongside the provider that backs the MLS
@@ -808,7 +819,7 @@ mod tests {
     fn build_conversation_scored<Sc: PeerScoreStorage + Default>(
         mls: TestMls,
         steward_list: StewardListService,
-    ) -> Conversation<DefaultConsensusPlugin, Sc> {
+    ) -> Conversation<DefaultConsensusPlugin, Sc, crate::MockClock> {
         let (consensus, consensus_rx) = make_test_consensus_service();
         Conversation::new(
             "g".to_string(),
@@ -826,6 +837,7 @@ mod tests {
             },
             ConversationStateMachine::new_as_member(),
             ConversationConfig::default(),
+            crate::MockClock::new(),
             Arc::from(&b"test-member-id"[..]),
             Arc::from(&[0u8; 16][..]),
         )
@@ -940,7 +952,6 @@ mod tests {
 
         // Re-register with a different `vote` and a longer delay; the
         // second insert must overwrite, not co-exist.
-        std::thread::sleep(Duration::from_millis(2));
         conversation.register_auto_vote(7, Duration::from_secs(20), false);
         assert_eq!(conversation.timing.pending_auto_votes.len(), 1);
         let entry = conversation.timing.pending_auto_votes[&7];
@@ -974,11 +985,9 @@ mod tests {
     #[test]
     fn register_then_unregister_consensus_timeout() {
         let mut conversation = make_conversation_working();
-        let before = Instant::now();
         conversation.register_consensus_timeout(42, Duration::from_secs(30));
         let fire_at = conversation.timing.pending_consensus_timeouts[&42];
-        assert!(fire_at > before + Duration::from_secs(29));
-        assert!(fire_at < Instant::now() + Duration::from_secs(31));
+        assert_eq!(fire_at, conversation.clock.now() + Duration::from_secs(30));
 
         conversation.unregister_consensus_timeout(42);
         assert!(
@@ -1098,7 +1107,8 @@ mod tests {
         conversation.config.recovery_inactivity_duration = Duration::ZERO;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        conversation.timing.phase_timer.start();
+        let anchor = conversation.clock.now();
+        conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
         conversation.poll(&provider, &signer);
@@ -1142,7 +1152,8 @@ mod tests {
         conversation.config.recovery_max_rounds = 0;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        conversation.timing.phase_timer.start();
+        let anchor = conversation.clock.now();
+        conversation.timing.phase_timer.start(anchor);
 
         // No approved proposals — nothing to recover.
         conversation.poll(&provider, &signer);
@@ -1173,7 +1184,8 @@ mod tests {
         conversation.config.recovery_max_rounds = 3;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        conversation.timing.phase_timer.start();
+        let anchor = conversation.clock.now();
+        conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
         // Rounds 1 and 2 land no commit but must re-open the collection window
@@ -1216,7 +1228,8 @@ mod tests {
         conversation.config.recovery_max_rounds = 0; // retry forever (default)
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        conversation.timing.phase_timer.start();
+        let anchor = conversation.clock.now();
+        conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
         for round in 1..=5 {
@@ -1251,7 +1264,8 @@ mod tests {
         conversation.config.recovery_max_rounds = 1;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        conversation.timing.phase_timer.start();
+        let anchor = conversation.clock.now();
+        conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
         conversation.poll(&provider, &signer);
@@ -1346,7 +1360,8 @@ mod tests {
     fn epoch_steward_request_clears_takeover_anchor() {
         let (mut conversation, provider, signer) =
             make_conversation_with_steward(steward_service_steward(b"test-member-id"));
-        conversation.timing.sync_resend_anchor = Some(Instant::now());
+        let now = conversation.clock.now();
+        conversation.timing.sync_resend_anchor = Some(now);
 
         conversation
             .on_conversation_sync_request(&provider, b"joiner", &signer)

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -21,7 +21,7 @@ use crate::{
     CommitRoundResult, ConsensusEngine, ConsensusPlugin, ConversationConfig, ConversationError,
     ConversationEvent, ConversationQueues, ConversationState, ConversationStateMachine,
     OperatingMode, Outbound, PeerScoreStorage, PeerScoringService, PhaseTimer, ProcessResult,
-    ProposalKind, StewardListService, SystemClock, Timestamp, WallClock,
+    ProposalKind, StewardListService, Timestamp, WallClock,
     consensus::outcome_bus::OutcomeReceiver,
     decode_inbound_payload, finalize_commit_round, member_set,
     mls_crypto::{CommitArtifacts, MlsCommitInput, MlsService},
@@ -123,14 +123,13 @@ impl Timing {
     }
 }
 
-pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage, T: WallClock = SystemClock> {
+pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage, T: WallClock> {
     /// Conversation name. Identifies this conversation in the integrator's
     /// registry and is used to construct scope keys for consensus operations.
     /// Read via [`Conversation::conversation_id`].
     pub(crate) conversation_id: String,
     /// Caller-owned time source. Every deadline anchor and the consensus
-    /// wire timestamps derive from `clock.now()`; the library reads no
-    /// other clock.
+    /// wire timestamps derive from `clock.now()`.
     pub(crate) clock: T,
     pub(crate) queues: ConversationQueues,
     /// Per-conversation MLS service, plug-in instances, and consensus wiring.
@@ -999,6 +998,43 @@ mod tests {
 
         // Unregistering an unknown id is a no-op (no panic, no error).
         conversation.unregister_consensus_timeout(999);
+    }
+
+    /// `next_wakeup_in` is the external scheduler's contract: `None` with
+    /// nothing scheduled, the earliest of the three deadline sources
+    /// otherwise, and `Some(ZERO)` once a deadline has elapsed.
+    #[test]
+    fn next_wakeup_in_reports_the_earliest_deadline() {
+        let mut conversation = make_conversation_working();
+        assert_eq!(
+            conversation.next_wakeup_in(),
+            None,
+            "nothing scheduled means no wakeup"
+        );
+
+        conversation.register_consensus_timeout(1, Duration::from_secs(30));
+        conversation.register_auto_vote(2, Duration::from_secs(10), true);
+        assert_eq!(
+            conversation.next_wakeup_in(),
+            Some(Duration::from_secs(10)),
+            "the earlier auto-vote wins over the consensus timeout"
+        );
+
+        // A phase deadline (freeze window) undercuts both pending entries.
+        conversation.config.freeze_duration = Duration::from_secs(5);
+        conversation.start_freezing();
+        assert_eq!(
+            conversation.next_wakeup_in(),
+            Some(Duration::from_secs(5)),
+            "the freeze-window end is the earliest deadline"
+        );
+
+        conversation.clock.advance(Duration::from_secs(6));
+        assert_eq!(
+            conversation.next_wakeup_in(),
+            Some(Duration::ZERO),
+            "an elapsed deadline reports zero, not None"
+        );
     }
 
     // ── build_local_candidate guards ──────────────────────────────────

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -128,8 +128,9 @@ pub struct Conversation<Cp: ConsensusPlugin, Sc: PeerScoreStorage, Wc: WallClock
     /// registry and is used to construct scope keys for consensus operations.
     /// Read via [`Conversation::conversation_id`].
     pub(crate) conversation_id: String,
-    /// Caller-owned time source. Every deadline anchor and the consensus
-    /// wire timestamps derive from `clock.now()`.
+    /// The conversation's time source, moved in at construction. Every
+    /// deadline anchor and the consensus wire timestamps derive from
+    /// `clock.now()`.
     pub(crate) clock: Wc,
     pub(crate) queues: ConversationQueues,
     /// Per-conversation MLS service, plug-in instances, and consensus wiring.

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -29,6 +29,7 @@ use crate::{
         AppMessage, CommitCandidate, conversation_update_request::Payload,
     },
     replay_early_candidates,
+    wall_clock::WallClockExt,
 };
 
 /// Outcome of [`Conversation::leave`].
@@ -535,7 +536,7 @@ where
     /// inactivity). Forward to an external scheduler that calls `poll()` on
     /// fire; extra/early wakeups are no-ops.
     pub fn next_wakeup_in(&self) -> Option<Duration> {
-        let now = self.clock.now();
+        let now = self.clock.timestamp();
         let earliest = self
             .timing
             .pending_consensus_timeouts
@@ -614,7 +615,7 @@ where
         self.timing.pending_auto_votes.insert(
             proposal_id,
             AutoVoteEntry {
-                fire_at: self.clock.now() + delay,
+                fire_at: self.clock.timestamp() + delay,
                 vote,
             },
         );
@@ -654,7 +655,7 @@ where
     /// Register a consensus-session timeout. Fires `delay` from now via
     /// `tick_deadlines`; removed naturally on consensus resolution.
     pub(crate) fn register_consensus_timeout(&mut self, proposal_id: u32, delay: Duration) {
-        let fire_at = self.clock.now() + delay;
+        let fire_at = self.clock.timestamp() + delay;
         self.timing
             .pending_consensus_timeouts
             .insert(proposal_id, fire_at);
@@ -682,7 +683,7 @@ where
     /// from any other state.
     pub(crate) fn start_freezing(&mut self) -> Option<ConversationState> {
         if self.state_machine.start_freezing() {
-            let now = self.clock.now();
+            let now = self.clock.timestamp();
             self.timing.phase_timer.start(now);
             info!(state = "Freezing", "state transition");
             Some(ConversationState::Freezing)
@@ -710,7 +711,7 @@ where
     /// `Some(Freezing)` on transition; `None` from any other state.
     pub(crate) fn reopen_recovery_window(&mut self) -> Option<ConversationState> {
         if self.state_machine.reopen_freezing() {
-            let now = self.clock.now();
+            let now = self.clock.timestamp();
             self.timing.phase_timer.start(now);
             info!(state = "Freezing", "state transition (recovery retry)");
             Some(ConversationState::Freezing)
@@ -725,7 +726,7 @@ where
             && self
                 .timing
                 .phase_timer
-                .elapsed_since_anchor(self.clock.now(), self.config.freeze_duration)
+                .elapsed_since_anchor(self.clock.timestamp(), self.config.freeze_duration)
     }
 
     /// Drives the "steward waited too long to commit" transition into
@@ -741,7 +742,7 @@ where
         if self.current_state() != ConversationState::Working || approved_proposals_count == 0 {
             return None;
         }
-        let now = self.clock.now();
+        let now = self.clock.timestamp();
         if self.timing.phase_timer.started_at().is_none() {
             self.timing.phase_timer.start(now);
             info!(
@@ -987,7 +988,10 @@ mod tests {
         let mut conversation = make_conversation_working();
         conversation.register_consensus_timeout(42, Duration::from_secs(30));
         let fire_at = conversation.timing.pending_consensus_timeouts[&42];
-        assert_eq!(fire_at, conversation.clock.now() + Duration::from_secs(30));
+        assert_eq!(
+            fire_at,
+            conversation.clock.timestamp() + Duration::from_secs(30)
+        );
 
         conversation.unregister_consensus_timeout(42);
         assert!(
@@ -1144,7 +1148,7 @@ mod tests {
         conversation.config.recovery_inactivity_duration = Duration::ZERO;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        let anchor = conversation.clock.now();
+        let anchor = conversation.clock.timestamp();
         conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
@@ -1189,7 +1193,7 @@ mod tests {
         conversation.config.recovery_max_rounds = 0;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        let anchor = conversation.clock.now();
+        let anchor = conversation.clock.timestamp();
         conversation.timing.phase_timer.start(anchor);
 
         // No approved proposals — nothing to recover.
@@ -1221,7 +1225,7 @@ mod tests {
         conversation.config.recovery_max_rounds = 3;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        let anchor = conversation.clock.now();
+        let anchor = conversation.clock.timestamp();
         conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
@@ -1265,7 +1269,7 @@ mod tests {
         conversation.config.recovery_max_rounds = 0; // retry forever (default)
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        let anchor = conversation.clock.now();
+        let anchor = conversation.clock.timestamp();
         conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
@@ -1301,7 +1305,7 @@ mod tests {
         conversation.config.recovery_max_rounds = 1;
         conversation.enter_recovery_mode();
         conversation.start_freezing();
-        let anchor = conversation.clock.now();
+        let anchor = conversation.clock.timestamp();
         conversation.timing.phase_timer.start(anchor);
         seed_approved_work(&mut conversation);
 
@@ -1397,7 +1401,7 @@ mod tests {
     fn epoch_steward_request_clears_takeover_anchor() {
         let (mut conversation, provider, signer) =
             make_conversation_with_steward(steward_service_steward(b"test-member-id"));
-        let now = conversation.clock.now();
+        let now = conversation.clock.timestamp();
         conversation.timing.sync_resend_anchor = Some(now);
 
         conversation

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -53,7 +53,7 @@ pub struct AutoVoteEntry {
 /// grouped so the handle holds them as one unit. Construction builds the MLS
 /// service, moves the plug-in instances in, and subscribes the consensus
 /// receiver here.
-pub(crate) struct ConversationServices<C: ConsensusPlugin, Sc: PeerScoreStorage> {
+pub(crate) struct ConversationServices<Cp: ConsensusPlugin, Sc: PeerScoreStorage> {
     /// Per-conversation MLS service. Present for the conversation's whole
     /// lifetime: the creator seeds it at [`Conversation::create`], the joiner
     /// at [`Conversation::join`].
@@ -65,7 +65,7 @@ pub(crate) struct ConversationServices<C: ConsensusPlugin, Sc: PeerScoreStorage>
     /// Per-conversation consensus service. Owns this conversation's scope
     /// in the shared storage and a private event bus. Built from the
     /// consensus service passed at construction.
-    pub(crate) consensus: ConsensusEngine<C>,
+    pub(crate) consensus: ConsensusEngine<Cp>,
     /// Drain end of `consensus`'s outcome bus. Walked by `tick_deadlines`,
     /// which dispatches each event through `handle_consensus_outcome`.
     /// Subscribed when the conversation is built in [`Conversation::create`] /
@@ -123,17 +123,17 @@ impl Timing {
     }
 }
 
-pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage, T: WallClock> {
+pub struct Conversation<Cp: ConsensusPlugin, Sc: PeerScoreStorage, Wc: WallClock> {
     /// Conversation name. Identifies this conversation in the integrator's
     /// registry and is used to construct scope keys for consensus operations.
     /// Read via [`Conversation::conversation_id`].
     pub(crate) conversation_id: String,
     /// Caller-owned time source. Every deadline anchor and the consensus
     /// wire timestamps derive from `clock.now()`.
-    pub(crate) clock: T,
+    pub(crate) clock: Wc,
     pub(crate) queues: ConversationQueues,
     /// Per-conversation MLS service, plug-in instances, and consensus wiring.
-    pub(crate) services: ConversationServices<C, Sc>,
+    pub(crate) services: ConversationServices<Cp, Sc>,
     pub(crate) state_machine: ConversationStateMachine,
     /// Per-conversation durable config: voting/consensus durations,
     /// `liveness_criteria_yes`, `pending_update_max_epochs`.
@@ -164,11 +164,11 @@ pub struct Conversation<C: ConsensusPlugin, Sc: PeerScoreStorage, T: WallClock> 
     pending_outbound: Mutex<Vec<Outbound>>,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Build a fresh conversation around an already-assembled `services`
     /// bundle (MLS service seeded, plug-ins configured, consensus receiver
@@ -177,10 +177,10 @@ where
     pub(crate) fn new(
         conversation_id: String,
         queues: ConversationQueues,
-        services: ConversationServices<C, Sc>,
+        services: ConversationServices<Cp, Sc>,
         state_machine: ConversationStateMachine,
         config: ConversationConfig,
-        clock: T,
+        clock: Wc,
         self_member_id: Arc<[u8]>,
         app_id: Arc<[u8]>,
     ) -> Self {

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -168,11 +168,11 @@ pub enum DispatchOutcome {
     LeaveRequested,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Decrypt and dispatch an inbound conversation payload. Drops self-echoes.
     /// Runs the full dispatch chain internally. Returns

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -19,6 +19,7 @@ use std::error::Error as StdError;
 use openmls_traits::signatures::Signer;
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
 
+use hashgraph_like_consensus::error::ConsensusError;
 use hashgraph_like_consensus::protos::consensus::v1::Proposal;
 use prost::Message;
 use tracing::{error, info, warn};
@@ -322,11 +323,39 @@ where
             return Ok(());
         }
 
+        let proposal_id = proposal.proposal_id;
+        let expected_voters = proposal.expected_voters_count;
+        let expiration_timestamp = proposal.expiration_timestamp;
+
+        // Consensus validation runs before any queue mirroring, so a proposal
+        // that fails it (expired or otherwise mis-stamped) leaves no local
+        // trace — a crafted timestamp can't arm the partial freeze or park a
+        // pending update.
+        let scope = self.conversation_id.clone();
+        let local_now = self.clock.now().as_secs();
+        if let Err(e) = self
+            .services
+            .consensus
+            .process_incoming_proposal(&scope, proposal, local_now)
+        {
+            if matches!(e, ConsensusError::ProposalExpired) {
+                self.emit_event(ConversationEvent::Error {
+                    operation: "incoming_proposal".to_string(),
+                    message: format!(
+                        "proposal {proposal_id} expired on arrival \
+                         (expiration {expiration_timestamp}, local now {local_now}); \
+                         possible clock skew"
+                    ),
+                });
+            }
+            return Err(e.into());
+        }
+
         if let Some(req) = decoded.as_ref() {
             let current_epoch = self.mls().current_epoch()?;
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
-                    self.queues.insert_emergency(proposal.proposal_id);
+                    self.queues.insert_emergency(proposal_id);
                 }
                 Some(conversation_update_request::Payload::MemberInvite(_))
                 | Some(conversation_update_request::Payload::RemoveMember(_)) => {
@@ -336,15 +365,6 @@ where
                 _ => {}
             }
         }
-        let proposal_id = proposal.proposal_id;
-        let expected_voters = proposal.expected_voters_count;
-
-        let scope = self.conversation_id.clone();
-        self.services.consensus.process_incoming_proposal(
-            &scope,
-            proposal,
-            self.clock.now().as_secs(),
-        )?;
         // Skip the vote request + auto-vote for fast-path proposals: the
         // creator's bundled YES already resolved the consensus session, so peers have
         // nothing to vote on.

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -35,6 +35,7 @@ use crate::{
         AppMessage, ConversationSync, ConversationUpdateRequest, EventMembershipChange,
         TimingConfig, TypeMembershipChange, app_message, conversation_update_request,
     },
+    wall_clock::WallClockExt,
 };
 
 use crate::{Conversation, ConversationError, ConversationState};
@@ -589,7 +590,7 @@ where
         }
         // A backup arms the takeover timer; a plain member can't answer.
         if self.is_steward() && self.timing.sync_resend_anchor.is_none() {
-            self.timing.sync_resend_anchor = Some(self.clock.now());
+            self.timing.sync_resend_anchor = Some(self.clock.timestamp());
         }
         Ok(())
     }

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -15,7 +15,6 @@
 //!   the consensus scope.
 
 use std::error::Error as StdError;
-use std::time::Instant;
 
 use openmls_traits::signatures::Signer;
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
@@ -26,7 +25,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     ConsensusPlugin, ConversationEvent, PeerScoreStorage, ProcessResult, ProposalKind,
-    ScoreSnapshot, StewardList, StewardListConfig,
+    ScoreSnapshot, StewardList, StewardListConfig, WallClock,
     commit_round::{compute_commit_hash, receive_commit_candidate},
     conversation::{ConversationQueues, member_set},
     mls_crypto::{DecryptedMessage, MlsService},
@@ -168,10 +167,11 @@ pub enum DispatchOutcome {
     LeaveRequested,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Decrypt and dispatch an inbound conversation payload. Drops self-echoes.
     /// Runs the full dispatch chain internally. Returns
@@ -340,9 +340,11 @@ where
         let expected_voters = proposal.expected_voters_count;
 
         let scope = self.conversation_id.clone();
-        self.services
-            .consensus
-            .process_incoming_proposal(&scope, proposal)?;
+        self.services.consensus.process_incoming_proposal(
+            &scope,
+            proposal,
+            self.clock.now().as_secs(),
+        )?;
         // Skip the vote request + auto-vote for fast-path proposals: the
         // creator's bundled YES already resolved the consensus session, so peers have
         // nothing to vote on.
@@ -567,7 +569,7 @@ where
         }
         // A backup arms the takeover timer; a plain member can't answer.
         if self.is_steward() && self.timing.sync_resend_anchor.is_none() {
-            self.timing.sync_resend_anchor = Some(Instant::now());
+            self.timing.sync_resend_anchor = Some(self.clock.now());
         }
         Ok(())
     }

--- a/src/conversation/messaging.rs
+++ b/src/conversation/messaging.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationState, CreatorVote,
-    PeerScoreStorage,
+    PeerScoreStorage, WallClock,
     protos::de_mls::messages::v1::{
         AppMessage, ConversationMessage, ConversationSyncRequest, ConversationUpdateRequest,
         MemberInvite,
@@ -32,10 +32,11 @@ pub struct Outbound {
     pub payload: Vec<u8>,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Buffer a chat message for broadcast. The conversation never sends — the
     /// message is enqueued and the integrator drains it via

--- a/src/conversation/messaging.rs
+++ b/src/conversation/messaging.rs
@@ -32,11 +32,11 @@ pub struct Outbound {
     pub payload: Vec<u8>,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Buffer a chat message for broadcast. The conversation never sends — the
     /// message is enqueued and the integrator drains it via

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -17,6 +17,7 @@ use crate::{
     CommitRoundOutcome, ConsensusPlugin, Conversation, ConversationError, ConversationEvent,
     ConversationState, DispatchOutcome, PeerScoreStorage, ScoreEvent, ScoreOp, WallClock,
     protos::de_mls::messages::v1::{AppMessage, MemberWelcome},
+    wall_clock::WallClockExt,
 };
 
 /// Summary returned by [`Conversation::poll`] after one polling pass.
@@ -151,7 +152,7 @@ where
                 + self.config.recovery_inactivity_duration;
             self.timing
                 .phase_timer
-                .elapsed_since_anchor(self.clock.now(), window)
+                .elapsed_since_anchor(self.clock.timestamp(), window)
         } else {
             self.is_freeze_window_elapsed()
         };
@@ -388,7 +389,7 @@ where
         if !self
             .timing
             .phase_timer
-            .elapsed_since_anchor(self.clock.now(), delay)
+            .elapsed_since_anchor(self.clock.timestamp(), delay)
             || self.queues.commit_round.has_local_candidate()
         {
             return;
@@ -476,7 +477,7 @@ where
         }
 
         // Backup steward: give the epoch steward the recovery window first.
-        let now = self.clock.now();
+        let now = self.clock.timestamp();
         let anchor = match self.timing.buffered_propose_anchor {
             Some(a) => a,
             None => {
@@ -519,7 +520,7 @@ where
             self.timing.sync_resend_anchor = None;
             return Ok(());
         }
-        if self.clock.now() < anchor + self.config.voting_inactivity_window() {
+        if self.clock.timestamp() < anchor + self.config.voting_inactivity_window() {
             return Ok(());
         }
         self.timing.sync_resend_anchor = None;

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -6,10 +6,7 @@
 //! `poll()` once per wakeup cycle and reacts to the returned [`PollOutcome`].
 
 use std::error::Error as StdError;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use openmls_traits::signatures::Signer;
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
@@ -18,7 +15,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     CommitRoundOutcome, ConsensusPlugin, Conversation, ConversationError, ConversationEvent,
-    ConversationState, DispatchOutcome, PeerScoreStorage, ScoreEvent, ScoreOp,
+    ConversationState, DispatchOutcome, PeerScoreStorage, ScoreEvent, ScoreOp, WallClock,
     protos::de_mls::messages::v1::{AppMessage, MemberWelcome},
 };
 
@@ -34,10 +31,11 @@ pub struct PollOutcome {
     pub leave_requested: bool,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Drive one polling cycle: tick consensus deadlines, advance freeze
     /// state, and check steward inactivity.
@@ -151,7 +149,9 @@ where
                 .recovery_auto_commit_delay
                 .unwrap_or(Duration::ZERO)
                 + self.config.recovery_inactivity_duration;
-            self.timing.phase_timer.elapsed_since_anchor(window)
+            self.timing
+                .phase_timer
+                .elapsed_since_anchor(self.clock.now(), window)
         } else {
             self.is_freeze_window_elapsed()
         };
@@ -385,7 +385,10 @@ where
         let Some(delay) = self.config.recovery_auto_commit_delay else {
             return;
         };
-        if !self.timing.phase_timer.elapsed_since_anchor(delay)
+        if !self
+            .timing
+            .phase_timer
+            .elapsed_since_anchor(self.clock.now(), delay)
             || self.queues.commit_round.has_local_candidate()
         {
             return;
@@ -473,15 +476,16 @@ where
         }
 
         // Backup steward: give the epoch steward the recovery window first.
+        let now = self.clock.now();
         let anchor = match self.timing.buffered_propose_anchor {
             Some(a) => a,
             None => {
-                self.timing.buffered_propose_anchor = Some(Instant::now());
+                self.timing.buffered_propose_anchor = Some(now);
                 return Ok(());
             }
         };
         let delay = self.config.voting_inactivity_window();
-        if Instant::now() < anchor + delay {
+        if now < anchor + delay {
             return Ok(());
         }
         self.timing.buffered_propose_anchor = None;
@@ -515,7 +519,7 @@ where
             self.timing.sync_resend_anchor = None;
             return Ok(());
         }
-        if Instant::now() < anchor + self.config.voting_inactivity_window() {
+        if self.clock.now() < anchor + self.config.voting_inactivity_window() {
             return Ok(());
         }
         self.timing.sync_resend_anchor = None;

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -31,11 +31,11 @@ pub struct PollOutcome {
     pub leave_requested: bool,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Drive one polling cycle: tick consensus deadlines, advance freeze
     /// state, and check steward inactivity.

--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -2,13 +2,14 @@
 
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationState, MemberRole,
-    PeerScoreStorage, protos::de_mls::messages::v1::ConversationUpdateRequest,
+    PeerScoreStorage, WallClock, protos::de_mls::messages::v1::ConversationUpdateRequest,
 };
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     /// Current state of the conversation's state machine.
     pub fn state(&self) -> ConversationState {

--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -5,11 +5,11 @@ use crate::{
     PeerScoreStorage, WallClock, protos::de_mls::messages::v1::ConversationUpdateRequest,
 };
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     /// Current state of the conversation's state machine.
     pub fn state(&self) -> ConversationState {

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -11,7 +11,7 @@ use tracing::{error, info};
 
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationState, CreatorVote,
-    ElectionDecision, ElectionSkip, PeerScoreStorage, member_set,
+    ElectionDecision, ElectionSkip, PeerScoreStorage, WallClock, member_set,
     protos::de_mls::messages::v1::{
         AppMessage, ConversationSync, ConversationUpdateRequest, PeerScore,
         StewardElectionProposal, TimingConfig, ViolationEvidence, conversation_update_request,
@@ -31,10 +31,11 @@ pub(crate) enum StewardListReconcile {
     NeedsElection,
 }
 
-impl<C, Sc> Conversation<C, Sc>
+impl<C, Sc, T> Conversation<C, Sc, T>
 where
     C: ConsensusPlugin,
     Sc: PeerScoreStorage,
+    T: WallClock,
 {
     // ── Public API ───────────────────────────────────────────────────
 

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -31,11 +31,11 @@ pub(crate) enum StewardListReconcile {
     NeedsElection,
 }
 
-impl<C, Sc, T> Conversation<C, Sc, T>
+impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
 where
-    C: ConsensusPlugin,
+    Cp: ConsensusPlugin,
     Sc: PeerScoreStorage,
-    T: WallClock,
+    Wc: WallClock,
 {
     // ── Public API ───────────────────────────────────────────────────
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 //! Library error type: [`ConversationError`], raised by conversation operations.
 
-use std::time::SystemTimeError;
-
 use hashgraph_like_consensus::error::ConsensusError;
 
 use crate::mls_crypto::MlsError;
@@ -30,9 +28,6 @@ pub enum ConversationError {
 
     #[error("Message error: {0}")]
     Message(#[from] prost::DecodeError),
-
-    #[error("System time error: {0}")]
-    SystemTime(#[from] SystemTimeError),
 
     #[error("Score storage error: {0}")]
     ScoreStorage(Box<dyn std::error::Error + Send + Sync>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,15 @@
 //! ## Quick Example
 //!
 //! ```ignore
-//! use de_mls::{Conversation, SystemClock};
+//! use de_mls::Conversation;
 //!
 //! // Build a conversation from direct arguments: the OpenMLS provider,
 //! // credential + ciphersuite, the plug-in instances, a consensus service,
-//! // and the time source (SystemClock in production, MockClock in tests).
+//! // and the time source (`clock` is your `WallClock` impl — wrap
+//! // `SystemTime` in production, use `MockClock` in tests).
 //! let mut conversation = Conversation::create(
 //!     "de-mls-test", member_id, provider, credential, ciphersuite, &signer,
-//!     consensus, scoring, SystemClock::new(), app_id, config,
+//!     consensus, scoring, clock, app_id, config,
 //! )?;
 //!
 //! // Send a chat message — buffered, never auto-sent.
@@ -78,7 +79,7 @@ pub mod proposal_kind;
 pub mod phase_timer;
 
 /// Caller-owned time source: [`WallClock`] trait, [`Timestamp`],
-/// [`SystemClock`], and the test-oriented [`MockClock`].
+/// and the test-oriented [`MockClock`].
 pub mod wall_clock;
 
 /// Library error types.
@@ -102,7 +103,7 @@ pub use consensus::{ConsensusPlugin, CreatorVote};
 
 pub(crate) use phase_timer::PhaseTimer;
 
-pub use wall_clock::{MockClock, SystemClock, Timestamp, WallClock};
+pub use wall_clock::{MockClock, Timestamp, WallClock};
 
 /// MLS cryptographic operations: OpenMLS wrapper for encryption/decryption.
 pub mod mls_crypto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub mod proposal_kind;
 /// Wall-clock anchor combined with the conversation state machine.
 pub mod phase_timer;
 
-/// Caller-owned time source: [`WallClock`] trait, [`Timestamp`],
+/// Caller-supplied time source: [`WallClock`] trait, [`Timestamp`],
 /// and the test-oriented [`MockClock`].
 pub mod wall_clock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,14 @@
 //! ## Quick Example
 //!
 //! ```ignore
-//! use de_mls::Conversation;
+//! use de_mls::{Conversation, SystemClock};
 //!
 //! // Build a conversation from direct arguments: the OpenMLS provider,
-//! // credential + ciphersuite, the plug-in instances, and a consensus service.
+//! // credential + ciphersuite, the plug-in instances, a consensus service,
+//! // and the time source (SystemClock in production, MockClock in tests).
 //! let mut conversation = Conversation::create(
 //!     "de-mls-test", member_id, provider, credential, ciphersuite, &signer,
-//!     consensus, scoring, app_id, config,
+//!     consensus, scoring, SystemClock::new(), app_id, config,
 //! )?;
 //!
 //! // Send a chat message — buffered, never auto-sent.
@@ -76,6 +77,10 @@ pub mod proposal_kind;
 /// Wall-clock anchor combined with the conversation state machine.
 pub mod phase_timer;
 
+/// Caller-owned time source: [`WallClock`] trait, [`Timestamp`],
+/// [`SystemClock`], and the test-oriented [`MockClock`].
+pub mod wall_clock;
+
 /// Library error types.
 pub mod error;
 
@@ -96,6 +101,8 @@ pub(crate) use consensus::{ConsensusApplyResult, ConsensusEngine, apply_consensu
 pub use consensus::{ConsensusPlugin, CreatorVote};
 
 pub(crate) use phase_timer::PhaseTimer;
+
+pub use wall_clock::{MockClock, SystemClock, Timestamp, WallClock};
 
 /// MLS cryptographic operations: OpenMLS wrapper for encryption/decryption.
 pub mod mls_crypto;

--- a/src/phase_timer.rs
+++ b/src/phase_timer.rs
@@ -1,7 +1,10 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use crate::wall_clock::Timestamp;
 
 /// Wall-clock anchor for the active phase. Holds only the anchor
-/// `Instant`; queries take the relevant `Duration` as a parameter.
+/// [`Timestamp`]; queries take the current time and the relevant
+/// `Duration` as parameters, so the timer itself never reads a clock.
 /// [`crate::Conversation`] composes the timer with the state
 /// machine and [`crate::ConversationConfig`] durations.
 #[derive(Debug, Clone, Default)]
@@ -11,7 +14,7 @@ pub struct PhaseTimer {
     ///   (drives the steward-inactivity timer).
     /// - Freezing: time the freeze window started.
     /// - Other states: `None`.
-    started_at: Option<Instant>,
+    started_at: Option<Timestamp>,
 }
 
 impl PhaseTimer {
@@ -19,11 +22,11 @@ impl PhaseTimer {
         Self::default()
     }
 
-    /// Anchor the timer at "now". Called by the orchestrator when entering
+    /// Anchor the timer at `now`. Called by the orchestrator when entering
     /// a phase whose timeout matters (Freezing, on first approved proposal
     /// in Working).
-    pub fn start(&mut self) {
-        self.started_at = Some(Instant::now());
+    pub fn start(&mut self, now: Timestamp) {
+        self.started_at = Some(now);
     }
 
     /// Drop the anchor. Called by the orchestrator when leaving a
@@ -32,15 +35,15 @@ impl PhaseTimer {
         self.started_at = None;
     }
 
-    pub fn started_at(&self) -> Option<Instant> {
+    pub fn started_at(&self) -> Option<Timestamp> {
         self.started_at
     }
 
     /// `false` when no anchor is set. Caller is responsible for state
     /// guarding and for choosing the right duration for the current phase.
-    pub fn elapsed_since_anchor(&self, duration: Duration) -> bool {
+    pub fn elapsed_since_anchor(&self, now: Timestamp, duration: Duration) -> bool {
         match self.started_at {
-            Some(t) => Instant::now() >= t + duration,
+            Some(t) => now >= t + duration,
             None => false,
         }
     }
@@ -51,30 +54,34 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    fn t(ms: u64) -> Timestamp {
+        Timestamp::from_duration_since_epoch(Duration::from_millis(ms))
+    }
+
     #[test]
     fn unset_never_elapsed() {
         let pt = PhaseTimer::new();
-        assert!(!pt.elapsed_since_anchor(Duration::from_secs(1)));
+        assert!(!pt.elapsed_since_anchor(t(10_000), Duration::from_secs(1)));
     }
 
     #[test]
     fn fresh_anchor_not_elapsed() {
         let mut pt = PhaseTimer::new();
-        pt.start();
-        assert!(!pt.elapsed_since_anchor(Duration::from_secs(60)));
+        pt.start(t(1_000));
+        assert!(!pt.elapsed_since_anchor(t(1_000), Duration::from_secs(60)));
     }
 
     #[test]
     fn elapsed_when_anchor_old_enough() {
         let mut pt = PhaseTimer::new();
-        pt.started_at = Some(Instant::now() - Duration::from_secs(30));
-        assert!(pt.elapsed_since_anchor(Duration::from_secs(1)));
+        pt.start(t(1_000));
+        assert!(pt.elapsed_since_anchor(t(31_000), Duration::from_secs(1)));
     }
 
     #[test]
     fn clear_drops_anchor() {
         let mut pt = PhaseTimer::new();
-        pt.start();
+        pt.start(t(1_000));
         assert!(pt.started_at().is_some());
         pt.clear();
         assert!(pt.started_at().is_none());

--- a/src/phase_timer.rs
+++ b/src/phase_timer.rs
@@ -4,7 +4,7 @@ use crate::wall_clock::Timestamp;
 
 /// Wall-clock anchor for the active phase. Holds only the anchor
 /// [`Timestamp`]; queries take the current time and the relevant
-/// `Duration` as parameters, so the timer itself never reads a clock.
+/// `Duration` as parameters — the caller supplies the clock reading.
 /// [`crate::Conversation`] composes the timer with the state
 /// machine and [`crate::ConversationConfig`] durations.
 #[derive(Debug, Clone, Default)]

--- a/src/wall_clock.rs
+++ b/src/wall_clock.rs
@@ -1,4 +1,4 @@
-//! Caller-owned time source.
+//! Caller-supplied time source.
 //!
 //! Every deadline in the library — commit/recovery inactivity, the freeze
 //! window, consensus timeouts, auto-votes — is measured against a
@@ -53,9 +53,10 @@ impl Add<Duration> for Timestamp {
     }
 }
 
-/// The conversation's time source, owned by the integrator and moved in at
-/// construction like the other services. All deadline math and the
-/// consensus wire timestamps derive from [`now`](WallClock::now).
+/// The conversation's time source. The integrator picks the impl and moves
+/// an instance in at construction like the other services; the conversation
+/// owns it from then on. All deadline math and the consensus wire
+/// timestamps derive from [`now`](WallClock::now).
 pub trait WallClock {
     /// The current time. Successive readings must never decrease — a
     /// reading that runs backwards un-elapses pending deadlines.

--- a/src/wall_clock.rs
+++ b/src/wall_clock.rs
@@ -59,7 +59,13 @@ impl Add<Duration> for Timestamp {
 /// timestamps derive from [`now`](WallClock::now).
 pub trait WallClock {
     /// The current time. Successive readings must never decrease — a
-    /// reading that runs backwards un-elapses pending deadlines.
+    /// reading that runs backwards un-elapses pending deadlines and can
+    /// break the timestamp ordering peers validate votes against.
+    ///
+    /// This is weaker than a monotonic clock: forward jumps, freezes, and
+    /// slew are all fine; only backwards readings are ruled out. A
+    /// [`std::time::SystemTime`]-backed impl should clamp against backwards
+    /// steps (return the max of the last reading and now).
     fn now(&self) -> Timestamp;
 }
 

--- a/src/wall_clock.rs
+++ b/src/wall_clock.rs
@@ -1,0 +1,171 @@
+//! Caller-owned time source (RFC issue #129).
+//!
+//! Every deadline in the library — commit/recovery inactivity, the freeze
+//! window, consensus timeouts, auto-votes — is measured against a
+//! [`WallClock`] the integrator supplies at construction, so the
+//! application controls where time comes from: [`SystemClock`] in
+//! production, [`MockClock`] in tests. The library never reads the system
+//! clock outside [`SystemClock`].
+
+use std::{
+    ops::Add,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+/// A point in time: milliseconds since the Unix epoch.
+///
+/// Unlike [`std::time::Instant`], a `Timestamp` can be fabricated, which is
+/// what lets tests drive virtual time. [`Timestamp::as_secs`] yields the
+/// wire-format value carried in consensus proposals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Timestamp(Duration);
+
+impl Timestamp {
+    pub const ZERO: Timestamp = Timestamp(Duration::ZERO);
+
+    /// A timestamp `d` past the Unix epoch.
+    pub fn from_duration_since_epoch(d: Duration) -> Self {
+        Timestamp(d)
+    }
+
+    /// Whole seconds since the Unix epoch — the consensus wire format.
+    pub fn as_secs(&self) -> u64 {
+        self.0.as_secs()
+    }
+
+    /// Milliseconds since the Unix epoch.
+    pub fn as_millis(&self) -> u64 {
+        self.0.as_millis() as u64
+    }
+
+    /// Time elapsed from `earlier` to `self`, or [`Duration::ZERO`] when
+    /// `earlier` is in the future.
+    pub fn saturating_duration_since(&self, earlier: Timestamp) -> Duration {
+        self.0.saturating_sub(earlier.0)
+    }
+}
+
+impl Add<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    fn add(self, rhs: Duration) -> Timestamp {
+        Timestamp(self.0.saturating_add(rhs))
+    }
+}
+
+/// The conversation's time source, owned by the integrator and moved in at
+/// construction like the other services. All deadline math and the
+/// consensus wire timestamps derive from [`now`](WallClock::now).
+pub trait WallClock {
+    /// The current time. Successive calls must be non-decreasing.
+    fn now(&self) -> Timestamp;
+}
+
+/// Production clock backed by [`SystemTime`], clamped to be monotone
+/// non-decreasing so an OS clock step backwards can't un-elapse a deadline.
+/// Clones share the clamp state.
+#[derive(Debug, Clone, Default)]
+pub struct SystemClock {
+    /// Highest millisecond value handed out so far.
+    floor_ms: Arc<AtomicU64>,
+}
+
+impl SystemClock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl WallClock for SystemClock {
+    fn now(&self) -> Timestamp {
+        let system_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_millis() as u64;
+        let prev = self.floor_ms.fetch_max(system_ms, Ordering::Relaxed);
+        Timestamp(Duration::from_millis(system_ms.max(prev)))
+    }
+}
+
+/// Manually driven clock for tests. Clones share the same underlying time,
+/// so a test keeps one handle to [`advance`](MockClock::advance) while the
+/// conversation owns another.
+///
+/// Starts at [`Timestamp::ZERO`]; use [`MockClock::at`] to start elsewhere
+/// (e.g. real time, or skewed relative to another member's clock).
+#[derive(Debug, Clone, Default)]
+pub struct MockClock {
+    now_ms: Arc<AtomicU64>,
+}
+
+impl MockClock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A clock starting at `start`.
+    pub fn at(start: Timestamp) -> Self {
+        Self {
+            now_ms: Arc::new(AtomicU64::new(start.as_millis())),
+        }
+    }
+
+    /// Move time forward by `d`. Visible to every clone immediately.
+    pub fn advance(&self, d: Duration) {
+        self.now_ms
+            .fetch_add(d.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Jump to an absolute time. Backward jumps are allowed — skewing a
+    /// member's clock is the point of this type — but deadline math on a
+    /// single conversation assumes its own clock never runs backwards.
+    pub fn set(&self, t: Timestamp) {
+        self.now_ms.store(t.as_millis(), Ordering::Relaxed);
+    }
+}
+
+impl WallClock for MockClock {
+    fn now(&self) -> Timestamp {
+        Timestamp(Duration::from_millis(self.now_ms.load(Ordering::Relaxed)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_clock_clones_share_time() {
+        let clock = MockClock::new();
+        let handle = clock.clone();
+        handle.advance(Duration::from_secs(5));
+        assert_eq!(clock.now(), Timestamp::ZERO + Duration::from_secs(5));
+    }
+
+    #[test]
+    fn timestamp_ordering_and_arithmetic() {
+        let t0 = Timestamp::ZERO + Duration::from_millis(100);
+        let t1 = t0 + Duration::from_millis(50);
+        assert!(t1 > t0);
+        assert_eq!(t1.saturating_duration_since(t0), Duration::from_millis(50));
+        assert_eq!(t0.saturating_duration_since(t1), Duration::ZERO);
+    }
+
+    #[test]
+    fn system_clock_is_monotone_across_clones() {
+        let clock = SystemClock::new();
+        let a = clock.now();
+        let b = clock.clone().now();
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn wire_seconds_truncate_milliseconds() {
+        let t = Timestamp::from_duration_since_epoch(Duration::from_millis(1999));
+        assert_eq!(t.as_secs(), 1);
+    }
+}

--- a/src/wall_clock.rs
+++ b/src/wall_clock.rs
@@ -58,31 +58,45 @@ impl Add<Duration> for Timestamp {
 /// owns it from then on. All deadline math and the consensus wire
 /// timestamps derive from [`now`](WallClock::now).
 pub trait WallClock {
-    /// The current time. Successive readings must never decrease — a
-    /// reading that runs backwards un-elapses pending deadlines and can
-    /// break the timestamp ordering peers validate votes against.
+    /// The current time as a duration since the Unix epoch. Successive
+    /// readings must never decrease — a reading that runs backwards
+    /// un-elapses pending deadlines and can break the timestamp ordering
+    /// peers validate votes against.
     ///
     /// This is weaker than a monotonic clock: forward jumps, freezes, and
     /// slew are all fine; only backwards readings are ruled out. A
     /// [`std::time::SystemTime`]-backed impl should clamp against backwards
     /// steps (return the max of the last reading and now).
-    fn now(&self) -> Timestamp;
+    fn now(&self) -> Duration;
 }
+
+/// Internal bridge from the integrator-facing [`WallClock`] (plain
+/// [`Duration`] since the Unix epoch) to the [`Timestamp`] the library's
+/// deadline math runs on. Blanket-implemented for every clock, so external
+/// impls never construct the wrapper type.
+pub(crate) trait WallClockExt: WallClock {
+    /// [`WallClock::now`] as a [`Timestamp`].
+    fn timestamp(&self) -> Timestamp {
+        Timestamp::from_duration_since_epoch(self.now())
+    }
+}
+
+impl<Wc: WallClock> WallClockExt for Wc {}
 
 /// Manually driven clock for tests, nanosecond-precise. Clones share the
 /// same underlying  time, so a test keeps one handle to [`advance`](MockClock::advance)
 /// while the conversation owns another.
 ///
-/// Starts at [`Timestamp::ZERO`]; use [`MockClock::at`] to start elsewhere
+/// Starts at the Unix epoch; use [`MockClock::at`] to start elsewhere
 /// (e.g. real time, or skewed relative to another member's clock).
 #[derive(Debug, Clone, Default)]
 pub struct MockClock {
     now_nanos: Arc<AtomicU64>,
 }
 
-/// Truncate a [`Timestamp`] into the `MockClock` nanosecond range.
-fn timestamp_nanos(t: Timestamp) -> u64 {
-    t.0.as_nanos().min(u64::MAX as u128) as u64
+/// Truncate a [`Duration`] into the `MockClock` nanosecond range.
+fn duration_nanos(d: Duration) -> u64 {
+    d.as_nanos().min(u64::MAX as u128) as u64
 }
 
 impl MockClock {
@@ -90,17 +104,17 @@ impl MockClock {
         Self::default()
     }
 
-    /// A clock starting at `start`.
-    pub fn at(start: Timestamp) -> Self {
+    /// A clock starting at `start` past the Unix epoch.
+    pub fn at(start: Duration) -> Self {
         Self {
-            now_nanos: Arc::new(AtomicU64::new(timestamp_nanos(start))),
+            now_nanos: Arc::new(AtomicU64::new(duration_nanos(start))),
         }
     }
 
     /// Move time forward by `d` (saturating). Visible to every clone
     /// immediately.
     pub fn advance(&self, d: Duration) {
-        let add = d.as_nanos().min(u64::MAX as u128) as u64;
+        let add = duration_nanos(d);
         let _ = self
             .now_nanos
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
@@ -110,8 +124,8 @@ impl MockClock {
 }
 
 impl WallClock for MockClock {
-    fn now(&self) -> Timestamp {
-        Timestamp(Duration::from_nanos(self.now_nanos.load(Ordering::Relaxed)))
+    fn now(&self) -> Duration {
+        Duration::from_nanos(self.now_nanos.load(Ordering::Relaxed))
     }
 }
 
@@ -124,7 +138,7 @@ mod tests {
         let clock = MockClock::new();
         let handle = clock.clone();
         handle.advance(Duration::from_secs(5));
-        assert_eq!(clock.now(), Timestamp::ZERO + Duration::from_secs(5));
+        assert_eq!(clock.now(), Duration::from_secs(5));
     }
 
     #[test]
@@ -132,13 +146,22 @@ mod tests {
         let clock = MockClock::new();
         clock.advance(Duration::from_micros(500));
         clock.advance(Duration::from_micros(500));
-        assert_eq!(clock.now(), Timestamp::ZERO + Duration::from_millis(1));
+        assert_eq!(clock.now(), Duration::from_millis(1));
     }
 
     #[test]
     fn mock_clock_at_reproduces_the_start_exactly() {
-        let start = Timestamp::from_duration_since_epoch(Duration::new(1_750_000_000, 123_456));
+        let start = Duration::new(1_750_000_000, 123_456);
         assert_eq!(MockClock::at(start).now(), start);
+    }
+
+    #[test]
+    fn blanket_timestamp_bridges_now_into_deadline_math() {
+        let clock = MockClock::at(Duration::from_secs(7));
+        assert_eq!(
+            clock.timestamp(),
+            Timestamp::from_duration_since_epoch(Duration::from_secs(7))
+        );
     }
 
     #[test]

--- a/src/wall_clock.rs
+++ b/src/wall_clock.rs
@@ -1,11 +1,11 @@
-//! Caller-owned time source (RFC issue #129).
+//! Caller-owned time source.
 //!
 //! Every deadline in the library — commit/recovery inactivity, the freeze
 //! window, consensus timeouts, auto-votes — is measured against a
 //! [`WallClock`] the integrator supplies at construction, so the
-//! application controls where time comes from: [`SystemClock`] in
-//! production, [`MockClock`] in tests. The library never reads the system
-//! clock outside [`SystemClock`].
+//! application controls where time comes from: its own production impl
+//! (typically wrapping [`std::time::SystemTime`]), or [`MockClock`] in
+//! tests.
 
 use std::{
     ops::Add,
@@ -13,14 +13,10 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
-/// A point in time: milliseconds since the Unix epoch.
-///
-/// Unlike [`std::time::Instant`], a `Timestamp` can be fabricated, which is
-/// what lets tests drive virtual time. [`Timestamp::as_secs`] yields the
-/// wire-format value carried in consensus proposals.
+/// A point in time: a duration since the Unix epoch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Timestamp(Duration);
 
@@ -28,7 +24,7 @@ impl Timestamp {
     pub const ZERO: Timestamp = Timestamp(Duration::ZERO);
 
     /// A timestamp `d` past the Unix epoch.
-    pub fn from_duration_since_epoch(d: Duration) -> Self {
+    pub const fn from_duration_since_epoch(d: Duration) -> Self {
         Timestamp(d)
     }
 
@@ -37,7 +33,7 @@ impl Timestamp {
         self.0.as_secs()
     }
 
-    /// Milliseconds since the Unix epoch.
+    /// Milliseconds since the Unix epoch, truncated to `u64`.
     pub fn as_millis(&self) -> u64 {
         self.0.as_millis() as u64
     }
@@ -61,45 +57,25 @@ impl Add<Duration> for Timestamp {
 /// construction like the other services. All deadline math and the
 /// consensus wire timestamps derive from [`now`](WallClock::now).
 pub trait WallClock {
-    /// The current time. Successive calls must be non-decreasing.
+    /// The current time. Successive readings must never decrease — a
+    /// reading that runs backwards un-elapses pending deadlines.
     fn now(&self) -> Timestamp;
 }
 
-/// Production clock backed by [`SystemTime`], clamped to be monotone
-/// non-decreasing so an OS clock step backwards can't un-elapse a deadline.
-/// Clones share the clamp state.
-#[derive(Debug, Clone, Default)]
-pub struct SystemClock {
-    /// Highest millisecond value handed out so far.
-    floor_ms: Arc<AtomicU64>,
-}
-
-impl SystemClock {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl WallClock for SystemClock {
-    fn now(&self) -> Timestamp {
-        let system_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_millis() as u64;
-        let prev = self.floor_ms.fetch_max(system_ms, Ordering::Relaxed);
-        Timestamp(Duration::from_millis(system_ms.max(prev)))
-    }
-}
-
-/// Manually driven clock for tests. Clones share the same underlying time,
-/// so a test keeps one handle to [`advance`](MockClock::advance) while the
-/// conversation owns another.
+/// Manually driven clock for tests, nanosecond-precise. Clones share the
+/// same underlying  time, so a test keeps one handle to [`advance`](MockClock::advance)
+/// while the conversation owns another.
 ///
 /// Starts at [`Timestamp::ZERO`]; use [`MockClock::at`] to start elsewhere
 /// (e.g. real time, or skewed relative to another member's clock).
 #[derive(Debug, Clone, Default)]
 pub struct MockClock {
-    now_ms: Arc<AtomicU64>,
+    now_nanos: Arc<AtomicU64>,
+}
+
+/// Truncate a [`Timestamp`] into the `MockClock` nanosecond range.
+fn timestamp_nanos(t: Timestamp) -> u64 {
+    t.0.as_nanos().min(u64::MAX as u128) as u64
 }
 
 impl MockClock {
@@ -110,27 +86,25 @@ impl MockClock {
     /// A clock starting at `start`.
     pub fn at(start: Timestamp) -> Self {
         Self {
-            now_ms: Arc::new(AtomicU64::new(start.as_millis())),
+            now_nanos: Arc::new(AtomicU64::new(timestamp_nanos(start))),
         }
     }
 
-    /// Move time forward by `d`. Visible to every clone immediately.
+    /// Move time forward by `d` (saturating). Visible to every clone
+    /// immediately.
     pub fn advance(&self, d: Duration) {
-        self.now_ms
-            .fetch_add(d.as_millis() as u64, Ordering::Relaxed);
-    }
-
-    /// Jump to an absolute time. Backward jumps are allowed — skewing a
-    /// member's clock is the point of this type — but deadline math on a
-    /// single conversation assumes its own clock never runs backwards.
-    pub fn set(&self, t: Timestamp) {
-        self.now_ms.store(t.as_millis(), Ordering::Relaxed);
+        let add = d.as_nanos().min(u64::MAX as u128) as u64;
+        let _ = self
+            .now_nanos
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_add(add))
+            });
     }
 }
 
 impl WallClock for MockClock {
     fn now(&self) -> Timestamp {
-        Timestamp(Duration::from_millis(self.now_ms.load(Ordering::Relaxed)))
+        Timestamp(Duration::from_nanos(self.now_nanos.load(Ordering::Relaxed)))
     }
 }
 
@@ -147,20 +121,26 @@ mod tests {
     }
 
     #[test]
+    fn mock_clock_advance_is_sub_millisecond_exact() {
+        let clock = MockClock::new();
+        clock.advance(Duration::from_micros(500));
+        clock.advance(Duration::from_micros(500));
+        assert_eq!(clock.now(), Timestamp::ZERO + Duration::from_millis(1));
+    }
+
+    #[test]
+    fn mock_clock_at_reproduces_the_start_exactly() {
+        let start = Timestamp::from_duration_since_epoch(Duration::new(1_750_000_000, 123_456));
+        assert_eq!(MockClock::at(start).now(), start);
+    }
+
+    #[test]
     fn timestamp_ordering_and_arithmetic() {
         let t0 = Timestamp::ZERO + Duration::from_millis(100);
         let t1 = t0 + Duration::from_millis(50);
         assert!(t1 > t0);
         assert_eq!(t1.saturating_duration_since(t0), Duration::from_millis(50));
         assert_eq!(t0.saturating_duration_since(t1), Duration::ZERO);
-    }
-
-    #[test]
-    fn system_clock_is_monotone_across_clones() {
-        let clock = SystemClock::new();
-        let a = clock.now();
-        let b = clock.clone().now();
-        assert!(b >= a);
     }
 
     #[test]

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -34,7 +34,9 @@ use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationUpdateRequest, MemberInvite, MemberWelcome, app_message,
 };
 use de_mls::{Conversation, ConversationConfig, CreatorVote, MemberRole, Outbound, PollOutcome};
-use de_mls::{ConversationEvent, ConversationState, MockClock, ScoringConfig, StewardListConfig};
+use de_mls::{ConversationError, ConversationEvent, ConversationState, MockClock, ScoringConfig};
+use de_mls::{StewardListConfig, Timestamp};
+use hashgraph_like_consensus::error::ConsensusError;
 
 use crate::common::test_mls_group_config;
 use crate::common::{
@@ -44,6 +46,12 @@ use crate::common::{
 /// Per-conversation MLS service stack the harness runs, on virtual time.
 pub type TestConversation =
     Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, MockClock>;
+
+/// Where every member's virtual clock starts: a realistic Unix epoch, so
+/// consensus wire timestamps carry production-scale values instead of the
+/// 0..2s band.
+pub const HARNESS_EPOCH: Timestamp =
+    Timestamp::from_duration_since_epoch(Duration::from_secs(1_750_000_000));
 
 /// Fast sub-second timing so the virtual-clock polling loop converges in a
 /// handful of rounds.
@@ -91,7 +99,7 @@ impl Integrator {
             scoring_config: ScoringConfig::default(),
             steward_list_config,
             provider: OpenMlsRustCrypto::default(),
-            clock: MockClock::new(),
+            clock: MockClock::at(HARNESS_EPOCH),
         }
     }
 
@@ -128,6 +136,9 @@ pub struct Member {
     integ: Integrator,
     convo: Option<TestConversation>,
     events: Vec<ConversationEvent>,
+    /// Errors returned by `process_inbound` on delivery, in arrival order —
+    /// delivery keeps going, but tests can assert a rejection happened.
+    inbound_errors: Vec<ConversationError>,
     /// The encrypted `conversation_sync_bytes` from the welcome this member
     /// joined with — captured so a test can replay it (idempotency check).
     last_sync: Option<Vec<u8>>,
@@ -168,6 +179,7 @@ impl Member {
             integ,
             convo: Some(convo),
             events: Vec::new(),
+            inbound_errors: Vec::new(),
             last_sync: None,
             pending_config: config,
         }
@@ -189,6 +201,7 @@ impl Member {
             integ,
             convo: None,
             events: Vec::new(),
+            inbound_errors: Vec::new(),
             last_sync: None,
             pending_config: config,
         }
@@ -337,6 +350,17 @@ impl Member {
     /// Every [`ConversationEvent`] this member has emitted, in order.
     pub fn events(&self) -> &[ConversationEvent] {
         &self.events
+    }
+
+    /// Whether any delivered packet was rejected as an expired proposal —
+    /// the receiver-side signature of clock skew.
+    pub fn saw_expired_proposal(&self) -> bool {
+        self.inbound_errors.iter().any(|e| {
+            matches!(
+                e,
+                ConversationError::Consensus(ConsensusError::ProposalExpired)
+            )
+        })
     }
 
     /// Inbound chat messages, decoded from the event log in arrival order.
@@ -491,9 +515,11 @@ impl Member {
     /// Deliver a raw payload to this member as if it arrived from `sender`.
     /// No-op when the member hasn't joined.
     pub fn deliver_raw(&mut self, sender: &[u8], payload: &[u8]) {
-        if let Some(convo) = self.convo.as_mut() {
-            let _ =
-                convo.process_inbound(&self.integ.provider, &self.integ.signer, sender, payload);
+        if let Some(convo) = self.convo.as_mut()
+            && let Err(e) =
+                convo.process_inbound(&self.integ.provider, &self.integ.signer, sender, payload)
+        {
+            self.inbound_errors.push(e);
         }
     }
 
@@ -554,13 +580,15 @@ impl Member {
     }
 
     fn deliver(&mut self, packet: &Outbound) {
-        if let Some(convo) = self.convo.as_mut() {
-            let _ = convo.process_inbound(
+        if let Some(convo) = self.convo.as_mut()
+            && let Err(e) = convo.process_inbound(
                 &self.integ.provider,
                 &self.integ.signer,
                 &packet.sender,
                 &packet.payload,
-            );
+            )
+        {
+            self.inbound_errors.push(e);
         }
     }
 

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -20,7 +20,6 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
-use std::thread::sleep;
 use std::time::Duration;
 
 use alloy::signers::local::PrivateKeySigner;
@@ -35,18 +34,19 @@ use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationUpdateRequest, MemberInvite, MemberWelcome, app_message,
 };
 use de_mls::{Conversation, ConversationConfig, CreatorVote, MemberRole, Outbound, PollOutcome};
-use de_mls::{ConversationEvent, ConversationState, ScoringConfig, StewardListConfig};
+use de_mls::{ConversationEvent, ConversationState, MockClock, ScoringConfig, StewardListConfig};
 
 use crate::common::test_mls_group_config;
 use crate::common::{
     MintedKeyPackage, make_scoring, mint_key_package, test_credential, wallet::WalletMemberId,
 };
 
-/// Per-conversation MLS service stack the harness runs.
-pub type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage>;
+/// Per-conversation MLS service stack the harness runs, on virtual time.
+pub type TestConversation =
+    Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, MockClock>;
 
-/// Fast sub-second timing so a real-wall-clock polling loop converges in a
-/// handful of rounds. Mirror of the gateway suite's `fast_test_config`.
+/// Fast sub-second timing so the virtual-clock polling loop converges in a
+/// handful of rounds.
 pub fn fast_config() -> ConversationConfig {
     ConversationConfig {
         commit_inactivity_duration: Duration::from_millis(50),
@@ -73,6 +73,9 @@ struct Integrator {
     /// model). The creator seeds its group into it; a joiner mints its key
     /// package into it and later opens the welcome from it.
     provider: OpenMlsRustCrypto,
+    /// This member's virtual clock. The harness keeps this handle and moves
+    /// it forward each driving round; the conversation owns a clone.
+    clock: MockClock,
 }
 
 impl Integrator {
@@ -88,6 +91,7 @@ impl Integrator {
             scoring_config: ScoringConfig::default(),
             steward_list_config,
             provider: OpenMlsRustCrypto::default(),
+            clock: MockClock::new(),
         }
     }
 
@@ -155,6 +159,7 @@ impl Member {
             &integ.signer,
             &integ.consensus,
             scoring,
+            integ.clock.clone(),
             integ.app_id(),
             config.clone(),
         )
@@ -476,6 +481,13 @@ impl Member {
         self.drain_outbound()
     }
 
+    /// Move this member's virtual clock forward by `d` — for tests that
+    /// drive one member's `poll` directly instead of going through
+    /// [`TestHarness::process`].
+    pub fn advance_clock(&self, d: Duration) {
+        self.integ.clock.advance(d);
+    }
+
     /// Deliver a raw payload to this member as if it arrived from `sender`.
     /// No-op when the member hasn't joined.
     pub fn deliver_raw(&mut self, sender: &[u8], payload: &[u8]) {
@@ -599,6 +611,7 @@ impl Member {
             &welcome.conversation_sync_bytes,
             &self.integ.consensus,
             scoring,
+            self.integ.clock.clone(),
             self.integ.app_id(),
             self.pending_config.clone(),
         ) {
@@ -782,14 +795,17 @@ impl<const N: usize> TestHarness<N> {
         &self.members
     }
 
-    /// One driving round: sleep a step, poll every member, route welcomes,
-    /// then broadcast all buffered outbound. Welcomes are routed before app
-    /// traffic so a joiner's MLS is attached before same-round commit/election
-    /// packets arrive. Events are drained twice — before and after relay — so
-    /// phase/chat events emitted by this round's welcome acceptance and
-    /// delivery land in the log before the next predicate check.
+    /// One driving round: advance every member's virtual clock a step, poll
+    /// every member, route welcomes, then broadcast all buffered outbound.
+    /// Welcomes are routed before app traffic so a joiner's MLS is attached
+    /// before same-round commit/election packets arrive. Events are drained
+    /// twice — before and after relay — so phase/chat events emitted by this
+    /// round's welcome acceptance and delivery land in the log before the
+    /// next predicate check.
     pub fn process(&mut self, step: Duration) {
-        sleep(step);
+        for member in &self.members {
+            member.integ.clock.advance(step);
+        }
         for member in &mut self.members {
             let _ = member.poll();
         }
@@ -830,8 +846,9 @@ impl<const N: usize> TestHarness<N> {
         }
     }
 
-    /// Drive `process` in 50 ms steps until `predicate` holds, panicking after
-    /// a fixed timeout. `label` is logged for diagnosis.
+    /// Drive `process` in 50 ms virtual-time steps until `predicate` holds,
+    /// panicking after a fixed virtual-time budget. `label` is logged for
+    /// diagnosis.
     pub fn process_until(&mut self, label: &str, predicate: impl Fn(&Self) -> bool) {
         const TIMEOUT: Duration = Duration::from_secs(30);
         const STEP: Duration = Duration::from_millis(50);

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -29,13 +29,13 @@ use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use prost::Message;
 
+use de_mls::StewardListConfig;
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
 use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationUpdateRequest, MemberInvite, MemberWelcome, app_message,
 };
 use de_mls::{Conversation, ConversationConfig, CreatorVote, MemberRole, Outbound, PollOutcome};
 use de_mls::{ConversationError, ConversationEvent, ConversationState, MockClock, ScoringConfig};
-use de_mls::{StewardListConfig, Timestamp};
 use hashgraph_like_consensus::error::ConsensusError;
 
 use crate::common::test_mls_group_config;
@@ -47,11 +47,10 @@ use crate::common::{
 pub type TestConversation =
     Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, MockClock>;
 
-/// Where every member's virtual clock starts: a realistic Unix epoch, so
-/// consensus wire timestamps carry production-scale values instead of the
-/// 0..2s band.
-pub const HARNESS_EPOCH: Timestamp =
-    Timestamp::from_duration_since_epoch(Duration::from_secs(1_750_000_000));
+/// Where every member's virtual clock starts (as a duration past the Unix
+/// epoch): a realistic wall time, so consensus wire timestamps carry
+/// production-scale values instead of the 0..2s band.
+pub const HARNESS_EPOCH: Duration = Duration::from_secs(1_750_000_000);
 
 /// Fast sub-second timing so the virtual-clock polling loop converges in a
 /// handful of rounds.

--- a/tests/protocol_clock_skew.rs
+++ b/tests/protocol_clock_skew.rs
@@ -1,0 +1,100 @@
+//! Asymmetric-clock reproduction of the failure that motivated the
+//! caller-owned clock: a proposal that reaches a peer after its expiration
+//! window (network latency exceeding the configured timers) is dropped by
+//! that peer's consensus validation, so the peer never surfaces a vote
+//! request. The control test pins the same flow on lockstep clocks, proving
+//! the skew alone causes the drop.
+//!
+//! The skewed member's clock runs ahead of the proposer's, which is
+//! equivalent to the proposal arriving late: by the time it lands, the
+//! receiver's `now` is already past the proposal's `expiration_timestamp`.
+
+mod common;
+
+use std::time::Duration;
+
+use common::harness::TestHarness;
+use de_mls::ConversationConfig;
+use de_mls::StewardListConfig;
+
+const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+/// The proposal-validity window under test. The skew pushes the receiver
+/// past it; the wire format is whole seconds, so both are multi-second.
+const EXPIRATION: Duration = Duration::from_secs(2);
+const SKEW: Duration = Duration::from_secs(3);
+
+/// With two expected voters the consensus library requires both votes, so
+/// the proposer's session fails at the timeout when the peer stays silent —
+/// nothing commits over the peer that never saw the proposal.
+fn skew_config() -> ConversationConfig {
+    ConversationConfig {
+        commit_inactivity_duration: Duration::from_secs(2),
+        freeze_duration: Duration::from_millis(20),
+        voting_delay: Duration::from_millis(300),
+        election_voting_delay: Duration::from_millis(300),
+        consensus_timeout: Duration::from_millis(500),
+        proposal_expiration: EXPIRATION,
+        ..ConversationConfig::default()
+    }
+}
+
+/// Control: on lockstep clocks the same proposal reaches the peer inside its
+/// validity window and surfaces a vote request.
+#[test]
+fn lockstep_peer_surfaces_the_vote_request() {
+    let mut h = TestHarness::<2>::bootstrap(
+        [ALICE, BOB],
+        "skew-control",
+        skew_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    let bob_id = h.member(1).member_id_bytes().to_vec();
+    h.member_mut(0).remove_member(&bob_id);
+
+    h.process_until("bob receives the vote request", |h| {
+        h.member(1).pending_vote_request().is_some()
+    });
+}
+
+/// Reproduction: the receiver's clock is past the proposal's expiration when
+/// the proposal arrives, so consensus validation drops it — no vote request,
+/// no session, and nothing commits on either side.
+#[test]
+fn proposal_arriving_past_expiration_is_dropped_by_skewed_peer() {
+    let mut h = TestHarness::<2>::bootstrap(
+        [ALICE, BOB],
+        "skew-late",
+        skew_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    let epoch_before = h.epoch();
+
+    // Bob's clock runs ahead of alice's by more than the validity window —
+    // every proposal alice stamps is already expired when bob validates it.
+    h.member(1).advance_clock(SKEW);
+
+    let bob_id = h.member(1).member_id_bytes().to_vec();
+    h.member_mut(0).remove_member(&bob_id);
+
+    // Drive well past the consensus timeout: the proposal round must resolve
+    // (or retry) without bob ever seeing it.
+    for _ in 0..30 {
+        h.process(Duration::from_millis(50));
+    }
+
+    assert!(
+        h.member(1).pending_vote_request().is_none(),
+        "an expired proposal must be dropped before the vote request"
+    );
+    assert_eq!(
+        h.epoch(),
+        epoch_before,
+        "a proposal the peer never saw must not commit"
+    );
+    assert!(h.epochs_agree(), "both members stay on the same epoch");
+    assert_eq!(h.member(0).member_count(), 2, "bob is not removed");
+    assert!(!h.member(1).saw_leaving(), "bob does not leave");
+}

--- a/tests/protocol_clock_skew.rs
+++ b/tests/protocol_clock_skew.rs
@@ -51,6 +51,11 @@ fn lockstep_peer_surfaces_the_vote_request() {
         StewardListConfig::new(1, 5).unwrap(),
     );
 
+    assert!(
+        h.member(1).pending_vote_request().is_none(),
+        "no vote request exists before the removal is proposed"
+    );
+
     let bob_id = h.member(1).member_id_bytes().to_vec();
     h.member_mut(0).remove_member(&bob_id);
 
@@ -85,6 +90,10 @@ fn proposal_arriving_past_expiration_is_dropped_by_skewed_peer() {
         h.process(Duration::from_millis(50));
     }
 
+    assert!(
+        h.member(1).saw_expired_proposal(),
+        "bob's inbound processing rejects the proposal as expired"
+    );
     assert!(
         h.member(1).pending_vote_request().is_none(),
         "an expired proposal must be dropped before the vote request"

--- a/tests/protocol_join_lifecycle.rs
+++ b/tests/protocol_join_lifecycle.rs
@@ -3,7 +3,6 @@
 
 mod common;
 
-use std::thread::sleep;
 use std::time::Duration;
 
 use common::harness::{TestHarness, fast_config};
@@ -140,7 +139,8 @@ fn backup_steward_resends_sync_when_epoch_steward_silent() {
     );
 
     // Past the window with no answer seen, the backup re-sends the sync.
-    sleep(cfg.voting_inactivity_window() + Duration::from_millis(50));
+    h.member(backup)
+        .advance_clock(cfg.voting_inactivity_window() + Duration::from_millis(50));
     h.member_mut(backup).poll();
     assert_eq!(
         h.member_mut(backup).take_outbound().len(),

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -16,7 +16,7 @@ use openmls::credentials::CredentialWithKey;
 use openmls_basic_credential::SignatureKeyPair;
 
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
-use de_mls::{Conversation, ConversationState};
+use de_mls::{Conversation, ConversationState, MockClock};
 use de_mls::{ConversationEvent, ScoringConfig};
 
 use common::{
@@ -26,8 +26,8 @@ use common::{
 
 use crate::common::test_mls_group_config;
 
-/// Per-conversation stack the standalone tests build.
-type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage>;
+/// Per-conversation stack the standalone tests build, on virtual time.
+type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, MockClock>;
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -42,6 +42,8 @@ struct Integrator {
     consensus: DefaultConsensusPlugin,
     member_id: WalletMemberId,
     provider: TestProvider,
+    /// The virtual clock this integrator drives; conversations own clones.
+    clock: MockClock,
 }
 
 impl Integrator {
@@ -59,6 +61,7 @@ impl Integrator {
             consensus: DefaultConsensusPlugin::new(EthereumConsensusSigner::new(eth_signer)),
             member_id,
             provider: TestProvider::default(),
+            clock: MockClock::new(),
         }
     }
 
@@ -91,6 +94,7 @@ fn create_builds_a_working_steward_session_without_user() {
         &integrator.signer,
         &integrator.consensus,
         integrator.scoring(),
+        integrator.clock.clone(),
         integrator.app_id(),
         de_mls::ConversationConfig::default(),
     )
@@ -143,6 +147,7 @@ fn join_completes_in_one_call() {
         &alice.signer,
         &alice.consensus,
         alice.scoring(),
+        alice.clock.clone(),
         alice.app_id(),
         fast_config(),
     )
@@ -163,7 +168,7 @@ fn join_completes_in_one_call() {
     // Drive the creator until the welcome is minted.
     let mut welcome = None;
     for _ in 0..40 {
-        std::thread::sleep(Duration::from_millis(30));
+        alice.clock.advance(Duration::from_millis(30));
         creator.poll(&alice.provider, &alice.signer);
         for event in creator.drain_events() {
             if let ConversationEvent::WelcomeReady {
@@ -191,6 +196,7 @@ fn join_completes_in_one_call() {
         &welcome.conversation_sync_bytes,
         &bystander.consensus,
         bystander.scoring(),
+        bystander.clock.clone(),
         bystander.app_id(),
         fast_config(),
     )
@@ -211,6 +217,7 @@ fn join_completes_in_one_call() {
         &welcome.conversation_sync_bytes,
         &bob.consensus,
         bob.scoring(),
+        bob.clock.clone(),
         bob.app_id(),
         fast_config(),
     )

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -168,7 +168,10 @@ fn join_completes_in_one_call() {
     // Drive the creator until the welcome is minted.
     let mut welcome = None;
     for _ in 0..40 {
+        // Advance both integrators' clocks in lockstep so bob's later join
+        // starts from the same virtual time alice's proposal was stamped at.
         alice.clock.advance(Duration::from_millis(30));
+        bob.clock.advance(Duration::from_millis(30));
         creator.poll(&alice.provider, &alice.signer);
         for event in creator.drain_events() {
             if let ConversationEvent::WelcomeReady {


### PR DESCRIPTION
Connected to #129.

Every deadline the library tracks — commit/recovery inactivity, the freeze window, consensus timeouts, auto-votes — and every consensus wire timestamp now derives from a `WallClock` the integrator supplies at construction, carried as a third generic on `Conversation<C, Sc, T: WallClock>`. The library ships only the contract: the `WallClock` trait, a fabricable `Timestamp` (duration since Unix epoch; `as_secs()` is the consensus wire format), and a nanosecond-precise `MockClock` for tests. The production clock is the integrator's, like identity and transport.

`PhaseTimer` is now pure (queries take `now` as a parameter), all `Timing` anchors moved from `Instant` to `Timestamp`, and `hashgraph-like-consensus` is bumped to 0.6, whose API takes `now: u64` per call. `ConversationError::SystemTime` is gone — no fallible clock read exists.

Inbound proposals are validated by consensus before any queue mirroring, so a proposal with a crafted or expired timestamp leaves no local trace (previously an expired emergency proposal could permanently wedge partial-freeze). Expired arrivals surface as a warning plus `ConversationEvent::Error`, making clock skew observable to the integrator.

The integration harness runs on per-member `MockClock`s advanced in lockstep — no real sleeps remain, the suite executes in ~2s, and a new skew test deterministically reproduces the late-arriving-proposal failure that motivated the issue. Validated end-to-end against a downstream integrator on virtual time.
