### PR TITLE
fix(steward): recover when the sole steward goes offline

### DIFF
--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -84,6 +84,7 @@ where
             proposal_id, approved, "consensus reached"
         );
         self.queues.mark_consensus_outcome_applied(proposal_id);
+        self.queues.clear_observed_election(proposal_id);
         let consensus_apply =
             apply_consensus_result(&mut self.queues, proposal_id, approved, &request)?;
 
@@ -100,7 +101,7 @@ where
                 self.handle_election_accepted(provider, election, signer)?;
             }
             ConsensusApplyResult::ElectionRejected => {
-                self.handle_election_rejected(provider, signer)?;
+                self.advance_election_retry(provider, signer)?;
             }
             ConsensusApplyResult::RecoveryModeOpened => {
                 // Open the collection window and notify the integrator; who mints
@@ -227,48 +228,6 @@ where
         );
 
         self.process_buffered_updates(provider, signer)
-    }
-
-    /// Bump the retry round and re-run the election, or escalate to a
-    /// `Deadlock` emergency proposal once retries are exhausted.
-    fn handle_election_rejected<Pr>(
-        &mut self,
-        provider: &Pr,
-        signer: &impl Signer,
-    ) -> Result<(), ConversationError>
-    where
-        Pr: OpenMlsProvider,
-        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
-    {
-        self.services.steward_list.bump_retry();
-        let round = self.services.steward_list.next_election_round();
-        let max = self.services.steward_list.max_retries();
-        if round > max {
-            info!(
-                conversation = %self.conversation_id,
-                round, max, "election retries exhausted; escalating to Layer 3"
-            );
-            // Only the deterministic proposer auto-files, so simultaneous
-            // exhaustion across members doesn't produce one ECP each.
-            if self.is_deadlock_proposer()?
-                && let Err(e) = self.request_recovery(provider, signer)
-            {
-                error!(conversation = %self.conversation_id, error = %e, "Deadlock ECP filing failed");
-                self.emit_event(ConversationEvent::Error {
-                    operation: "Reelection stuck".to_string(),
-                    message: e.to_string(),
-                });
-            }
-            return Ok(());
-        }
-        info!(
-            conversation = %self.conversation_id,
-            round, max, "steward election rejected, retrying"
-        );
-        if let Err(e) = self.initiate_steward_election(provider, true, signer) {
-            info!(conversation = %self.conversation_id, error = %e, "election retry deferred");
-        }
-        Ok(())
     }
 
     /// Emergency proposal resolved: apply the score ops, clear the

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -210,10 +210,14 @@ where
             election.proposed_stewards.len(),
             election.retry_round,
         )?;
