### PR TITLE
Expose Mls Extensions

### DIFF
--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -1,8 +1,8 @@
 //! Read-only queries over a conversation's state.
 
 use crate::{
-    ConsensusPlugin, Conversation, ConversationError, ConversationState, MemberRole,
-    PeerScoreStorage, protos::de_mls::messages::v1::ConversationUpdateRequest,
+    ConsensusPlugin, Conversation, ConversationError, ConversationState, Extensions, GroupContext,
+    MemberRole, PeerScoreStorage, protos::de_mls::messages::v1::ConversationUpdateRequest,
 };
 
 impl<C, Sc> Conversation<C, Sc>
@@ -149,5 +149,9 @@ where
 
     pub fn approved_proposals_for_current_epoch(&self) -> Vec<ConversationUpdateRequest> {
         self.queues.approved_proposals().values().cloned().collect()
+    }
+
+    pub fn extensions(&self) -> &Extensions<GroupContext> {
+        self.mls().extensions()
     }
 }

--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationState, Extensions, GroupContext,
-    MemberRole, PeerScoreStorage,WallClock, protos::de_mls::messages::v1::ConversationUpdateRequest,
+    MemberRole, PeerScoreStorage, WallClock,
+    protos::de_mls::messages::v1::ConversationUpdateRequest,
 };
 
 impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ pub(crate) use phase_timer::PhaseTimer;
 /// MLS cryptographic operations: OpenMLS wrapper for encryption/decryption.
 pub mod mls_crypto;
 
+pub use openmls::prelude::{Extensions, GroupContext};
+
 /// Reference implementations of the library's plug-in traits — in-memory
 /// MLS / peer-score storage, default consensus + per-conversation
 /// plug-in bundles, and a reference key-package provider. Production

--- a/src/mls_crypto/service.rs
+++ b/src/mls_crypto/service.rs
@@ -28,6 +28,7 @@ use prost::Message;
 use tracing::warn;
 
 use crate::{
+    Extensions, GroupContext,
     mls_crypto::{
         CommitArtifacts, DecryptedMessage, MlsCommitInput, MlsError, MlsMessageKind,
         MlsProposalOutput, StagedCandidateResult,
@@ -166,6 +167,11 @@ impl MlsService {
     /// Current MLS epoch — the single source of truth; keep no parallel counter.
     pub fn current_epoch(&self) -> Result<u64, MlsError> {
         Ok(self.group.epoch().as_u64())
+    }
+
+    // Extensions configured for the MlsGroup
+    pub fn extensions(&self) -> &Extensions<GroupContext> {
+        self.group.extensions()
     }
 
     // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
This PR exposes the MLS GroupContext of a conversation so information can be passed to clients.

## Notes

- This PR does not wrap the mls objects and exposes Extensions and GroupContext directly. Happy to change if desired.
- 

