### PR TITLE
fix(consensus): stop racing membership proposals from stalling the group

### DIFF
--- a/src/consensus/apply_result.rs
+++ b/src/consensus/apply_result.rs
@@ -287,7 +287,7 @@ mod tests {
         let request = election_request(list.members().to_vec(), 10);
 
         let proposal_id = 42;
-        conversation.track_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, &request);
 
         let result =
             apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
@@ -310,7 +310,7 @@ mod tests {
         let request = election_request(vec![member(1), member(2)], 10);
 
         let proposal_id = 43;
-        conversation.track_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, &request);
 
         let result =
             apply_consensus_result(&mut conversation, proposal_id, false, &request).unwrap();
@@ -371,7 +371,7 @@ mod tests {
         // A second removal for the same target passes consensus.
         let dup_id = 21;
         let dup_request = remove_request(target.clone());
-        conversation.track_voting_proposal(dup_id, dup_request.clone());
+        conversation.track_voting_proposal(dup_id, &dup_request);
 
         let result = apply_consensus_result(&mut conversation, dup_id, true, &dup_request).unwrap();
 
@@ -474,7 +474,7 @@ mod tests {
         let request = remove_request(target.clone());
 
         let proposal_id = 70;
-        conversation.track_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, &request);
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
 
@@ -497,7 +497,7 @@ mod tests {
             .unwrap();
 
         let proposal_id = 300;
-        conversation.track_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, &request);
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
 

--- a/src/consensus/apply_result.rs
+++ b/src/consensus/apply_result.rs
@@ -58,8 +58,6 @@ pub enum ConsensusApplyResult {
 /// - **Removal dedup** — the same member can be removed by several paths
 ///   (self-leave, ban, below-threshold) under different proposal ids. Only the
 ///   first reaches the approved queue; MLS rejects a duplicate at commit time.
-/// - **Owner-only edits** — queue bookkeeping that assumes we opened the
-///   proposal locally runs only when `is_owner_of_proposal`.
 ///
 /// The caller decodes the request once and passes it in.
 pub fn apply_consensus_result(
@@ -68,18 +66,15 @@ pub fn apply_consensus_result(
     approved: bool,
     request: &ConversationUpdateRequest,
 ) -> Result<ConsensusApplyResult, ConversationError> {
-    let is_owner = conversation.is_owner_of_proposal(proposal_id);
+    // The outcome resolved this proposal, so it leaves the in-flight queue.
+    // On YES the approved queue becomes its record (below).
+    conversation.remove_voting_proposal(proposal_id);
+
     let evidence = extract_emergency_evidence(request).cloned();
     let is_emergency = evidence.is_some();
 
     if let Some(election) = extract_election_proposal(request).cloned() {
-        return Ok(apply_election_result(
-            conversation,
-            proposal_id,
-            approved,
-            election,
-            is_owner,
-        ));
+        return Ok(apply_election_result(approved, election));
     }
 
     // ── Emergency and regular proposals ──
@@ -104,13 +99,26 @@ pub fn apply_consensus_result(
     if let Some(target) = &removal_target
         && conversation.has_approved_removal(target)
     {
-        if is_owner {
-            conversation.remove_voting_proposal(proposal_id);
-        }
         info!(
             proposal_id,
             target = ?target,
             "removal proposal deduped — target already queued for removal"
+        );
+        return Ok(ConsensusApplyResult::NoAction);
+    }
+
+    // Two approved proposals can admit one member (an invitation racing a
+    // sponsored join) with different key packages MLS won't collapse into one.
+    // Drop the duplicate, like removals above, or the whole batch is rejected.
+    if approved
+        && let Some(conversation_update_request::Payload::MemberInvite(invite)) =
+            request.payload.as_ref()
+        && conversation.has_approved_invite(&invite.member_id)
+    {
+        info!(
+            proposal_id,
+            target = ?invite.member_id,
+            "invite proposal deduped — target already queued for admission"
         );
         return Ok(ConsensusApplyResult::NoAction);
     }
@@ -120,27 +128,13 @@ pub fn apply_consensus_result(
     let sbt_evidence = evidence.as_ref().filter(|_| transforms_to_removal);
 
     if approved {
-        if is_owner {
-            conversation.mark_proposal_as_approved(proposal_id);
-            if let Some(ev) = sbt_evidence {
-                // Replace ECP with RemoveMember in approved queue (reuse proposal_id).
-                let removal = removal_request_for(ev);
-                conversation.remove_approved_proposal(proposal_id);
-                conversation.insert_approved_proposal(proposal_id, removal);
-            } else if is_emergency {
-                // Other emergencies don't produce MLS operations.
-                conversation.remove_approved_proposal(proposal_id);
-            }
-        } else if let Some(ev) = sbt_evidence {
-            // Non-owner: insert RemoveMember directly (the ECP was never stored).
-            let removal = removal_request_for(ev);
-            conversation.insert_approved_proposal(proposal_id, removal);
+        if let Some(ev) = sbt_evidence {
+            // ECP below threshold becomes a RemoveMember.
+            conversation.insert_approved_proposal(proposal_id, removal_request_for(ev));
         } else if !is_emergency {
-            // Regular proposal: add to approved queue for the next commit.
             conversation.insert_approved_proposal(proposal_id, request.clone());
         }
-    } else if is_owner {
-        conversation.remove_voting_proposal(proposal_id);
+        // Other emergencies produce no MLS operation, so nothing to stage.
     }
 
     if let Some(ev) = evidence.as_ref() {
@@ -184,31 +178,20 @@ pub fn apply_consensus_result(
 }
 
 /// The election branch of [`apply_consensus_result`]. YES hands the proposed
-/// roster back for validation and install; NO drops our voting-queue entry.
+/// roster back for validation and install; NO just reports the rejection.
 fn apply_election_result(
-    conversation: &mut ConversationQueues,
-    proposal_id: u32,
     approved: bool,
     election: StewardElectionProposal,
-    is_owner: bool,
 ) -> ConsensusApplyResult {
     if approved {
-        if is_owner {
-            conversation.mark_proposal_as_approved(proposal_id);
-            conversation.remove_approved_proposal(proposal_id);
-        }
         info!(
-            proposal_id,
             epoch = election.election_epoch,
             stewards = election.proposed_stewards.len(),
             "steward election proposal accepted"
         );
         ConsensusApplyResult::ElectionAccepted(election)
     } else {
-        if is_owner {
-            conversation.remove_voting_proposal(proposal_id);
-        }
-        info!(proposal_id, "steward election proposal rejected");
+        info!("steward election proposal rejected");
         ConsensusApplyResult::ElectionRejected
     }
 }
@@ -295,7 +278,7 @@ mod tests {
     /// YES on an election the local node owns returns the accepted proposal
     /// and doesn't leave the proposal in the approved queue.
     #[test]
-    fn election_yes_owner_returns_outcome_and_clears_queue() {
+    fn election_yes_returns_outcome_and_clears_voting() {
         let config = StewardListConfig::new(2, 5).unwrap();
         let mut conversation = ConversationQueues::new("test-conversation", 10);
         let mems = members(&[1, 2, 3, 4, 5]);
@@ -304,7 +287,7 @@ mod tests {
         let request = election_request(list.members().to_vec(), 10);
 
         let proposal_id = 42;
-        conversation.insert_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, request.clone());
 
         let result =
             apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
@@ -314,7 +297,9 @@ mod tests {
         };
         assert_eq!(outcome.election_epoch, 10);
         assert_eq!(outcome.proposed_stewards.len(), 5);
+        // An election never stages into approved, and its voting entry clears.
         assert_eq!(conversation.approved_proposals_count(), 0);
+        assert!(!conversation.is_voting(proposal_id));
     }
 
     /// NO on an election returns `ElectionRejected` and leaves the approved
@@ -325,31 +310,12 @@ mod tests {
         let request = election_request(vec![member(1), member(2)], 10);
 
         let proposal_id = 43;
-        conversation.insert_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, request.clone());
 
         let result =
             apply_consensus_result(&mut conversation, proposal_id, false, &request).unwrap();
 
         assert!(matches!(result, ConsensusApplyResult::ElectionRejected));
-        assert_eq!(conversation.approved_proposals_count(), 0);
-    }
-
-    /// YES on an election the local node *doesn't* own still returns the outcome
-    /// (non-owner path), and doesn't touch any proposal queues.
-    #[test]
-    fn election_yes_nonowner_returns_outcome_without_queue_side_effects() {
-        let mut conversation = ConversationQueues::new("test-conversation", 10);
-        let request = election_request(vec![member(1), member(2), member(3)], 5);
-
-        let proposal_id = 44;
-        let result =
-            apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
-
-        let ConsensusApplyResult::ElectionAccepted(outcome) = result else {
-            panic!("expected ElectionAccepted, got {result:?}");
-        };
-        assert_eq!(outcome.election_epoch, 5);
-        assert_eq!(outcome.proposed_stewards.len(), 3);
         assert_eq!(conversation.approved_proposals_count(), 0);
     }
 
@@ -364,7 +330,7 @@ mod tests {
         let mut conversation = ConversationQueues::new("test-conversation", 10);
         let target = member(7);
 
-        // First removal — non-owner path inserts straight into approved.
+        // First removal stages into the approved queue.
         let first_id = 10;
         let request = remove_request(target.clone());
         let first_result =
@@ -390,10 +356,10 @@ mod tests {
         assert!(!conversation.approved_proposals().contains_key(&second_id));
     }
 
-    /// Owner-side dedup: the duplicate clears its voting-queue entry so the
-    /// queue does not retain an outcome we deliberately discarded.
+    /// Removal dedup clears the duplicate's voting-queue entry so the queue
+    /// does not retain an outcome we deliberately discarded.
     #[test]
-    fn removal_dedup_clears_owner_voting_entry() {
+    fn removal_dedup_clears_voting_entry() {
         let mut conversation = ConversationQueues::new("test-conversation", 10);
         let target = member(7);
 
@@ -402,19 +368,18 @@ mod tests {
         let pending = remove_request(target.clone());
         conversation.insert_approved_proposal(pending_id, pending);
 
-        // This user submits their own removal and it passes consensus.
-        let owner_id = 21;
-        let owner_request = remove_request(target.clone());
-        conversation.insert_voting_proposal(owner_id, owner_request.clone());
+        // A second removal for the same target passes consensus.
+        let dup_id = 21;
+        let dup_request = remove_request(target.clone());
+        conversation.track_voting_proposal(dup_id, dup_request.clone());
 
-        let result =
-            apply_consensus_result(&mut conversation, owner_id, true, &owner_request).unwrap();
+        let result = apply_consensus_result(&mut conversation, dup_id, true, &dup_request).unwrap();
 
         assert!(matches!(result, ConsensusApplyResult::NoAction));
         assert_eq!(conversation.approved_proposals_count(), 1);
         assert!(conversation.approved_proposals().contains_key(&pending_id));
         assert!(
-            !conversation.is_owner_of_proposal(owner_id),
+            !conversation.is_voting(dup_id),
             "duplicate must be cleared from voting queue"
         );
     }
@@ -509,7 +474,7 @@ mod tests {
         let request = remove_request(target.clone());
 
         let proposal_id = 70;
-        conversation.insert_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, request.clone());
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
 
@@ -532,7 +497,7 @@ mod tests {
             .unwrap();
 
         let proposal_id = 300;
-        conversation.insert_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, request.clone());
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
 

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -13,9 +13,7 @@ use crate::{
     ConsensusApplyResult, ConsensusPlugin, Conversation, ConversationError, ConversationEvent,
     ConversationState, PeerScoreStorage, ScoreOp, WallClock, apply_consensus_result,
     emergency_score_ops,
-    protos::de_mls::messages::v1::{
-        ConversationUpdateRequest, StewardElectionProposal, conversation_update_request,
-    },
+    protos::de_mls::messages::v1::{ConversationUpdateRequest, StewardElectionProposal},
 };
 
 impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
@@ -128,7 +126,7 @@ where
         // Empty for everything but emergency-criteria payloads.
         let score_ops = emergency_score_ops(&request, approved);
         if !score_ops.is_empty() {
-            self.handle_emergency_scored(provider, proposal_id, &request, &score_ops, signer)?;
+            self.handle_emergency_scored(provider, proposal_id, &score_ops, signer)?;
         }
 
         Ok(())
@@ -233,16 +231,14 @@ where
         self.process_buffered_updates(provider, signer)
     }
 
-    /// Emergency proposal resolved: apply the score ops, clear the
-    /// pending-removal buffer, lift the partial freeze (removing it from
-    /// the emergency set), and resume from `Reelection` if the emergency
-    /// put us there. Ends with a below-threshold sweep — the score ops may
-    /// have pushed someone over the removal line.
+    /// Emergency proposal resolved: apply the score ops, lift the partial
+    /// freeze (removing it from the emergency set), and resume from
+    /// `Reelection` if the emergency put us there. Ends with a below-threshold
+    /// sweep — the score ops may have pushed someone over the removal line.
     fn handle_emergency_scored<Pr>(
         &mut self,
         provider: &Pr,
         proposal_id: u32,
-        request: &ConversationUpdateRequest,
         score_ops: &[ScoreOp],
         signer: &impl Signer,
     ) -> Result<(), ConversationError>
@@ -251,12 +247,6 @@ where
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
         self.services.scoring.apply_ops(score_ops)?;
-        if let Some(conversation_update_request::Payload::EmergencyCriteria(ec)) = &request.payload
-            && let Some(ev) = &ec.evidence
-        {
-            self.queues.remove_pending_removal(&ev.target_member_id);
-        }
-
         self.queues.remove_emergency(proposal_id);
         let resumed_event = if self.current_state() == ConversationState::Reelection {
             Some(self.start_working())

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -84,7 +84,6 @@ where
             proposal_id, approved, "consensus reached"
         );
         self.queues.mark_consensus_outcome_applied(proposal_id);
-        self.queues.clear_observed_election(proposal_id);
         let consensus_apply =
             apply_consensus_result(&mut self.queues, proposal_id, approved, &request)?;
 

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -101,7 +101,7 @@ where
         )?;
 
         self.queues
-            .insert_voting_proposal(proposal_id, request.clone());
+            .track_voting_proposal(proposal_id, request.clone());
         if kind.is_emergency() {
             self.queues.insert_emergency(proposal_id);
         }
@@ -272,11 +272,10 @@ where
         let request = ConversationUpdateRequest::remove_member(self.self_member_id.to_vec());
         let proposal_id = self_leave_proposal_id(&self.self_member_id);
 
-        // Ownership must be recorded before the session opens: the bundled
-        // YES fires `ConsensusReached` synchronously, and the outcome
-        // handler needs `is_owner_of_proposal` to already be true.
+        // Track before the session opens: the bundled YES fires
+        // `ConsensusReached` synchronously.
         self.queues
-            .insert_voting_proposal(proposal_id, request.clone());
+            .track_voting_proposal(proposal_id, request.clone());
 
         let submitted = self.submit_self_leave_proposal(ProposalParams {
             expected_voters: 1,

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use crate::{
     ConsensusPlugin, Conversation, ConversationError, ConversationEvent, ConversationState,
     PeerScoreStorage, ProposalKind, WallClock,
+    conversation::in_flight_target,
     protos::de_mls::messages::v1::{AppMessage, ConversationUpdateRequest},
     self_leave_proposal_id,
     wall_clock::WallClockExt,
@@ -65,8 +66,9 @@ where
     /// shape and the integrator event.
     ///
     /// Errors when the state machine forbids new proposals (freeze phases,
-    /// partial freeze during an active emergency). On success the proposal
-    /// is on the wire and a consensus-timeout deadline is armed for
+    /// partial freeze during an active emergency). No-ops when a change for the
+    /// request's target member is already in flight locally. On success the
+    /// proposal is on the wire and a consensus-timeout deadline is armed for
     /// `tick_deadlines` to fire.
     pub fn initiate_proposal<Pr>(
         &mut self,
@@ -79,6 +81,21 @@ where
         Pr: OpenMlsProvider,
         <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
     {
+        // One in-flight change per member (local dedup): don't open a second
+        // session for a target already being voted on or approved here. A
+        // cross-node duplicate — two members proposing the same target — is
+        // caught later at approval by `has_approved_*`.
+        if let Some(target) = in_flight_target(&request)
+            && self.queues.active_proposal_targets().contains(target)
+        {
+            info!(
+                conversation = %self.conversation_id,
+                member = ?target,
+                "proposal skipped: a change for this member is already in flight"
+            );
+            return Ok(());
+        }
+
         let kind = ProposalKind::of(&request);
         let expected_voters = self.check_proposal_allowed(kind)?;
 

--- a/src/consensus/voting.rs
+++ b/src/consensus/voting.rs
@@ -68,10 +68,6 @@ where
     /// partial freeze during an active emergency). On success the proposal
     /// is on the wire and a consensus-timeout deadline is armed for
     /// `tick_deadlines` to fire.
-    ///
-    /// Local ownership is recorded before any vote is cast: with a single
-    /// expected voter the bundled YES resolves the session synchronously,
-    /// and the outcome handler must already see us as the owner by then.
     pub fn initiate_proposal<Pr>(
         &mut self,
         provider: &Pr,
@@ -100,8 +96,7 @@ where
             },
         )?;
 
-        self.queues
-            .track_voting_proposal(proposal_id, request.clone());
+        self.queues.track_voting_proposal(proposal_id, &request);
         if kind.is_emergency() {
             self.queues.insert_emergency(proposal_id);
         }
@@ -274,8 +269,7 @@ where
 
         // Track before the session opens: the bundled YES fires
         // `ConsensusReached` synchronously.
-        self.queues
-            .track_voting_proposal(proposal_id, request.clone());
+        self.queues.track_voting_proposal(proposal_id, &request);
 
         let submitted = self.submit_self_leave_proposal(ProposalParams {
             expected_voters: 1,

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -420,6 +420,13 @@ where
                 error = %e,
                 "own commit candidate build failed"
             );
+            // A mint failure stalls this round and repeats on every retry, and
+            // the phase change alone reads as a healthy freeze — so the
+            // integrator has no other view of it.
+            self.emit_event(ConversationEvent::Error {
+                operation: "commit_candidate_build".to_string(),
+                message: e.to_string(),
+            });
         }
         self.emit_event(ConversationEvent::PhaseChange(event));
         Ok(())
@@ -855,6 +862,55 @@ mod tests {
             Arc::from(&b"test-member-id"[..]),
             Arc::from(&[0u8; 16][..]),
         )
+    }
+
+    /// Build a conversation whose sole steward is the local member, plus the
+    /// provider/signer backing it — the shape every commit-mint test needs.
+    fn make_steward_conversation() -> (TestConversation, TestProvider, SignatureKeyPair) {
+        let (mls, provider, signer) = make_creator_mls(b"test-member-id");
+        (
+            build_conversation(mls, steward_service_steward(b"test-member-id")),
+            provider,
+            signer,
+        )
+    }
+
+    fn invite_for(
+        joiner_id: &[u8],
+        key_package_bytes: Vec<u8>,
+    ) -> crate::protos::de_mls::messages::v1::ConversationUpdateRequest {
+        use crate::protos::de_mls::messages::v1::{ConversationUpdateRequest, MemberInvite};
+        ConversationUpdateRequest::member_invite(MemberInvite {
+            key_package_bytes,
+            member_id: joiner_id.to_vec(),
+        })
+    }
+
+    /// A candidate that cannot be minted is not a phase-change detail — it
+    /// stalls the round and every retry after it. The integrator has no other
+    /// way to see it, so freeze entry must surface the failure rather than
+    /// logging it and reporting a clean phase change.
+    #[test]
+    fn freeze_entry_surfaces_candidate_build_failure() {
+        let (mut convo, provider, signer) = make_steward_conversation();
+        // Undecodable key-package bytes: the mint fails inside OpenMLS.
+        convo
+            .queues
+            .insert_approved_proposal(1, invite_for(b"joiner-member-id", vec![0xAA; 32]));
+
+        convo
+            .on_freeze_entered(&provider, &signer, ConversationState::Freezing)
+            .expect("freeze entry itself reports Ok");
+
+        let errors: Vec<_> = convo
+            .drain_events()
+            .into_iter()
+            .filter(|e| matches!(e, ConversationEvent::Error { .. }))
+            .collect();
+        assert!(
+            !errors.is_empty(),
+            "a failed candidate mint must reach the integrator as an Error event"
+        );
     }
 
     /// A [`PeerScoreStorage`] whose every read/write fails — for asserting that

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -354,17 +354,20 @@ where
 
         if let Some(req) = decoded.as_ref() {
             let current_epoch = self.mls().current_epoch()?;
+            // In flight the moment it arrives, so the steward's drain won't
+            // re-propose it.
+            self.queues.track_voting_proposal(proposal_id, req.clone());
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
                     self.queues.insert_emergency(proposal_id);
                 }
                 Some(conversation_update_request::Payload::MemberInvite(_))
                 | Some(conversation_update_request::Payload::RemoveMember(_)) => {
+                    // RFC §Buffering KeyPackages: hold the change until a
+                    // commit applies it, so a later steward can retry it if this
+                    // round never lands.
                     self.queues
                         .insert_pending_update(req.clone(), current_epoch);
-                }
-                Some(conversation_update_request::Payload::StewardElection(_)) => {
-                    self.queues.note_observed_election(proposal_id);
                 }
                 _ => {}
             }

--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -356,7 +356,7 @@ where
             let current_epoch = self.mls().current_epoch()?;
             // In flight the moment it arrives, so the steward's drain won't
             // re-propose it.
-            self.queues.track_voting_proposal(proposal_id, req.clone());
+            self.queues.track_voting_proposal(proposal_id, req);
             match &req.payload {
                 Some(conversation_update_request::Payload::EmergencyCriteria(_)) => {
                     self.queues.insert_emergency(proposal_id);

--- a/src/conversation/mod.rs
+++ b/src/conversation/mod.rs
@@ -38,4 +38,4 @@ pub use messaging::Outbound;
 pub use poll::PollOutcome;
 pub use queues::{ConversationQueues, ProposalId};
 pub use state_machine::{ConversationState, ConversationStateMachine, OperatingMode};
-pub use util::{member_set, self_leave_proposal_id, target_member_id_of};
+pub use util::{in_flight_target, member_set, self_leave_proposal_id, target_member_id_of};

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -80,7 +80,11 @@ pub struct ConversationQueues {
     /// vector — library proposal IDs are content-derived hashes, so
     /// sort-by-id is not temporal.
     approved_proposals: IndexMap<ProposalId, ConversationUpdateRequest>,
-    /// Proposals waiting on consensus voting (created by this user).
+    /// Proposals in flight through consensus — ours and peers', treated
+    /// identically. It is the record that a change is already being voted on,
+    /// which stops the epoch steward re-proposing it out of `pending_updates`
+    /// (RFC §Consensus Types: the epoch steward collects and commits YES-voted
+    /// proposals; it does not re-create them).
     voting_proposals: HashMap<ProposalId, ConversationUpdateRequest>,
     /// Active emergency criteria proposals not yet finalized by consensus.
     /// While non-empty, lower-priority proposals MUST be blocked (RFC §Partial Freeze).
@@ -123,11 +127,6 @@ pub struct ConversationQueues {
     /// restores its authority and candidacy mid-recovery — and the whole set
     /// clears when a commit merges.
     unresponsive_stewards: HashSet<Vec<u8>>,
-    /// Steward-election proposals observed from peers and not yet resolved by
-    /// consensus. Folded into [`Self::has_election_in_flight`] so a member
-    /// waiting out a peer's election doesn't count the wait as reelection
-    /// silence and claim proposer authority over a vote already running.
-    observed_election_ids: HashSet<ProposalId>,
 }
 
 impl ConversationQueues {
@@ -147,7 +146,6 @@ impl ConversationQueues {
             member_join_epoch: HashMap::new(),
             welcome_broadcast_hashes: BoundedSet::new(dedup_window),
             unresponsive_stewards: HashSet::new(),
-            observed_election_ids: HashSet::new(),
         }
     }
 
@@ -233,6 +231,17 @@ impl ConversationQueues {
             .any(|req| removes_member(req, member_id))
     }
 
+    /// True iff `approved_proposals` already admits `member_id`. Mirrors
+    /// [`Self::has_approved_removal`]: an invitation and a sponsored join
+    /// request can admit the same member under different proposal ids, and
+    /// their key packages need not match — so MLS cannot collapse them into one
+    /// proposal and rejects the whole batch.
+    pub fn has_approved_invite(&self, member_id: &[u8]) -> bool {
+        self.approved_proposals
+            .values()
+            .any(|req| invites_member(req, member_id))
+    }
+
     /// True if `member_id` has a self-leave waiting for the next commit —
     /// an approved `RemoveMember(member_id)` under the deterministic
     /// self-leave ID. Used by live rotation to skip the leaver.
@@ -243,14 +252,7 @@ impl ConversationQueues {
             .is_some_and(|req| removes_member(req, member_id))
     }
 
-    /// Move a proposal from the voting queue into the approved queue.
-    pub fn mark_proposal_as_approved(&mut self, proposal_id: ProposalId) {
-        if let Some(proposal) = self.voting_proposals.remove(&proposal_id) {
-            self.approved_proposals.insert(proposal_id, proposal);
-        }
-    }
-
-    /// Insert a proposal straight into the approved queue (non-owner path).
+    /// Insert a proposal straight into the approved queue, staged for commit.
     pub fn insert_approved_proposal(
         &mut self,
         proposal_id: ProposalId,
@@ -295,28 +297,25 @@ impl ConversationQueues {
 
     // ─────────────────────────── Voting Proposals ───────────────────────────
 
-    /// True when this user created `proposal_id` (it's still in the voting queue).
-    pub fn is_owner_of_proposal(&self, proposal_id: ProposalId) -> bool {
-        self.voting_proposals.contains_key(&proposal_id)
-    }
-
-    /// Add a newly-created proposal to the voting queue.
-    pub fn insert_voting_proposal(
+    /// Record `proposal_id` as in flight, whoever opened it. Idempotent: a
+    /// later sighting (e.g. a peer echo of our own proposal) leaves the first
+    /// entry untouched.
+    pub fn track_voting_proposal(
         &mut self,
         proposal_id: ProposalId,
         proposal: ConversationUpdateRequest,
     ) {
-        self.voting_proposals.insert(proposal_id, proposal);
+        self.voting_proposals.entry(proposal_id).or_insert(proposal);
     }
 
-    /// Drop a proposal from the voting queue (rejected or failed consensus).
+    /// True while `proposal_id` is in flight (in the voting queue).
+    pub fn is_voting(&self, proposal_id: ProposalId) -> bool {
+        self.voting_proposals.contains_key(&proposal_id)
+    }
+
+    /// Drop a proposal from the voting queue (resolved, rejected, or deduped).
     pub fn remove_voting_proposal(&mut self, proposal_id: ProposalId) {
         self.voting_proposals.remove(&proposal_id);
-    }
-
-    /// Drop every entry in the voting queue.
-    pub fn clear_voting_proposals(&mut self) {
-        self.voting_proposals.clear();
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election
@@ -324,22 +323,9 @@ impl ConversationQueues {
     /// Reads the local voting queue and the observed-election set — a
     /// proposal-queue concern, not steward-list state.
     pub fn has_election_in_flight(&self) -> bool {
-        !self.observed_election_ids.is_empty()
-            || self
-                .voting_proposals
-                .values()
-                .any(|req| ProposalKind::of(req).is_steward_election())
-    }
-
-    /// Record a peer's steward-election proposal as in flight.
-    pub fn note_observed_election(&mut self, proposal_id: ProposalId) {
-        self.observed_election_ids.insert(proposal_id);
-    }
-
-    /// A consensus outcome landed for `proposal_id` — the election (if it was
-    /// one) is no longer in flight. No-op for other proposal kinds.
-    pub fn clear_observed_election(&mut self, proposal_id: ProposalId) {
-        self.observed_election_ids.remove(&proposal_id);
+        self.voting_proposals
+            .values()
+            .any(|req| ProposalKind::of(req).is_steward_election())
     }
 
     // ─────────────────────────── Unresponsive stewards ───────────────────────────
@@ -609,6 +595,14 @@ fn removes_member(req: &ConversationUpdateRequest, member_id: &[u8]) -> bool {
     )
 }
 
+/// True when `req` admits `member_id`, whatever key package it carries.
+fn invites_member(req: &ConversationUpdateRequest, member_id: &[u8]) -> bool {
+    matches!(
+        req.payload.as_ref(),
+        Some(conversation_update_request::Payload::MemberInvite(m)) if m.member_id == member_id
+    )
+}
+
 /// Capacity of the resolved-outcome dedup set (`resolved_proposals`): proposal
 /// IDs with a locally observed consensus outcome, kept for the duplicate-drop
 /// guard in `handle_consensus_outcome` and the late-vote classifier in
@@ -862,23 +856,6 @@ mod tests {
         assert!(!conversation.has_pending_update(&prior));
     }
 
-    /// `clear_voting_proposals` empties the owner-side voting queue —
-    /// proposals the local node submitted but never reached consensus
-    /// must not survive into the next round.
-    #[test]
-    fn clear_voting_proposals_empties_owner_queue() {
-        let mut conversation = ConversationQueues::new("reject-voting", 10);
-        conversation.insert_voting_proposal(1, ConversationUpdateRequest { payload: None });
-        conversation.insert_voting_proposal(2, ConversationUpdateRequest { payload: None });
-        assert!(conversation.is_owner_of_proposal(1));
-        assert!(conversation.is_owner_of_proposal(2));
-
-        conversation.clear_voting_proposals();
-
-        assert!(!conversation.is_owner_of_proposal(1));
-        assert!(!conversation.is_owner_of_proposal(2));
-    }
-
     /// `observe → has → resolve` cycle for `pending_removal_targets`,
     /// covering the idempotent re-observe path.
     #[test]
@@ -919,7 +896,7 @@ mod tests {
             ViolationEvidence::score_below_threshold(target.clone(), 0, 0).with_creator(creator);
         let request = evidence.into_update_request().unwrap();
         let proposal_id = 300;
-        conversation.insert_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, request.clone());
         conversation.insert_pending_removal(target.clone());
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -21,6 +21,15 @@ use crate::{
 /// Consensus proposal identifier (assigned by the consensus service).
 pub type ProposalId = u32;
 
+/// What the queues need to reason about an in-flight proposal without holding
+/// the full request — consensus storage keeps that. Just who it targets and
+/// whether it is a steward election.
+#[derive(Clone, Debug)]
+struct VotingMeta {
+    target: Option<Vec<u8>>,
+    kind: ProposalKind,
+}
+
 /// Represents a pending membership update that may not yet be committed.
 ///
 /// Buffered by each member. If the epoch steward doesn't commit the change,
@@ -80,12 +89,13 @@ pub struct ConversationQueues {
     /// vector — library proposal IDs are content-derived hashes, so
     /// sort-by-id is not temporal.
     approved_proposals: IndexMap<ProposalId, ConversationUpdateRequest>,
-    /// Proposals in flight through consensus — ours and peers', treated
-    /// identically. It is the record that a change is already being voted on,
-    /// which stops the epoch steward re-proposing it out of `pending_updates`
-    /// (RFC §Consensus Types: the epoch steward collects and commits YES-voted
-    /// proposals; it does not re-create them).
-    voting_proposals: HashMap<ProposalId, ConversationUpdateRequest>,
+    /// Index of proposals in flight through consensus — ours and peers',
+    /// treated identically. The record that a change is already being voted on,
+    /// so the epoch steward doesn't re-propose it out of `pending_updates` (RFC
+    /// §Consensus Types: the steward collects and commits YES-voted proposals;
+    /// it does not re-create them). Holds only what the queues query; the full
+    /// request lives in consensus storage.
+    voting_proposals: HashMap<ProposalId, VotingMeta>,
     /// Active emergency criteria proposals not yet finalized by consensus.
     /// While non-empty, lower-priority proposals MUST be blocked (RFC §Partial Freeze).
     active_emergency_ids: HashSet<ProposalId>,
@@ -214,11 +224,15 @@ impl ConversationQueues {
     /// already approved. A buffered update whose target is in this set is
     /// already covered by a live proposal and must not be re-proposed.
     pub fn active_proposal_targets(&self) -> HashSet<&[u8]> {
-        self.voting_proposals
+        let voting = self
+            .voting_proposals
             .values()
-            .chain(self.approved_proposals.values())
-            .filter_map(target_member_id_of)
-            .collect()
+            .filter_map(|m| m.target.as_deref());
+        let approved = self
+            .approved_proposals
+            .values()
+            .filter_map(target_member_id_of);
+        voting.chain(approved).collect()
     }
 
     /// True iff `approved_proposals` carries any `RemoveMember(member_id)`,
@@ -303,9 +317,14 @@ impl ConversationQueues {
     pub fn track_voting_proposal(
         &mut self,
         proposal_id: ProposalId,
-        proposal: ConversationUpdateRequest,
+        proposal: &ConversationUpdateRequest,
     ) {
-        self.voting_proposals.entry(proposal_id).or_insert(proposal);
+        self.voting_proposals
+            .entry(proposal_id)
+            .or_insert_with(|| VotingMeta {
+                target: target_member_id_of(proposal).map(<[u8]>::to_vec),
+                kind: ProposalKind::of(proposal),
+            });
     }
 
     /// True while `proposal_id` is in flight (in the voting queue).
@@ -319,13 +338,11 @@ impl ConversationQueues {
     }
 
     /// Cheap idempotence check for auto-retry: don't submit a second election
-    /// while a previous one — own or a peer's — is still being voted on.
-    /// Reads the local voting queue and the observed-election set — a
-    /// proposal-queue concern, not steward-list state.
+    /// while one — own or a peer's — is still being voted on.
     pub fn has_election_in_flight(&self) -> bool {
         self.voting_proposals
             .values()
-            .any(|req| ProposalKind::of(req).is_steward_election())
+            .any(|m| m.kind.is_steward_election())
     }
 
     // ─────────────────────────── Unresponsive stewards ───────────────────────────
@@ -896,7 +913,7 @@ mod tests {
             ViolationEvidence::score_below_threshold(target.clone(), 0, 0).with_creator(creator);
         let request = evidence.into_update_request().unwrap();
         let proposal_id = 300;
-        conversation.track_voting_proposal(proposal_id, request.clone());
+        conversation.track_voting_proposal(proposal_id, &request);
         conversation.insert_pending_removal(target.clone());
 
         apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();

--- a/src/conversation/queues.rs
+++ b/src/conversation/queues.rs
@@ -1,6 +1,5 @@
 //! Per-conversation protocol-queue state: approved/voting proposal queues,
-//! commit-round candidate buffer, pending-update buffer, urgent-commit
-//! target, ECP dedup.
+//! commit-round candidate buffer, pending-update buffer, urgent-commit target.
 
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -10,7 +9,8 @@ use indexmap::{IndexMap, IndexSet};
 use crate::{
     commit_round::{CommitHash, CommitRoundBuffer},
     conversation::util::{
-        is_auto_approved_entry, member_set, self_leave_proposal_id, target_member_id_of,
+        in_flight_target, is_auto_approved_entry, member_set, self_leave_proposal_id,
+        target_member_id_of,
     },
     proposal_kind::ProposalKind,
     protos::de_mls::messages::v1::{
@@ -99,8 +99,6 @@ pub struct ConversationQueues {
     /// Active emergency criteria proposals not yet finalized by consensus.
     /// While non-empty, lower-priority proposals MUST be blocked (RFC §Partial Freeze).
     active_emergency_ids: HashSet<ProposalId>,
-    /// Members with pending score-based removal ECPs (dedup to prevent duplicates).
-    pending_removal_targets: HashSet<Vec<u8>>,
     /// Recent commit hashes for dedup.
     committed_batch_hashes: BoundedSet<CommitHash>,
     /// Commit-round candidate buffer for deterministic selection.
@@ -146,7 +144,6 @@ impl ConversationQueues {
             approved_proposals: IndexMap::new(),
             voting_proposals: HashMap::new(),
             active_emergency_ids: HashSet::new(),
-            pending_removal_targets: HashSet::new(),
             committed_batch_hashes: BoundedSet::new(dedup_window),
             commit_round: CommitRoundBuffer::default(),
             pending_updates: HashMap::new(),
@@ -322,7 +319,7 @@ impl ConversationQueues {
         self.voting_proposals
             .entry(proposal_id)
             .or_insert_with(|| VotingMeta {
-                target: target_member_id_of(proposal).map(<[u8]>::to_vec),
+                target: in_flight_target(proposal).map(<[u8]>::to_vec),
                 kind: ProposalKind::of(proposal),
             });
     }
@@ -393,23 +390,6 @@ impl ConversationQueues {
     /// should be rejected under the current freeze state.
     pub fn partial_freeze_blocks(&self, kind: ProposalKind) -> bool {
         self.has_active_emergency() && kind < ProposalKind::Emergency
-    }
-
-    // ─────────────────────────── Removal Dedup ───────────────────────────
-
-    /// Record that a score-based removal ECP has been submitted for this member.
-    pub fn insert_pending_removal(&mut self, member_id: Vec<u8>) {
-        self.pending_removal_targets.insert(member_id);
-    }
-
-    /// Check if a removal ECP is already pending for this member.
-    pub fn has_pending_removal(&self, member_id: &[u8]) -> bool {
-        self.pending_removal_targets.contains(member_id)
-    }
-
-    /// Mark a removal ECP as finalized (resolved regardless of outcome).
-    pub fn remove_pending_removal(&mut self, member_id: &[u8]) {
-        self.pending_removal_targets.remove(member_id);
     }
 
     // ─────────────────────────── Committed-Hash Dedup ───────────────────────────
@@ -571,11 +551,6 @@ impl ConversationQueues {
                 _ => true,
             }
         });
-
-        // Drop removal-dedup entries for targets no longer present: a leaked
-        // entry (ECP that never resolved) would otherwise block them forever.
-        self.pending_removal_targets
-            .retain(|target| in_conversation.contains(target));
     }
 
     // ─────────────────────────── Urgent (ECP-driven) Commit Target ───────────────────────────
@@ -873,35 +848,13 @@ mod tests {
         assert!(!conversation.has_pending_update(&prior));
     }
 
-    /// `observe → has → resolve` cycle for `pending_removal_targets`,
-    /// covering the idempotent re-observe path.
+    /// A score-below-threshold removal is a live change for its target across
+    /// its whole lifecycle: while the ECP is still voting (via the in-flight
+    /// index) and after it resolves into a queued `RemoveMember` (via the
+    /// approved queue). `active_proposal_targets` sees it the whole time, so
+    /// the steward never files a duplicate.
     #[test]
-    fn pending_removal_target_observe_resolve_cycle() {
-        let mut conversation = ConversationQueues::new("dedup", 10);
-        let target = member(10);
-
-        assert!(!conversation.has_pending_removal(&target));
-
-        conversation.insert_pending_removal(target.clone());
-        assert!(conversation.has_pending_removal(&target));
-
-        conversation.insert_pending_removal(target.clone());
-        assert!(
-            conversation.has_pending_removal(&target),
-            "second observe is idempotent"
-        );
-
-        conversation.remove_pending_removal(&target);
-        assert!(!conversation.has_pending_removal(&target));
-    }
-
-    /// Once an ECP score-below-threshold YES has resolved into a queued
-    /// `RemoveMember`, `has_approved_removal` flips true (it's in the approved
-    /// queue) and `has_pending_removal` flips false (the in-flight ECP dedup
-    /// is cleared). Both gates together must keep the steward from
-    /// re-proposing for the same target.
-    #[test]
-    fn below_threshold_target_queued_for_removal_is_not_re_proposed() {
+    fn score_removal_target_stays_covered_through_its_lifecycle() {
         use crate::apply_consensus_result;
         use crate::protos::de_mls::messages::v1::ViolationEvidence;
 
@@ -913,20 +866,27 @@ mod tests {
             ViolationEvidence::score_below_threshold(target.clone(), 0, 0).with_creator(creator);
         let request = evidence.into_update_request().unwrap();
         let proposal_id = 300;
+
+        // Voting: the ECP hasn't produced a RemoveMember yet, but the target is
+        // already covered — the blind spot the ECP-aware index closes.
         conversation.track_voting_proposal(proposal_id, &request);
-        conversation.insert_pending_removal(target.clone());
-
-        apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
-        // Mirror the coordinator: clear the in-flight ECP dedup on resolution.
-        conversation.remove_pending_removal(&target);
-
         assert!(
-            conversation.has_approved_removal(&target),
-            "RemoveMember should be queued in approved_proposals"
+            conversation
+                .active_proposal_targets()
+                .contains(target.as_slice()),
+            "the in-flight ECP already covers its target"
         );
+        assert!(!conversation.has_approved_removal(&target));
+
+        // Resolved: the ECP transforms into a queued RemoveMember, and the
+        // target stays covered with no gap.
+        apply_consensus_result(&mut conversation, proposal_id, true, &request).unwrap();
+        assert!(conversation.has_approved_removal(&target));
         assert!(
-            !conversation.has_pending_removal(&target),
-            "in-flight ECP dedup is cleared once the ECP resolves"
+            conversation
+                .active_proposal_targets()
+                .contains(target.as_slice()),
+            "the queued RemoveMember still covers the target"
         );
     }
 }

--- a/src/conversation/steward.rs
+++ b/src/conversation/steward.rs
@@ -402,32 +402,21 @@ where
             if !is_steward {
                 return Ok(());
             }
-            // Two dedup gates:
-            //   - `has_pending_removal` — there's an in-flight ECP for
-            //     this target (live consensus session).
-            //   - `has_approved_removal` — `RemoveMember(target)` is
-            //     already queued in `approved_proposals` waiting for
-            //     the next commit. Without this gate, a just-resolved
-            //     `ViolationType::SCORE_BELOW_THRESHOLD`ECP (which clears
-            //     `pending_removal_targets` on resolve, but leaves the
-            //     target in `approved_proposals` with their score still
-            //     ≤ threshold) would re-fire a duplicate ECP for the
-            //     same target before the RemoveMember commits.
+            // Skip a target that already has a removal in flight or approved.
+            // The in-flight index now includes score-removal ECPs, so this one
+            // check covers both a live ECP session and a queued RemoveMember —
+            // the target stays covered across the ECP's whole lifecycle, so no
+            // duplicate is filed.
+            let active = self.queues.active_proposal_targets();
             let self_id: &[u8] = &self_id_arc;
             let mut to_remove: Vec<(Vec<u8>, i64)> = Vec::new();
             for id in self.services.scoring.members_below_threshold()? {
-                if id.as_slice() == self_id
-                    || self.queues.has_pending_removal(&id)
-                    || self.queues.has_approved_removal(&id)
-                {
+                if id.as_slice() == self_id || active.contains(id.as_slice()) {
                     continue;
                 }
                 if let Some(score) = self.services.scoring.score_for(&id)? {
                     to_remove.push((id, score));
                 }
-            }
-            for (id, _) in &to_remove {
-                self.queues.insert_pending_removal(id.clone());
             }
             (epoch, to_remove, self_id_arc, self.conversation_id.clone())
         };
@@ -448,7 +437,6 @@ where
             // member must be removed. The steward's vote is YES by
             // protocol, so we bundle it at submit and skip the vote request.
             if let Err(e) = self.initiate_proposal(provider, request, CreatorVote::Yes, signer) {
-                self.queues.remove_pending_removal(&target_id);
                 error!(
                     conversation = %conversation_id,
                     target = ?target_id,

--- a/src/conversation/util.rs
+++ b/src/conversation/util.rs
@@ -4,7 +4,9 @@ use std::collections::HashSet;
 
 use sha2::{Digest, Sha256};
 
-use crate::protos::de_mls::messages::v1::{ConversationUpdateRequest, conversation_update_request};
+use crate::protos::de_mls::messages::v1::{
+    ConversationUpdateRequest, ViolationType, conversation_update_request,
+};
 
 /// Deterministic proposal ID for a self-leave, derived from the leaver's ID.
 /// Pinning the ID dedupes a crash-retry against any in-flight
@@ -39,4 +41,22 @@ pub fn target_member_id_of(request: &ConversationUpdateRequest) -> Option<&[u8]>
         conversation_update_request::Payload::RemoveMember(m) => Some(&m.member_id),
         _ => None,
     }
+}
+
+/// Member a proposal will add or remove once it lands — the membership target,
+/// plus a score-below-threshold ECP, which transforms into a RemoveMember on
+/// approval. Lets the in-flight index dedup a repeated or buffered change
+/// against a live score-removal for the whole voting window, not just after it
+/// becomes a RemoveMember.
+pub fn in_flight_target(request: &ConversationUpdateRequest) -> Option<&[u8]> {
+    if let Some(id) = target_member_id_of(request) {
+        return Some(id);
+    }
+    let conversation_update_request::Payload::EmergencyCriteria(ec) = request.payload.as_ref()?
+    else {
+        return None;
+    };
+    let ev = ec.evidence.as_ref()?;
+    (ViolationType::try_from(ev.violation_type) == Ok(ViolationType::ScoreBelowThreshold))
+        .then_some(ev.target_member_id.as_slice())
 }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -33,6 +33,7 @@ use de_mls::StewardListConfig;
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
 use de_mls::protos::de_mls::messages::v1::{
     AppMessage, ConversationUpdateRequest, MemberInvite, MemberWelcome, app_message,
+    conversation_update_request,
 };
 use de_mls::{Conversation, ConversationConfig, CreatorVote, MemberRole, Outbound, PollOutcome};
 use de_mls::{ConversationError, ConversationEvent, ConversationState, MockClock, ScoringConfig};
@@ -144,6 +145,10 @@ pub struct Member {
     /// Config passed to `Conversation::join` when this member accepts a welcome
     /// (joiner path) or rejoins.
     pending_config: ConversationConfig,
+    /// When `false`, this member ignores every welcome addressed to it. Models
+    /// an invitee that is in the ratchet tree but has never run the protocol:
+    /// distinct from `mute`, which silences a member that did join.
+    accepts_welcome: bool,
 }
 
 impl Member {
@@ -181,6 +186,7 @@ impl Member {
             inbound_errors: Vec::new(),
             last_sync: None,
             pending_config: config,
+            accepts_welcome: true,
         }
     }
 
@@ -203,6 +209,7 @@ impl Member {
             inbound_errors: Vec::new(),
             last_sync: None,
             pending_config: config,
+            accepts_welcome: true,
         }
     }
 
@@ -423,6 +430,58 @@ impl Member {
             .collect()
     }
 
+    /// Distinct proposals this member has seen that admit `member_id` — its own
+    /// submissions plus peers' surfaced for a vote. Counts `MemberInvite` only:
+    /// a group that outgrows `sn_max` also votes on a steward election, and that
+    /// is not a duplicate invitation.
+    pub fn observed_invite_proposals(&self, member_id: &[u8]) -> Vec<u32> {
+        let invites_target = |req: &ConversationUpdateRequest| {
+            matches!(
+                req.payload.as_ref(),
+                Some(conversation_update_request::Payload::MemberInvite(im))
+                    if im.member_id == member_id
+            )
+        };
+        let mut ids: Vec<u32> = self
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                ConversationEvent::VoteRequested {
+                    proposal_id,
+                    request,
+                }
+                | ConversationEvent::OwnProposalSubmitted {
+                    proposal_id,
+                    request,
+                } if invites_target(request) => Some(*proposal_id),
+                _ => None,
+            })
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
+    /// Member ids added by every commit this member applied, in commit order.
+    /// One entry per `MemberInvite` in the committed batch, so a member added
+    /// twice appears twice.
+    pub fn committed_adds(&self) -> Vec<Vec<u8>> {
+        self.events
+            .iter()
+            .filter_map(|e| match e {
+                ConversationEvent::CommitApplied(reqs) => Some(reqs),
+                _ => None,
+            })
+            .flatten()
+            .filter_map(|r| match r.payload.as_ref() {
+                Some(conversation_update_request::Payload::MemberInvite(im)) => {
+                    Some(im.member_id.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Count of commits this member has applied (membership batches landed).
     pub fn commits_applied(&self) -> usize {
         self.events
@@ -544,6 +603,13 @@ impl Member {
         self.integ.mint_key_package()
     }
 
+    /// Never open a welcome addressed to this member. Its key package still
+    /// mints and still lands in the ratchet tree, so peers count it as a full
+    /// member and a first-class voter — it simply never runs.
+    pub fn withhold_welcome(&mut self) {
+        self.accepts_welcome = false;
+    }
+
     /// Reset this member to a fresh prospective joiner of `conversation_id`
     /// (same identity / keys) — for rejoining after eviction. The conversation
     /// rebuilds from the next welcome.
@@ -621,7 +687,7 @@ impl Member {
     /// from the welcome + bundled sync); `false` for everyone else. Already-
     /// joined members ignore further welcomes.
     fn try_accept_welcome(&mut self, welcome: &MemberWelcome) -> bool {
-        if self.convo.is_some() {
+        if self.convo.is_some() || !self.accepts_welcome {
             return false;
         }
         // The integrator's reused provider holds the minted KP's private keys;
@@ -799,6 +865,29 @@ impl<const N: usize> TestHarness<N> {
         self.members.iter().all(Member::is_working)
     }
 
+    /// Whether every joined member can decrypt a message from `from`.
+    ///
+    /// This is the only available check that tells one group apart from two
+    /// that merely agree on the integers: [`Self::epochs_agree`] compares epoch
+    /// *numbers* and [`Self::membership_agrees`] compares member-id *sets*, and
+    /// both report `true` for members whose epoch secrets have diverged. MLS
+    /// exposes `epoch_authenticator` for exactly this purpose, but de-mls does
+    /// not surface it, so a chat round-trip stands in.
+    ///
+    /// Drives the bus (chat needs relaying), so call it as a terminal
+    /// assertion rather than inside a predicate.
+    pub fn secrets_agree(&mut self, from: usize, probe: &[u8]) -> bool {
+        self.members[from].send_message(probe.to_vec());
+        for _ in 0..20 {
+            self.process(Duration::from_millis(50));
+        }
+        self.members
+            .iter()
+            .enumerate()
+            .filter(|(i, m)| *i != from && m.convo.is_some())
+            .all(|(_, m)| m.got_chat(probe))
+    }
+
     /// Every member sees the same set of MLS members (order-independent).
     pub fn membership_agrees(&self) -> bool {
         let canonical = |m: &Member| {
@@ -845,8 +934,14 @@ impl<const N: usize> TestHarness<N> {
     /// welcome to its joiner.
     fn drain_and_route_welcomes(&mut self) {
         let mut welcomes = Vec::new();
-        for member in &mut self.members {
-            welcomes.append(&mut member.drain_events_collect_welcomes());
+        for (index, member) in self.members.iter_mut().enumerate() {
+            let minted = member.drain_events_collect_welcomes();
+            // A muted member's welcome is dropped like the rest of its
+            // outbound: a welcome is something a member *sends*, so routing it
+            // out of band would let a silenced steward keep seeding joiners.
+            if !self.muted[index] {
+                welcomes.extend(minted);
+            }
         }
         for welcome in &welcomes {
             for member in &mut self.members {

--- a/tests/founding_group.rs
+++ b/tests/founding_group.rs
@@ -248,28 +248,21 @@ fn a_single_silent_founder_and_the_next_add() {
     assert!(!h.member(2).is_working());
 }
 
-/// The creator founds the group, everyone arrives, then the creator — the sole
-/// steward of epoch 1, since nobody else has settled yet — is cut off in a
-/// send-only partition: it still hears proposals, so it still acts as steward
-/// and mints commits, but nothing it sends arrives.
+/// A send-only partition of the sole epoch-1 steward: it still hears proposals,
+/// so it still mints commits, but nothing it sends arrives.
 ///
-/// Two separate things are true, and the second is the reason this test exists.
+/// The guarantee this test pins is recovery — the survivors land the add
+/// without the creator, so a group does not die with its founder.
 ///
-/// The survivors *do* recover: they land the add without the creator, so a
-/// group does not die with the member who founded it. That is the property
-/// that matters for founding.
-///
-/// But the creator merged its own lost commit locally and advanced onto a
-/// branch of its own, and it never rejoins. Both branches report the same epoch
-/// number and the same member set, so `epochs_agree` and `membership_agrees` —
-/// the assertions the rest of the suite converges on — are `true` across a
-/// forked group. Only the epoch secret tells them apart.
-///
-/// The fork itself is a partition-induced divergence (the steward is isolated
-/// past the recovery window), not obviously a protocol defect. The silence is
-/// the finding: nothing in the library or the suite detects it.
+/// Known gap, documented but not asserted: the isolated creator merged its own
+/// lost commit and advanced onto a private branch. Both branches report the
+/// same epoch number and member set — `epochs_agree`/`membership_agrees` can't
+/// tell them apart — and nothing detects the divergence. We assert the recovery
+/// and that integer-level agreement (which is *why* the fork is silent), but
+/// deliberately not that the fork persists: a future fork fix shouldn't have to
+/// fight this test.
 #[test]
-fn survivors_recover_without_the_creator_but_the_creator_forks() {
+fn survivors_recover_when_the_sole_steward_is_partitioned() {
     let mut h = TestHarness::<5>::start(
         [ALICE, BOB, CHARLIE, DAVE, ERIN],
         "offline",
@@ -311,8 +304,11 @@ fn survivors_recover_without_the_creator_but_the_creator_forks() {
     );
     assert!(h.member(4).is_working(), "erin joined without the creator");
 
-    // The creator comes back. Nothing about its return is rejected, flagged,
-    // or repaired.
+    // The creator returns from the partition. Nothing detects or repairs the
+    // divergence: its branch and the survivors' report the same epoch number
+    // and member set even though their epoch secrets differ. That integer-level
+    // agreement is exactly why the fork is silent — assert it (it survives a
+    // future fix), but don't assert the fork itself.
     h.unmute(0);
     for _ in 0..40 {
         h.process(STEP);
@@ -321,9 +317,5 @@ fn survivors_recover_without_the_creator_but_the_creator_forks() {
     assert!(
         h.epochs_agree() && h.membership_agrees(),
         "both branches report the same epoch number and member set"
-    );
-    assert!(
-        !h.secrets_agree(1, b"after the partition"),
-        "yet the creator is on a branch of its own, undetected"
     );
 }

--- a/tests/founding_group.rs
+++ b/tests/founding_group.rs
@@ -1,0 +1,329 @@
+//! Founding a group with members you already hold key packages for.
+//!
+//! These tests pin how the protocol behaves *today* when a creator seeds a
+//! group with several friends at once, before any of them has run. They are
+//! the baseline a "genesis" create-with-members API has to beat, and they
+//! measure two things the rest of the suite never exercises:
+//!
+//! - what the founding adds cost in wall-clock time, on a config whose
+//!   inactivity window is long enough to see (every other test runs
+//!   `fast_config`, where the window is 50 ms and effectively invisible);
+//! - what an invitee who is in the ratchet tree but has never opened its
+//!   welcome does to consensus — `withhold_welcome` models exactly that.
+
+mod common;
+
+use std::time::Duration;
+
+use common::harness::{TestHarness, fast_config};
+use de_mls::{ConversationConfig, StewardListConfig};
+
+const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+const DAVE: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
+const ERIN: &str = "47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a";
+const FRANK: &str = "8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba";
+
+/// One driving step of virtual time.
+const STEP: Duration = Duration::from_millis(50);
+
+/// A config whose commit-inactivity window is long enough to measure, while
+/// every other gate stays sub-second. Preserves the documented ordering
+/// invariant `voting_delay < consensus_timeout < commit_inactivity_duration`.
+fn measurable_commit_window() -> ConversationConfig {
+    ConversationConfig {
+        commit_inactivity_duration: Duration::from_secs(2),
+        freeze_duration: Duration::from_millis(20),
+        voting_delay: Duration::from_millis(30),
+        election_voting_delay: Duration::from_millis(30),
+        consensus_timeout: Duration::from_millis(150),
+        proposal_expiration: Duration::from_secs(10),
+        ..ConversationConfig::default()
+    }
+}
+
+/// Drive until `predicate` holds, returning the virtual time it took. Unlike
+/// `process_until` this reports elapsed time rather than discarding it.
+fn drive_for<const N: usize>(
+    h: &mut TestHarness<N>,
+    label: &str,
+    budget: Duration,
+    predicate: impl Fn(&TestHarness<N>) -> bool,
+) -> Duration {
+    let mut elapsed = Duration::ZERO;
+    while !predicate(h) {
+        assert!(elapsed < budget, "never converged: {label}");
+        h.process(STEP);
+        elapsed += STEP;
+    }
+    elapsed
+}
+
+/// The creator seeds three friends at epoch 0, before any of them has run.
+/// Pins that they batch into a single commit and a single welcome — and that
+/// the whole group still waits one full commit-inactivity window for a commit
+/// a one-member group already unanimously agreed with itself about.
+#[test]
+fn founding_adds_batch_into_one_commit_after_one_inactivity_window() {
+    let config = measurable_commit_window();
+    let mut h = TestHarness::<4>::start(
+        [ALICE, BOB, CHARLIE, DAVE],
+        "found",
+        config.clone(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    assert_eq!(h.member(0).epoch(), 0, "nothing has committed yet");
+    assert_eq!(h.member(0).member_count(), 1, "the creator is alone");
+
+    let landed_at = drive_for(
+        &mut h,
+        "founding commit lands",
+        Duration::from_secs(10),
+        |h| h.member(0).commits_applied() == 1,
+    );
+
+    assert!(
+        landed_at >= config.commit_inactivity_duration,
+        "the founding commit waited a full inactivity window ({:?}), landed at {landed_at:?}",
+        config.commit_inactivity_duration,
+    );
+
+    let welcomes = h.member(0).welcome_readys();
+    assert_eq!(welcomes.len(), 1, "all three adds mint exactly one welcome");
+    assert_eq!(
+        welcomes[0].0.joiner_identities.len(),
+        3,
+        "the single welcome addresses all three friends"
+    );
+
+    drive_for(
+        &mut h,
+        "friends open their welcomes",
+        Duration::from_secs(10),
+        |h| h.all_working(),
+    );
+
+    assert_eq!(h.member(0).epoch(), 1, "one commit, one epoch");
+    assert_eq!(h.member(0).member_count(), 4, "the group is whole");
+    assert_eq!(
+        h.member(0).commits_applied(),
+        1,
+        "three adds cost exactly one commit"
+    );
+    assert!(h.epochs_agree() && h.membership_agrees());
+}
+
+/// Immediately after the founding commit, the freshly-added friends are not
+/// yet settled, so the creator remains the sole steward for the whole of
+/// epoch 1. Pins the property a genesis path would change by marking founders
+/// settled — and shows the creator's epoch-1 stewardship is a *consequence* of
+/// the settled rule, not a guarantee of creation.
+#[test]
+fn founders_are_not_stewards_in_the_epoch_they_arrive() {
+    let mut h = TestHarness::<4>::start(
+        [ALICE, BOB, CHARLIE, DAVE],
+        "settle",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    drive_for(
+        &mut h,
+        "founding commit lands",
+        Duration::from_secs(10),
+        |h| h.all_working() && h.member(0).member_count() == 4,
+    );
+
+    assert_eq!(h.member(0).epoch(), 1);
+    assert!(
+        h.member(0).is_epoch_steward(),
+        "the creator stewards epoch 1 alone"
+    );
+    for i in 1..4 {
+        assert!(
+            !h.member(i).is_steward(),
+            "member {i} joined at epoch 1 and is not settled, so not a steward"
+        );
+    }
+}
+
+/// Five members in the tree, four of whom have never run. The creator adds a
+/// sixth. Pins what the four silent leaves contribute to that vote.
+#[test]
+fn silent_founders_are_counted_as_voters_on_the_next_add() {
+    let mut h = TestHarness::<6>::start(
+        [ALICE, BOB, CHARLIE, DAVE, ERIN, FRANK],
+        "ghost",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    // Four friends land in the tree but never open their welcome.
+    for i in 1..5 {
+        h.member_mut(i).withhold_welcome();
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    drive_for(
+        &mut h,
+        "founding commit lands",
+        Duration::from_secs(10),
+        |h| h.member(0).member_count() == 5,
+    );
+
+    for i in 1..5 {
+        assert!(!h.member(i).is_working(), "member {i} never ran");
+    }
+    assert!(
+        h.member(0).is_epoch_steward(),
+        "the creator is the only member who can commit"
+    );
+
+    // Frank is a real joiner: the creator proposes him with four of five
+    // expected voters permanently silent.
+    let frank_kp = h.member_mut(5).mint_key_package();
+    h.member_mut(0).add_member(&frank_kp);
+
+    let outcome = drive_for(
+        &mut h,
+        "frank's add resolves either way",
+        Duration::from_secs(10),
+        |h| h.member(5).is_working() || h.member(0).epoch() > 1,
+    );
+
+    assert!(
+        h.member(5).is_working(),
+        "frank joined at {outcome:?} — four members who never ran consented for him"
+    );
+    assert_eq!(h.member(0).member_count(), 6);
+}
+
+/// The two-person case: me and one friend who never opens the welcome. Pins
+/// what the pair can still do — the most common real-world founding shape.
+#[test]
+fn a_single_silent_founder_and_the_next_add() {
+    let mut h = TestHarness::<3>::start(
+        [ALICE, BOB, CHARLIE],
+        "pair",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    h.member_mut(1).withhold_welcome();
+    let bob_kp = h.member_mut(1).mint_key_package();
+    h.member_mut(0).add_member(&bob_kp);
+    drive_for(
+        &mut h,
+        "bob lands in the tree",
+        Duration::from_secs(10),
+        |h| h.member(0).member_count() == 2,
+    );
+    assert!(!h.member(1).is_working(), "bob never opened his welcome");
+
+    let charlie_kp = h.member_mut(2).mint_key_package();
+    h.member_mut(0).add_member(&charlie_kp);
+
+    // Drive well past consensus_timeout so a timeout resolution has landed.
+    let mut elapsed = Duration::ZERO;
+    while elapsed < Duration::from_secs(3) {
+        h.process(STEP);
+        elapsed += STEP;
+    }
+
+    assert_eq!(
+        h.member(0).member_count(),
+        2,
+        "charlie never lands: one silent member of two vetoes by silence"
+    );
+    assert!(!h.member(2).is_working());
+}
+
+/// The creator founds the group, everyone arrives, then the creator — the sole
+/// steward of epoch 1, since nobody else has settled yet — is cut off in a
+/// send-only partition: it still hears proposals, so it still acts as steward
+/// and mints commits, but nothing it sends arrives.
+///
+/// Two separate things are true, and the second is the reason this test exists.
+///
+/// The survivors *do* recover: they land the add without the creator, so a
+/// group does not die with the member who founded it. That is the property
+/// that matters for founding.
+///
+/// But the creator merged its own lost commit locally and advanced onto a
+/// branch of its own, and it never rejoins. Both branches report the same epoch
+/// number and the same member set, so `epochs_agree` and `membership_agrees` —
+/// the assertions the rest of the suite converges on — are `true` across a
+/// forked group. Only the epoch secret tells them apart.
+///
+/// The fork itself is a partition-induced divergence (the steward is isolated
+/// past the recovery window), not obviously a protocol defect. The silence is
+/// the finding: nothing in the library or the suite detects it.
+#[test]
+fn survivors_recover_without_the_creator_but_the_creator_forks() {
+    let mut h = TestHarness::<5>::start(
+        [ALICE, BOB, CHARLIE, DAVE, ERIN],
+        "offline",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    drive_for(
+        &mut h,
+        "founding commit lands",
+        Duration::from_secs(10),
+        |h| h.member(0).member_count() == 4 && h.members()[..4].iter().all(|m| m.is_working()),
+    );
+    assert_eq!(h.member(0).epoch(), 1);
+    assert!(h.member(0).is_epoch_steward(), "creator stewards epoch 1");
+    assert!(
+        h.secrets_agree(0, b"before the partition"),
+        "the founded group is one group to begin with"
+    );
+
+    h.mute(0);
+
+    let erin_kp = h.member_mut(4).mint_key_package();
+    h.member_mut(1).add_member(&erin_kp);
+
+    let recovered_at = drive_for(
+        &mut h,
+        "the survivors land a commit without their creator",
+        Duration::from_secs(25),
+        |h| h.member(1).member_count() == 5,
+    );
+    assert!(
+        h.member(1).epoch() > 1,
+        "the survivors advanced the epoch on their own at {recovered_at:?}"
+    );
+    assert!(h.member(4).is_working(), "erin joined without the creator");
+
+    // The creator comes back. Nothing about its return is rejected, flagged,
+    // or repaired.
+    h.unmute(0);
+    for _ in 0..40 {
+        h.process(STEP);
+    }
+
+    assert!(
+        h.epochs_agree() && h.membership_agrees(),
+        "both branches report the same epoch number and member set"
+    );
+    assert!(
+        !h.secrets_agree(1, b"after the partition"),
+        "yet the creator is on a branch of its own, undetected"
+    );
+}

--- a/tests/protocol_membership.rs
+++ b/tests/protocol_membership.rs
@@ -11,6 +11,8 @@ use de_mls::{ConversationState, StewardListConfig};
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+const DAVE: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
+const ERIN: &str = "47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a";
 
 #[test]
 fn three_members_join_and_converge() {
@@ -106,5 +108,129 @@ fn welcome_fans_out_to_every_member_with_a_single_minter() {
     assert!(
         h.epochs_agree() && h.membership_agrees(),
         "the group reconverges after charlie joins"
+    );
+}
+
+/// A plain member inviting someone with `add_member` must cost exactly one
+/// proposal.
+///
+/// `add_member` is an invitation — the caller already holds the joiner's key
+/// package — and is distinct from `sponsor_member`, which relays a join request
+/// announced on the group's channel. But every member mirrors each membership
+/// proposal it sees into `pending_updates`, the backup buffer whose job is to
+/// retry an add that never landed. The epoch steward drains that buffer
+/// immediately, and the drain skips only targets that already carry an
+/// *approved* proposal — not one still in flight. So the steward re-proposes an
+/// invitation that is already being voted on, doubling the consensus traffic and
+/// putting two Adds for one member into the commit batch.
+///
+/// Four members is the smallest group that shows it, and the size is load-bearing:
+/// `poll` runs `tick_deadlines` before the buffer drain, so at three members the
+/// steward's own auto-vote completes the `ceil(2n/3) = 2` quorum inside the same
+/// poll and the drain correctly sees an approved proposal. From four members up,
+/// quorum needs a vote that has not been relayed yet, the drain sees nothing
+/// approved, and it re-proposes.
+#[test]
+fn non_steward_add_member_costs_exactly_one_proposal() {
+    let mut h = TestHarness::<5>::start(
+        [ALICE, BOB, CHARLIE, DAVE, ERIN],
+        "one-prop",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    h.process_until("founding commit lands", |h| {
+        h.member(0).member_count() == 4 && h.members()[..4].iter().all(|m| m.is_working())
+    });
+    assert!(
+        !h.member(1).is_steward(),
+        "bob must be a plain member for this to test the non-steward path"
+    );
+
+    let erin_kp = h.member_mut(4).mint_key_package();
+    let erin_id = erin_kp.member_id().to_vec();
+    h.member_mut(1).add_member(&erin_kp);
+    h.process_until("erin joins", |h| h.member(4).is_working());
+
+    for i in 0..4 {
+        let seen = h.member(i).observed_invite_proposals(&erin_id).len();
+        assert_eq!(
+            seen, 1,
+            "member {i} saw {seen} proposals for a single invitation"
+        );
+    }
+    assert_eq!(
+        h.member(0)
+            .committed_adds()
+            .iter()
+            .filter(|id| **id == erin_id)
+            .count(),
+        1,
+        "erin is added exactly once"
+    );
+}
+
+/// An invitation and a sponsored join request can name the same member at the
+/// same time: bob holds erin's key package and invites her (RFC step 5, "any
+/// member start to create voting proposals"), while erin also publishes a key
+/// package that the steward turns into its own proposal (RFC step 3, "upon
+/// receipt, the steward MUST initiate a voting proposal"). Neither node can see
+/// the other's proposal before creating its own, so both reach consensus.
+///
+/// The two invites carry different key packages, so — unlike two duplicate
+/// removals, which are byte-identical and collapse into one MLS proposal — they
+/// become two Adds for one leaf, and MLS rejects the whole commit with
+/// "Duplicate signature key in proposals and group". The steward retries and
+/// fails identically every round, so the group stops admitting anyone at all.
+#[test]
+fn invitation_racing_a_sponsored_join_admits_the_member_once() {
+    let mut h = TestHarness::<5>::start(
+        [ALICE, BOB, CHARLIE, DAVE, ERIN],
+        "race",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    h.process_until("founding commit lands", |h| {
+        h.member(0).member_count() == 4 && h.members()[..4].iter().all(|m| m.is_working())
+    });
+    let epoch_before = h.member(0).epoch();
+
+    // Two key packages for erin, proposed by two different members.
+    let invited_kp = h.member_mut(4).mint_key_package();
+    let erin_id = invited_kp.member_id().to_vec();
+    let announced_kp = h.member_mut(4).announce_key_package("race");
+
+    h.deliver_key_package_to(0, &announced_kp); // steward sponsors the request
+    h.member_mut(1).add_member(&invited_kp); // bob invites her in parallel
+
+    h.process_until("erin joins despite the racing invites", |h| {
+        h.member(4).is_working()
+    });
+
+    assert_eq!(
+        h.member(0)
+            .committed_adds()
+            .iter()
+            .filter(|id| **id == erin_id)
+            .count(),
+        1,
+        "erin is admitted exactly once"
+    );
+    assert_eq!(h.member(0).member_count(), 5, "the group grew by one");
+    assert!(
+        h.member(0).epoch() > epoch_before,
+        "the round committed rather than stalling"
+    );
+    assert!(h.epochs_agree() && h.membership_agrees());
+    assert!(
+        h.secrets_agree(1, b"after the race"),
+        "the group stays one group"
     );
 }

--- a/tests/protocol_membership.rs
+++ b/tests/protocol_membership.rs
@@ -234,3 +234,50 @@ fn invitation_racing_a_sponsored_join_admits_the_member_once() {
         "the group stays one group"
     );
 }
+
+/// The same node proposing one joiner twice — with different key packages, so
+/// the two requests don't collide on their content-derived proposal id — must
+/// open exactly one consensus session. The local in-flight dedup at proposal
+/// initiation catches the second; without it, a redundant session runs and is
+/// only cleaned up at approval.
+#[test]
+fn repeated_add_for_one_joiner_opens_one_proposal() {
+    let mut h = TestHarness::<5>::start(
+        [ALICE, BOB, CHARLIE, DAVE, ERIN],
+        "double-add",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    for i in 1..4 {
+        let kp = h.member_mut(i).mint_key_package();
+        h.member_mut(0).add_member(&kp);
+    }
+    h.process_until("founding commit lands", |h| {
+        h.member(0).member_count() == 4 && h.members()[..4].iter().all(|m| m.is_working())
+    });
+
+    let erin_kp_a = h.member_mut(4).mint_key_package();
+    let erin_id = erin_kp_a.member_id().to_vec();
+    let erin_kp_b = h.member_mut(4).mint_key_package();
+
+    // Two proposals for erin, back to back, before any poll resolves the first.
+    h.member_mut(0).add_member(&erin_kp_a);
+    h.member_mut(0).add_member(&erin_kp_b);
+
+    h.process_until("erin joins", |h| h.member(4).is_working());
+
+    assert_eq!(
+        h.member(0).observed_invite_proposals(&erin_id).len(),
+        1,
+        "a repeated add for one joiner opens exactly one proposal"
+    );
+    assert_eq!(
+        h.member(0)
+            .committed_adds()
+            .iter()
+            .filter(|id| **id == erin_id)
+            .count(),
+        1,
+        "erin is added once"
+    );
+}


### PR DESCRIPTION
Fixes a set of proposal-lifecycle bugs that could permanently stall a group, and simplifies the voting-queue architecture that hid them.

An invitation and a sponsored join can admit the same member with different key packages; MLS then rejects the whole commit and the round retries forever. These are now deduped by target at approval, and a repeated proposal for one member is also caught locally at initiation.

A commit-candidate mint that fails (e.g. a malformed key package) was logged and swallowed, stalling the round with no signal to the integrator. It now surfaces as a `ConversationEvent::Error`.

The voting queue becomes an index over consensus storage rather than a second copy of each request, and proposal-ownership tracking is removed — every proposal is handled identically, own or peer. Score-removal dedup folds into the same index, closing a blind spot where an in-flight score-removal was invisible for its whole voting window.

Adds founding-group behavior tests, membership regressions, and a partitioned-steward recovery test with harness helpers for silent-member scenarios.

Known gap: a send-only partition of a sole steward still forks the group undetected. It's documented by the recovery test and is the target of follow-up work (detection via `epoch_authenticator` plus app-driven recovery), not addressed here.