-        // `retry_round` stays > 0 until the next successful commit, so the
-        // post-election inactivity check keeps the short recovery window.
         self.exit_recovery_mode();
         let resumed_from_reelection = if self.current_state() == ConversationState::Reelection {
+            // The approved work this conversation froze over is a recovery
+            // continuation: keep the short recovery window until its commit
+            // merges. `retry_round > 0` covers only bumped rounds — a
+            // round-0 recovery election would otherwise wait out a fresh
+            // full commit-inactivity epoch.
+            self.timing.reelection_recovered = true;
             Some(self.start_working())
         } else {
             None

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -299,9 +299,13 @@ where
     /// Feed a peer's vote into the local consensus session.
     ///
     /// Late arrivals are swallowed (logged, `Ok`) so inbound dispatch keeps
-    /// draining.
-    pub(crate) fn forward_incoming_vote(&self, vote: Vote) -> Result<(), ConversationError> {
+    /// draining. A vote that passes signature validation is authenticated
+    /// liveness proof for its owner, so it lifts any local unresponsive-
+    /// steward accusation — a member that comes back mid-recovery regains
+    /// proposer authority and steward candidacy.
+    pub(crate) fn forward_incoming_vote(&mut self, vote: Vote) -> Result<(), ConversationError> {
         let proposal_id = vote.proposal_id;
+        let vote_owner = vote.vote_owner.clone();
         let outcome_applied_locally = self.queues.is_consensus_outcome_applied(proposal_id);
         let scope = self.conversation_id.clone();
         let now = self.clock.now().as_secs();
@@ -310,8 +314,14 @@ where
             .consensus
             .process_incoming_vote(&scope, vote, now)
         {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.queues.clear_unresponsive_steward(&vote_owner);
+                Ok(())
+            }
             Err(ConsensusError::SessionNotActive) => {
+                // Signature validation ran before the session-state check, so
+                // even a late vote proves its owner is back.
+                self.queues.clear_unresponsive_steward(&vote_owner);
                 tracing::debug!(
                     conversation = %self.conversation_id,
                     proposal_id,
@@ -342,9 +352,15 @@ where
     // ── Private ──────────────────────────────────────────────────────
 
     /// Gate a new proposal on the current state and return the expected
-    /// voter count (the full member set). During `Reelection` only
-    /// emergency and election proposals pass; an active emergency
-    /// partial-freezes everything below its priority.
+    /// voter count: the member set minus locally-observed unresponsive
+    /// stewards. Counting an accused-silent member as an expected voter
+    /// would make the recovery ladder's own consensus rounds unresolvable
+    /// in small groups (with two expected voters the consensus library
+    /// requires both real votes, so one offline member vetoes by silence).
+    /// The stamped count travels with the proposal, so every peer's session
+    /// runs the same math. During `Reelection` only emergency and election
+    /// proposals pass; an active emergency partial-freezes everything below
+    /// its priority.
     fn check_proposal_allowed(&self, kind: ProposalKind) -> Result<u32, ConversationError> {
         let state = self.current_state();
 
@@ -368,7 +384,11 @@ where
         }
 
         let members = self.mls().members()?;
-        Ok(members.len() as u32)
+        let expected = members
+            .iter()
+            .filter(|m| !self.queues.is_unresponsive_steward(m))
+            .count();
+        Ok(expected as u32)
     }
 
     /// Push a proposal whose deadline elapsed into the consensus library's

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -113,6 +113,11 @@ pub(crate) struct Timing {
     /// `drive_reelection_retry`). Cleared outside `Reelection`, while an
     /// election is being voted on, and each time the ladder advances.
     pub(crate) reelection_silence_anchor: Option<Timestamp>,
+    /// A steward election landed while this conversation was parked in
+    /// `Reelection`: the pending approved work is a recovery continuation,
+    /// so the inactivity check keeps the short recovery window instead of a
+    /// fresh full commit-inactivity wait. Cleared when a commit merges.
+    pub(crate) reelection_recovered: bool,
 }
 
 impl Timing {
@@ -127,6 +132,7 @@ impl Timing {
             buffered_propose_anchor: None,
             sync_resend_anchor: None,
             reelection_silence_anchor: None,
+            reelection_recovered: false,
         }
     }
 }

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -107,6 +107,12 @@ pub(crate) struct Timing {
     /// stayed silent. Cleared when a `ConversationSync` is observed or the
     /// takeover no longer applies.
     pub(crate) sync_resend_anchor: Option<Timestamp>,
+    /// Anchor for the reelection-silence watchdog: set when a poll tick finds
+    /// the conversation parked in `Reelection` with no election in flight. A
+    /// full silent window past it counts as a rejected election round (see
+    /// `drive_reelection_retry`). Cleared outside `Reelection`, while an
+    /// election is being voted on, and each time the ladder advances.
+    pub(crate) reelection_silence_anchor: Option<Timestamp>,
 }
 
 impl Timing {
@@ -120,6 +126,7 @@ impl Timing {
             last_commit_round_progress: None,
             buffered_propose_anchor: None,
             sync_resend_anchor: None,
+            reelection_silence_anchor: None,
         }
     }
 }

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -382,6 +382,13 @@ where
             let delay = self.config.voting_delay_for(kind);
             let vote = self.config.liveness_criteria_yes;
             self.register_auto_vote(proposal_id, delay, vote);
+            // The consensus library resolves a quorum short of real votes
+            // only through `handle_consensus_timeout` (silent peers weighted
+            // by the liveness criteria), and it expects the application to
+            // arm that deadline for every session — not just its own
+            // proposals. Without this, a session whose quorum needs
+            // silent-peer weighting resolves on the proposer alone.
+            self.register_consensus_timeout(proposal_id, self.config.consensus_timeout);
         }
         Ok(())
     }

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -442,9 +442,10 @@ where
         // The commit merged, so advance to Working FIRST: the bookkeeping below
         // is best-effort and must not be able to strand the state machine in
         // Selection. reset_retry too — this commit ended any retry cycle, and
-        // the unresponsive-steward accusations with it.
+        // the unresponsive-steward accusations and recovery window with it.
         self.services.steward_list.reset_retry();
         self.queues.clear_unresponsive_stewards();
+        self.timing.reelection_recovered = false;
         let state = self.current_state();
         if matches!(
             state,

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -363,6 +363,9 @@ where
                     self.queues
                         .insert_pending_update(req.clone(), current_epoch);
                 }
