### PR TITLE
feat: expose epoch_authenticator for fork detection

### DIFF
--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -41,6 +41,13 @@ where
         Ok((epoch, self.services.steward_list.next_election_round()))
     }
 
+    /// This member's epoch authenticator for the current epoch. Compared at the
+    /// same epoch number, a mismatch across members is a fork; a match is real
+    /// convergence. Pair with [`Self::epoch_and_retry`] to compare like epochs.
+    pub fn epoch_authenticator(&self) -> Vec<u8> {
+        self.mls().epoch_authenticator().to_vec()
+    }
+
     /// Count of buffered pending membership updates. Used by tests and the UI
     /// to verify buffer hygiene (e.g., that a joiner's buffer is empty right
     /// after they receive the welcome).

--- a/src/mls_crypto/service.rs
+++ b/src/mls_crypto/service.rs
@@ -169,6 +169,15 @@ impl MlsService {
         Ok(self.group.epoch().as_u64())
     }
 
+    /// MLS epoch authenticator — a secret-derived tag identifying this group's
+    /// exact state at the current epoch. Two members at the same epoch number
+    /// with different authenticators have diverged (forked); identical
+    /// authenticators confirm the same state. The one value that tells a real
+    /// convergence apart from two branches that merely share an epoch count.
+    pub fn epoch_authenticator(&self) -> &[u8] {
+        self.group.epoch_authenticator().as_slice()
+    }
+
     // Extensions configured for the MlsGroup
     pub fn extensions(&self) -> &Extensions<GroupContext> {
         self.group.extensions()

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -345,6 +345,14 @@ impl Member {
             .unwrap_or(0)
     }
 
+    /// This member's epoch authenticator, or empty if it hasn't joined.
+    pub fn epoch_authenticator(&self) -> Vec<u8> {
+        self.convo
+            .as_ref()
+            .map(|c| c.epoch_authenticator())
+            .unwrap_or_default()
+    }
+
     pub fn member_count(&self) -> usize {
         self.convo
             .as_ref()
@@ -865,27 +873,21 @@ impl<const N: usize> TestHarness<N> {
         self.members.iter().all(Member::is_working)
     }
 
-    /// Whether every joined member can decrypt a message from `from`.
+    /// Every joined member shares the same epoch *and* the same epoch
+    /// authenticator — the real convergence check.
     ///
-    /// This is the only available check that tells one group apart from two
-    /// that merely agree on the integers: [`Self::epochs_agree`] compares epoch
-    /// *numbers* and [`Self::membership_agrees`] compares member-id *sets*, and
-    /// both report `true` for members whose epoch secrets have diverged. MLS
-    /// exposes `epoch_authenticator` for exactly this purpose, but de-mls does
-    /// not surface it, so a chat round-trip stands in.
-    ///
-    /// Drives the bus (chat needs relaying), so call it as a terminal
-    /// assertion rather than inside a predicate.
-    pub fn secrets_agree(&mut self, from: usize, probe: &[u8]) -> bool {
-        self.members[from].send_message(probe.to_vec());
-        for _ in 0..20 {
-            self.process(Duration::from_millis(50));
-        }
-        self.members
-            .iter()
-            .enumerate()
-            .filter(|(i, m)| *i != from && m.convo.is_some())
-            .all(|(_, m)| m.got_chat(probe))
+    /// [`Self::epochs_agree`] compares epoch *numbers* and
+    /// [`Self::membership_agrees`] compares member-id *sets*, and both report
+    /// `true` across a forked group whose branches share an epoch and roster
+    /// but hold different epoch secrets. The authenticator is the value that
+    /// tells them apart, so this is the check that actually detects a fork.
+    pub fn converged(&self) -> bool {
+        let mut joined = self.members.iter().filter(|m| m.convo.is_some());
+        let Some(first) = joined.next() else {
+            return true;
+        };
+        let key = (first.epoch(), first.epoch_authenticator());
+        joined.all(|m| (m.epoch(), m.epoch_authenticator()) == key)
     }
 
     /// Every member sees the same set of MLS members (order-independent).

--- a/tests/founding_group.rs
+++ b/tests/founding_group.rs
@@ -283,7 +283,7 @@ fn survivors_recover_when_the_sole_steward_is_partitioned() {
     assert_eq!(h.member(0).epoch(), 1);
     assert!(h.member(0).is_epoch_steward(), "creator stewards epoch 1");
     assert!(
-        h.secrets_agree(0, b"before the partition"),
+        h.converged(),
         "the founded group is one group to begin with"
     );
 
@@ -304,11 +304,10 @@ fn survivors_recover_when_the_sole_steward_is_partitioned() {
     );
     assert!(h.member(4).is_working(), "erin joined without the creator");
 
-    // The creator returns from the partition. Nothing detects or repairs the
-    // divergence: its branch and the survivors' report the same epoch number
-    // and member set even though their epoch secrets differ. That integer-level
-    // agreement is exactly why the fork is silent — assert it (it survives a
-    // future fix), but don't assert the fork itself.
+    // The creator returns from the partition. Nothing repairs the divergence:
+    // its branch and the survivors' report the same epoch number and member set
+    // even though their epoch secrets differ — which is exactly why the fork
+    // was silent before we surfaced the authenticator.
     h.unmute(0);
     for _ in 0..40 {
         h.process(STEP);
@@ -316,6 +315,15 @@ fn survivors_recover_when_the_sole_steward_is_partitioned() {
 
     assert!(
         h.epochs_agree() && h.membership_agrees(),
-        "both branches report the same epoch number and member set"
+        "the integer views match — the reason the fork went unnoticed"
+    );
+    // The capability this slice adds: the authenticator catches the divergence
+    // the integer checks miss. This assertion is the fork's canary — when
+    // prevention or auto-rejoin lands, this scenario stops forking and the
+    // assertion flips to `converged()`. That break is the signal to update the
+    // test, not a regression.
+    assert!(
+        !h.converged(),
+        "the epoch authenticators diverge — the fork the counts can't see"
     );
 }

--- a/tests/protocol_membership.rs
+++ b/tests/protocol_membership.rs
@@ -229,10 +229,7 @@ fn invitation_racing_a_sponsored_join_admits_the_member_once() {
         "the round committed rather than stalling"
     );
     assert!(h.epochs_agree() && h.membership_agrees());
-    assert!(
-        h.secrets_agree(1, b"after the race"),
-        "the group stays one group"
-    );
+    assert!(h.converged(), "the group stays one group");
 }
 
 /// The same node proposing one joiner twice — with different key packages, so


### PR DESCRIPTION
Surfaces the MLS epoch authenticator on the conversation handle so a fork becomes detectable: two members at the same epoch with different authenticators have diverged, where the epoch number and member set alone report converged.

Read-only passthrough — `MlsGroup` already exposes it; `MlsService` and `Conversation` forward it. No timers, state, or wire changes.

Tests replace the chat-round-trip `secrets_agree` stand-in with `converged()`, a direct `(epoch, authenticator)` comparison. The partitioned-steward test now asserts the fork is detectable — a marked canary that flips to `converged()` when prevention or auto-rejoin lands, which is the intended signal to update it.

This is the one de-mls primitive the follow-up recovery work needs. The plaintext state/probe message, a `Diverged` event, and the liveness-timer restructure are being prototyped in the POC first and promoted later.