+                Some(conversation_update_request::Payload::StewardElection(_)) => {
+                    self.queues.note_observed_election(proposal_id);
+                }
                 _ => {}
             }
         }

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -438,8 +438,10 @@ where
     {
         // The commit merged, so advance to Working FIRST: the bookkeeping below
         // is best-effort and must not be able to strand the state machine in
-        // Selection. reset_retry too — this commit ended any retry cycle.
+        // Selection. reset_retry too — this commit ended any retry cycle, and
+        // the unresponsive-steward accusations with it.
         self.services.steward_list.reset_retry();
+        self.queues.clear_unresponsive_stewards();
         let state = self.current_state();
         if matches!(
             state,

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -306,6 +306,10 @@ where
                     };
                     let accused = accuse_target.is_some();
                     if let Some(steward_id) = accuse_target {
+                        // Also strip the accused of recovery proposer
+                        // authority — an offline steward must not stay the
+                        // only member authorized to elect its replacement.
+                        self.queues.note_unresponsive_steward(steward_id.clone());
                         self.services.scoring.apply_op(&ScoreOp {
                             member_id: steward_id,
                             event: ScoreEvent::CensorshipInactivity,

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -565,9 +565,12 @@ where
             return Ok(());
         }
         // Recovery uses the shorter retry inactivity window so we don't
-        // burn another full epoch waiting for a steward to commit.
-        let in_recovery =
-            self.is_in_recovery_mode() || self.services.steward_list.next_election_round() > 0;
+        // burn another full epoch waiting for a steward to commit. That
+        // covers open recovery mode, a bumped retry round, and the stretch
+        // between a recovery election landing and its commit merging.
+        let in_recovery = self.is_in_recovery_mode()
+            || self.services.steward_list.next_election_round() > 0
+            || self.timing.reelection_recovered;
         let inactivity = if in_recovery {
             self.config.recovery_inactivity_duration
         } else if self.is_epoch_steward()? {

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -94,6 +94,14 @@ where
             );
         }
 
+        if let Err(e) = self.drive_reelection_retry(provider, signer) {
+            warn!(
+                conversation = %self.conversation_id,
+                error = %e,
+                "reelection-retry drive error in poll"
+            );
+        }
+
         PollOutcome {
             next_wakeup_in: self.next_wakeup_in(),
             leave_requested,
@@ -584,5 +592,46 @@ where
         );
         self.on_freeze_entered(provider, signer, event)?;
         Ok(())
+    }
+
+    /// Reelection-silence watchdog: while parked in `Reelection` with no
+    /// election in flight, a full silent window counts as a rejected round —
+    /// [`Conversation::advance_election_retry`] bumps the retry ladder, which
+    /// hands proposer authority to the next candidate and, once retries are
+    /// exhausted, escalates to the `Deadlock` emergency proposal. Without
+    /// this, a responsible proposer that never submits (e.g. an offline sole
+    /// steward) would park the conversation in `Reelection` forever.
+    fn drive_reelection_retry<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        if self.current_state() != ConversationState::Reelection
+            || self.queues.has_election_in_flight()
+        {
+            self.timing.reelection_silence_anchor = None;
+            return Ok(());
+        }
+        let now = self.clock.timestamp();
+        let anchor = match self.timing.reelection_silence_anchor {
+            Some(a) => a,
+            None => {
+                self.timing.reelection_silence_anchor = Some(now);
+                return Ok(());
+            }
+        };
+        if now < anchor + self.config.voting_inactivity_window() {
+            return Ok(());
+        }
+        self.timing.reelection_silence_anchor = None;
+        info!(
+            conversation = %self.conversation_id,
+            "no election proposal observed within the reelection window: counting a rejected round"
+        );
+        self.advance_election_retry(provider, signer)
     }
 }

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -114,6 +114,15 @@ pub struct ConversationQueues {
     /// Hashes of recently-seen welcome broadcasts, so gossip duplicates
     /// emit a single `WelcomeReady` event.
     welcome_broadcast_hashes: BoundedSet<CommitHash>,
+    /// Stewards this node observed letting the commit-inactivity window lapse
+    /// (the freeze-timeout accusation). Recovery elections and the `Deadlock`
+    /// escalation skip them when resolving proposer authority, so an offline
+    /// steward can't stay the only member authorized to recover from its own
+    /// silence. A member is cleared individually as soon as authenticated
+    /// activity from it is observed (a signature-validated vote) — a comeback
+    /// restores its authority and candidacy mid-recovery — and the whole set
+    /// clears when a commit merges.
+    unresponsive_stewards: HashSet<Vec<u8>>,
 }
 
 impl ConversationQueues {
@@ -132,6 +141,7 @@ impl ConversationQueues {
             early_candidates: Vec::new(),
             member_join_epoch: HashMap::new(),
             welcome_broadcast_hashes: BoundedSet::new(dedup_window),
+            unresponsive_stewards: HashSet::new(),
         }
     }
 
@@ -310,6 +320,32 @@ impl ConversationQueues {
         self.voting_proposals
             .values()
             .any(|req| ProposalKind::of(req).is_steward_election())
+    }
+
+    // ─────────────────────────── Unresponsive stewards ───────────────────────────
+
+    /// Record a locally-observed unresponsive steward (the freeze-timeout
+    /// accusation target).
+    pub fn note_unresponsive_steward(&mut self, member_id: Vec<u8>) {
+        self.unresponsive_stewards.insert(member_id);
+    }
+
+    /// Whether this node observed `member_id` letting the commit-inactivity
+    /// window lapse since the last merged commit.
+    pub fn is_unresponsive_steward(&self, member_id: &[u8]) -> bool {
+        self.unresponsive_stewards.contains(member_id)
+    }
+
+    /// Authenticated activity observed from `member_id` — it is back, so the
+    /// accusation no longer holds and its authority/candidacy return.
+    pub fn clear_unresponsive_steward(&mut self, member_id: &[u8]) {
+        self.unresponsive_stewards.remove(member_id);
+    }
+
+    /// A commit merged — the accusations served their purpose; a steward that
+    /// is still silent gets re-accused by the next freeze timeout.
+    pub fn clear_unresponsive_stewards(&mut self) {
+        self.unresponsive_stewards.clear();
     }
 
     // ─────────────────────────── Emergency (RFC §Partial Freeze) ───────────────────────────
@@ -578,6 +614,23 @@ mod tests {
     fn insert_self_leave(conversation: &mut ConversationQueues, member_id: &[u8]) {
         let remove = ConversationUpdateRequest::remove_member(member_id.to_vec());
         conversation.insert_approved_proposal(self_leave_proposal_id(member_id), remove);
+    }
+
+    #[test]
+    fn unresponsive_accusation_lifts_on_comeback_and_on_commit() {
+        let mut conversation = ConversationQueues::new("test-conversation", 10);
+        conversation.note_unresponsive_steward(member(1));
+        conversation.note_unresponsive_steward(member(2));
+        assert!(conversation.is_unresponsive_steward(&member(1)));
+
+        // Authenticated activity from member 1 — its accusation alone lifts.
+        conversation.clear_unresponsive_steward(&member(1));
+        assert!(!conversation.is_unresponsive_steward(&member(1)));
+        assert!(conversation.is_unresponsive_steward(&member(2)));
+
+        // A merged commit clears the rest.
+        conversation.clear_unresponsive_stewards();
+        assert!(!conversation.is_unresponsive_steward(&member(2)));
     }
 
     #[test]

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -123,6 +123,11 @@ pub struct ConversationQueues {
     /// restores its authority and candidacy mid-recovery — and the whole set
     /// clears when a commit merges.
     unresponsive_stewards: HashSet<Vec<u8>>,
+    /// Steward-election proposals observed from peers and not yet resolved by
+    /// consensus. Folded into [`Self::has_election_in_flight`] so a member
+    /// waiting out a peer's election doesn't count the wait as reelection
+    /// silence and claim proposer authority over a vote already running.
+    observed_election_ids: HashSet<ProposalId>,
 }
 
 impl ConversationQueues {
@@ -142,6 +147,7 @@ impl ConversationQueues {
             member_join_epoch: HashMap::new(),
             welcome_broadcast_hashes: BoundedSet::new(dedup_window),
             unresponsive_stewards: HashSet::new(),
+            observed_election_ids: HashSet::new(),
         }
     }
 
@@ -314,12 +320,26 @@ impl ConversationQueues {
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election
-    /// while the previous one is still being voted on. Reads the local
-    /// voting queue — proposal-queue concern, not steward-list state.
+    /// while a previous one — own or a peer's — is still being voted on.
+    /// Reads the local voting queue and the observed-election set — a
+    /// proposal-queue concern, not steward-list state.
     pub fn has_election_in_flight(&self) -> bool {
-        self.voting_proposals
-            .values()
-            .any(|req| ProposalKind::of(req).is_steward_election())
+        !self.observed_election_ids.is_empty()
+            || self
+                .voting_proposals
+                .values()
+                .any(|req| ProposalKind::of(req).is_steward_election())
+    }
+
+    /// Record a peer's steward-election proposal as in flight.
+    pub fn note_observed_election(&mut self, proposal_id: ProposalId) {
+        self.observed_election_ids.insert(proposal_id);
+    }
+
+    /// A consensus outcome landed for `proposal_id` — the election (if it was
+    /// one) is no longer in flight. No-op for other proposal kinds.
+    pub fn clear_observed_election(&mut self, proposal_id: ProposalId) {
+        self.observed_election_ids.remove(&proposal_id);
     }
 
     // ─────────────────────────── Unresponsive stewards ───────────────────────────

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -495,13 +495,18 @@ where
             }
 
             // Build the candidate pool: settled MLS members minus queued
-            // removals (recovery only — non-recovery elections trust the
-            // current MLS roster). Unsettled (just-joined) members are excluded
-            // — they may not have attached MLS and can't serve as stewards yet.
+            // removals and locally-observed unresponsive stewards (recovery
+            // only — non-recovery elections trust the current MLS roster).
+            // Unsettled (just-joined) members are excluded — they may not
+            // have attached MLS and can't serve as stewards yet.
             let candidate_pool: Vec<Vec<u8>> = mls_members
                 .iter()
                 .filter(|m| self.queues.is_settled(m, epoch))
-                .filter(|m| !(recovery && self.queues.has_approved_removal(m)))
+                .filter(|m| {
+                    !(recovery
+                        && (self.queues.has_approved_removal(m)
+                            || self.queues.is_unresponsive_steward(m)))
+                })
                 .cloned()
                 .collect();
             let pool_set: std::collections::HashSet<&[u8]> =
@@ -516,11 +521,29 @@ where
                 recovery,
             )? {
                 ElectionDecision::Skip(skip) => {
-                    if skip == ElectionSkip::NoEligibleCandidates {
-                        info!(
-                            conversation = %self.conversation_id,
-                            "skipping election: {skip}"
-                        );
+                    match skip {
+                        // Routine outcome of every epoch-advance housekeeping
+                        // call — not worth a log line.
+                        ElectionSkip::NotExhausted => {}
+                        ElectionSkip::NotResponsibleProposer => {
+                            let proposer = self.services.steward_list.responsible_proposer(
+                                self.services.steward_list.next_election_round(),
+                                &candidate_pool,
+                                eligible,
+                            );
+                            info!(
+                                conversation = %self.conversation_id,
+                                proposer = ?proposer,
+                                retry_round = self.services.steward_list.next_election_round(),
+                                "skipping election: {skip}"
+                            );
+                        }
+                        ElectionSkip::NoEligibleCandidates => {
+                            info!(
+                                conversation = %self.conversation_id,
+                                "skipping election: {skip}"
+                            );
+                        }
                     }
                     return Ok(());
                 }
@@ -591,9 +614,11 @@ where
     }
 
     /// Whether this member is the deterministic proposer that should auto-file
-    /// the `Deadlock` ECP when re-election exhausts — the election proposer,
-    /// restricted to a candidate that is MLS-present and not queued for removal.
-    /// Gates the automatic escalation so it doesn't file one ECP per member.
+    /// the `Deadlock` ECP when re-election exhausts — the responsible proposer
+    /// for the current retry round, restricted to candidates that are
+    /// MLS-present, not queued for removal, and not locally observed as
+    /// unresponsive. Gates the automatic escalation so it doesn't file one ECP
+    /// per member.
     pub(crate) fn is_deadlock_proposer(&self) -> Result<bool, ConversationError> {
         let mls = self.mls();
         let mls_members = mls.members()?;
@@ -604,9 +629,15 @@ where
         Ok(self
             .services
             .steward_list
-            .election_proposer(|c: &[u8]| {
-                mls_set.contains(c) && !conversation_ref.has_approved_removal(c)
-            })
+            .responsible_proposer(
+                self.services.steward_list.next_election_round(),
+                &mls_members,
+                |c: &[u8]| {
+                    mls_set.contains(c)
+                        && !conversation_ref.has_approved_removal(c)
+                        && !conversation_ref.is_unresponsive_steward(c)
+                },
+            )
             .is_some_and(|proposer| proposer == self_id))
     }
 }

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -10,8 +10,8 @@ use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
 use tracing::{error, info};
 
 use crate::{
-    ConsensusPlugin, Conversation, ConversationError, ConversationState, CreatorVote,
-    ElectionDecision, ElectionSkip, PeerScoreStorage, WallClock, member_set,
+    ConsensusPlugin, Conversation, ConversationError, ConversationEvent, ConversationState,
+    CreatorVote, ElectionDecision, ElectionSkip, PeerScoreStorage, WallClock, member_set,
     protos::de_mls::messages::v1::{
         AppMessage, ConversationSync, ConversationUpdateRequest, PeerScore,
         StewardElectionProposal, TimingConfig, ViolationEvidence, conversation_update_request,
@@ -639,5 +639,51 @@ where
                 },
             )
             .is_some_and(|proposer| proposer == self_id))
+    }
+
+    /// Advance the election retry ladder after a failed round — an election
+    /// rejected by vote, or a reelection window that passed with no election
+    /// proposal observed at all. Bumps the retry round (which hands proposer
+    /// authority to the next candidate) and re-runs the election; once
+    /// retries are exhausted, the deterministic deadlock proposer escalates
+    /// to the `Deadlock` emergency proposal instead.
+    pub(crate) fn advance_election_retry<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        self.services.steward_list.bump_retry();
+        let round = self.services.steward_list.next_election_round();
+        let max = self.services.steward_list.max_retries();
+        if round > max {
+            info!(
+                conversation = %self.conversation_id,
+                round, max, "election retries exhausted; escalating to Layer 3"
+            );
+            // Only the deterministic proposer auto-files, so simultaneous
+            // exhaustion across members doesn't produce one ECP each.
+            if self.is_deadlock_proposer()?
+                && let Err(e) = self.request_recovery(provider, signer)
+            {
+                error!(conversation = %self.conversation_id, error = %e, "Deadlock ECP filing failed");
+                self.emit_event(ConversationEvent::Error {
+                    operation: "Reelection stuck".to_string(),
+                    message: e.to_string(),
+                });
+            }
+            return Ok(());
+        }
+        info!(
+            conversation = %self.conversation_id,
+            round, max, "election round failed, retrying"
+        );
+        if let Err(e) = self.initiate_steward_election(provider, true, signer) {
+            info!(conversation = %self.conversation_id, error = %e, "election retry deferred");
+        }
+        Ok(())
     }
 }

--- a/src/steward_list/service.rs
+++ b/src/steward_list/service.rs
@@ -200,6 +200,39 @@ impl StewardListService {
             .and_then(|l| l.epoch_steward(l.election_epoch(), eligible))
     }
 
+    /// The member authorized to act for election retry round `round`: entry
+    /// `round % len` of the authority sequence — the installed list's eligible
+    /// members in rotation order, followed by the remaining eligible
+    /// candidates in ascending id order. Round 0 is the classic
+    /// [`Self::election_proposer`]; every failed round (rejected by vote or
+    /// silent past the reelection window) hands authority to the next entry,
+    /// so an unresponsive proposer can't strand the election or the
+    /// `Deadlock` escalation. `None` when nobody is eligible.
+    pub fn responsible_proposer<'a, F: Fn(&[u8]) -> bool>(
+        &'a self,
+        round: u32,
+        candidate_pool: &'a [Vec<u8>],
+        eligible: F,
+    ) -> Option<&'a [u8]> {
+        let list_members = self.list.as_ref().map(|l| l.members()).unwrap_or(&[]);
+        let mut sequence: Vec<&[u8]> = list_members
+            .iter()
+            .map(Vec::as_slice)
+            .filter(|c| eligible(c))
+            .collect();
+        let mut pool_rest: Vec<&[u8]> = candidate_pool
+            .iter()
+            .map(Vec::as_slice)
+            .filter(|c| eligible(c) && !sequence.contains(c))
+            .collect();
+        pool_rest.sort_unstable();
+        sequence.append(&mut pool_rest);
+        if sequence.is_empty() {
+            return None;
+        }
+        Some(sequence[round as usize % sequence.len()])
+    }
+
     /// Build and install a list of size `sn`. `retry_round` seeds the SHA256 sort
     /// and is stored on the list; use `0` for bootstrap and deterministic regen.
     pub fn install_list(
@@ -254,17 +287,17 @@ impl StewardListService {
         if !recovery && !self.is_exhausted(epoch) {
             return Ok(ElectionDecision::Skip(ElectionSkip::NotExhausted));
         }
+        if candidate_pool.is_empty() {
+            return Ok(ElectionDecision::Skip(ElectionSkip::NoEligibleCandidates));
+        }
+        let retry_round = self.next_election_round();
         let is_authorized = self
-            .election_proposer(&eligible)
+            .responsible_proposer(retry_round, candidate_pool, &eligible)
             .is_some_and(|proposer| proposer == self_member_id);
         if !is_authorized {
             return Ok(ElectionDecision::Skip(ElectionSkip::NotResponsibleProposer));
         }
-        if candidate_pool.is_empty() {
-            return Ok(ElectionDecision::Skip(ElectionSkip::NoEligibleCandidates));
-        }
 
-        let retry_round = self.next_election_round();
         let sn = self.config.compute_list_size(candidate_pool.len());
         let list = StewardList::generate(
             epoch,
@@ -471,6 +504,60 @@ mod tests {
             .election_proposer(|c: &[u8]| c != proposer.as_slice())
             .unwrap();
         assert_ne!(next, proposer.as_slice());
+    }
+
+    #[test]
+    fn responsible_proposer_round_zero_matches_election_proposer() {
+        let mut p = StewardListService::empty(StewardListConfig::new(3, 3).unwrap());
+        let mems = members(&[1, 2, 3]);
+        p.install_list(0, &mems, 3, 0).unwrap();
+
+        assert_eq!(
+            p.responsible_proposer(0, &mems, |_: &[u8]| true),
+            p.election_proposer(|_: &[u8]| true),
+        );
+    }
+
+    #[test]
+    fn responsible_proposer_falls_back_past_ineligible_list() {
+        // The whole installed list is ineligible (e.g. its sole steward is
+        // unresponsive): authority falls back to the lowest eligible pool id.
+        let mut p = StewardListService::empty(StewardListConfig::new(1, 1).unwrap());
+        let listed = members(&[9]);
+        p.install_list(0, &listed, 1, 0).unwrap();
+
+        let pool = members(&[3, 2, 9]);
+        let proposer = p
+            .responsible_proposer(0, &pool, |c: &[u8]| c != member(9).as_slice())
+            .unwrap();
+        assert_eq!(proposer, member(2).as_slice());
+    }
+
+    #[test]
+    fn responsible_proposer_rotates_by_round() {
+        // Authority sequence: eligible list members in list order, then the
+        // remaining eligible pool ids ascending; the round indexes it (mod
+        // len), so every failed round hands authority to the next candidate.
+        let mut p = StewardListService::empty(StewardListConfig::new(1, 1).unwrap());
+        let listed = members(&[9]);
+        p.install_list(0, &listed, 1, 0).unwrap();
+
+        let pool = members(&[3, 2, 9]);
+        let all = |_: &[u8]| true;
+        assert_eq!(p.responsible_proposer(0, &pool, all).unwrap(), member(9));
+        assert_eq!(p.responsible_proposer(1, &pool, all).unwrap(), member(2));
+        assert_eq!(p.responsible_proposer(2, &pool, all).unwrap(), member(3));
+        assert_eq!(p.responsible_proposer(3, &pool, all).unwrap(), member(9));
+    }
+
+    #[test]
+    fn responsible_proposer_none_when_no_one_eligible() {
+        let mut p = StewardListService::empty(StewardListConfig::new(1, 1).unwrap());
+        let listed = members(&[9]);
+        p.install_list(0, &listed, 1, 0).unwrap();
+
+        let pool = members(&[2]);
+        assert_eq!(p.responsible_proposer(0, &pool, |_: &[u8]| false), None);
     }
 
     #[test]

--- a/tests/protocol_recovery.rs
+++ b/tests/protocol_recovery.rs
@@ -144,8 +144,15 @@ fn sole_steward_offline_recovers_and_commits_approved_add() {
     // remaining member must claim election-proposer authority — the accused
     // steward loses it, and authority falls through to the lowest eligible
     // candidate — install a fresh list, commit the Add, and welcome the joiner.
+    //
+    // The long commit-inactivity against process_until's 30 s virtual budget
+    // also pins the post-election window: the freeze wait before reelection
+    // already costs ~20 s, so the recovered steward must commit within the
+    // short recovery window — waiting out a second full commit-inactivity
+    // epoch would blow the budget.
     let cfg = ConversationConfig {
-        recovery_inactivity_duration: Duration::from_millis(50),
+        commit_inactivity_duration: Duration::from_secs(20),
+        recovery_inactivity_duration: Duration::from_millis(100),
         ..fast_config()
     };
     let mut h = TestHarness::<3>::start(

--- a/tests/protocol_recovery.rs
+++ b/tests/protocol_recovery.rs
@@ -12,6 +12,7 @@ use de_mls::{ConversationConfig, ConversationEvent, ConversationState, StewardLi
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+const DAVE: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
 #[test]
 fn recovery_auto_mint_converges_on_one_commit() {
@@ -133,5 +134,117 @@ fn manual_only_recovery_does_not_auto_commit() {
     assert!(
         h.member(online[0]).convo().is_in_recovery_mode(),
         "recovery stays open, waiting for a manual commit"
+    );
+}
+
+#[test]
+fn sole_steward_offline_recovers_and_commits_approved_add() {
+    // The filed deadlock: a 2-member group whose installed steward list holds
+    // only the (offline) creator, with an approved Add stuck behind it. The
+    // remaining member must claim election-proposer authority — the accused
+    // steward loses it, and authority falls through to the lowest eligible
+    // candidate — install a fresh list, commit the Add, and welcome the joiner.
+    let cfg = ConversationConfig {
+        recovery_inactivity_duration: Duration::from_millis(50),
+        ..fast_config()
+    };
+    let mut h = TestHarness::<3>::start(
+        [ALICE, BOB, CHARLIE],
+        "sole",
+        cfg,
+        StewardListConfig::new(1, 1).unwrap(),
+    );
+    let conversation_id = h.conversation_id().to_string();
+
+    // Bob joins; Charlie only announces later, so the group is Alice + Bob
+    // with Alice the sole steward.
+    let bob_announcement = h.member_mut(1).announce_key_package(&conversation_id);
+    h.deliver_key_package_all(&bob_announcement);
+    h.process_until("bob joins", |h| h.member(1).is_working());
+
+    // Charlie's announced join reaches consensus on Bob...
+    let charlie_announcement = h.member_mut(2).announce_key_package(&conversation_id);
+    h.deliver_key_package_all(&charlie_announcement);
+    h.process_until("charlie's add is approved on bob", |h| {
+        h.member(1).approved_count() == 1
+    });
+
+    // ...and Alice goes dark before committing it.
+    h.mute(0);
+
+    // Bob must not park in Reelection: the freeze timeout accuses Alice,
+    // authority falls through to Bob, a fresh list installs, and Bob commits
+    // the stuck Add — Charlie receives its welcome.
+    h.process_until("bob recovers and charlie joins", |h| {
+        h.member(1).member_count() == 3 && h.member(2).is_working()
+    });
+
+    assert!(
+        h.member(1).saw_phase(ConversationState::Reelection),
+        "bob went through the reelection stall path"
+    );
+    assert_eq!(
+        h.member(1).epoch(),
+        h.member(2).epoch(),
+        "bob and charlie agree on the epoch"
+    );
+}
+
+#[test]
+fn silent_election_proposer_hands_authority_to_next_member() {
+    // Deeper stall: the sole steward is offline AND the member that authority
+    // first falls through to is offline as well. The reelection-silence
+    // watchdog must count the empty window as a rejected round, rotating
+    // proposer authority to the next online member until the stuck removal
+    // lands.
+    let cfg = ConversationConfig {
+        recovery_inactivity_duration: Duration::from_millis(50),
+        ..fast_config()
+    };
+    let mut h = TestHarness::<4>::bootstrap(
+        [ALICE, BOB, CHARLIE, DAVE],
+        "silent",
+        cfg,
+        StewardListConfig::new(1, 1).unwrap(),
+    );
+    for _ in 0..5 {
+        h.process(Duration::from_millis(40));
+    }
+
+    let steward = (0..4)
+        .find(|&i| h.member(i).is_epoch_steward())
+        .expect("a sole epoch steward exists");
+    let steward_id = h.member(steward).member_id_bytes().to_vec();
+    // With the steward's removal approved, round-0 proposer authority falls
+    // to the lowest remaining member id — take that member offline too.
+    let mut others: Vec<usize> = (0..4).filter(|&i| i != steward).collect();
+    others.sort_by(|&a, &b| {
+        h.member(a)
+            .member_id_bytes()
+            .cmp(h.member(b).member_id_bytes())
+    });
+    let (silent_proposer, online) = (others[0], [others[1], others[2]]);
+    h.mute(steward);
+    h.mute(silent_proposer);
+
+    // Approve the steward's removal among the three non-steward members
+    // (two online + the silent proposer, who still receives and votes but
+    // whose outbound is dropped; the silent peers count as YES at timeout).
+    h.member_mut(online[0]).remove_member(&steward_id);
+
+    h.process_until("removal lands despite two silent members", |h| {
+        online
+            .iter()
+            .all(|&m| h.member(m).member_count() == 3 && h.member(m).is_working())
+    });
+
+    let retried = online
+        .iter()
+        .any(|&m| h.member(m).saw_phase(ConversationState::Reelection));
+    assert!(retried, "the online members went through reelection");
+    assert_eq!(
+        h.member(online[0]).epoch(),
+        h.member(online[1]).epoch(),
+        "no fork between the online members"
     );
 }


### PR DESCRIPTION
A group whose installed steward list holds only an offline steward parked in `Reelection` forever: the deterministic responsible proposer for both the recovery election and the Deadlock ECP resolved to the offline steward itself, every other member silently no-oped, and the Layer-2/3 recovery ladder never engaged.

- The freeze-timeout accusation now marks the steward locally unresponsive: recovery elections exclude it from the candidate pool and from proposer authority, and stop counting it toward expected voters — with two expected voters consensus required both real votes, so one silent member vetoed its own replacement. A signature-validated vote from the accused lifts the accusation, so a member that comes back regains authority and candidacy mid-recovery.

- Proposer authority rotates by retry round through a deterministic sequence (installed list order, then remaining eligible candidates ascending), so a silent proposer hands off instead of staying anointed.

- A reelection watchdog counts a silent window as a rejected round, feeding the existing retry/Deadlock escalation; peer elections are tracked in flight so observers don't bump over a running vote. The `NotResponsibleProposer` skip is now logged with the resolved proposer.

- Receivers arm the consensus timeout for incoming proposals — silent-peer-weighted resolution used to run only on the proposer.

- After a round-0 recovery election the fresh steward commits within the short recovery window instead of waiting a full commit-inactivity epoch.

Integration tests cover the two-member repro (the stuck Add commits and the joiner receives its welcome) and the deeper stall where the fall-through proposer is silent too.