### PR TITLE
feat: create_with_members founds a group with initial members

### DIFF
--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -20,8 +20,10 @@ use hashgraph_like_consensus::{events::ConsensusEventBus, service::ConsensusServ
 use crate::{
     ConsensusPlugin, Conversation, ConversationConfig, ConversationError, ConversationEvent,
     ConversationQueues, ConversationServices, ConversationStateMachine, PeerScoreStorage,
-    PeerScoringService, StewardListService, WallClock, consensus::outcome_bus::OutcomeBus,
-    mls_crypto::MlsService,
+    PeerScoringService, StewardListService, WallClock,
+    consensus::outcome_bus::OutcomeBus,
+    mls_crypto::{MlsCommitInput, MlsService},
+    protos::de_mls::messages::v1::MemberWelcome,
 };
 
 impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
@@ -74,6 +76,122 @@ where
             true,
             member_id,
         )
+    }
+
+    /// Create a conversation you steward, seeded with an initial set of members
+    /// at genesis. Like [`Self::create`], but the founders' key packages are
+    /// admitted in one commit at creation: the group opens at epoch 1 already
+    /// holding every founder, and their single welcome is emitted as a
+    /// [`ConversationEvent::WelcomeReady`] for the caller to drain and deliver.
+    /// Unlike a later `add_member`, this needs no consensus round and no
+    /// commit-inactivity wait — genesis is the creator's unilateral seed — and
+    /// the founders are settled from epoch 1, so they can steward it.
+    ///
+    /// `founders` are `(member_id, key_package_bytes)` pairs the caller already
+    /// holds; each founder's private keys must live in the provider it later
+    /// borrows to open its welcome.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_with_members<Pr>(
+        conversation_id: &str,
+        member_id: &[u8],
+        provider: &Pr,
+        credential: CredentialWithKey,
+        group_config: &MlsGroupCreateConfig,
+        signer: &impl Signer,
+        consensus: &Cp,
+        scoring: PeerScoringService<Sc>,
+        clock: Wc,
+        app_id: Arc<[u8]>,
+        config: ConversationConfig,
+        founders: &[(&[u8], &[u8])],
+    ) -> Result<Self, ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        let mut conversation = Self::create(
+            conversation_id,
+            member_id,
+            provider,
+            credential,
+            group_config,
+            signer,
+            consensus,
+            scoring,
+            clock,
+            app_id,
+            config,
+        )?;
+        conversation.seed_founders(provider, signer, founders)?;
+        Ok(conversation)
+    }
+
+    /// Admit the founders in one genesis commit: build the batched add, merge it
+    /// inline (no proposal, vote, or freeze), install the steward list over the
+    /// new settled roster, and deliver the single welcome. Founders' join epochs
+    /// are left unrecorded, so they are settled — and steward-eligible — from
+    /// epoch 1.
+    fn seed_founders<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+        founders: &[(&[u8], &[u8])],
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        if founders.is_empty() {
+            return Ok(());
+        }
+        let updates: Vec<MlsCommitInput> = founders
+            .iter()
+            .map(|(_, kp)| MlsCommitInput::Add(kp.to_vec()))
+            .collect();
+        let joiner_identities: Vec<Vec<u8>> = founders.iter().map(|(id, _)| id.to_vec()).collect();
+
+        // Genesis is the creator's unilateral seed: build the batched add-commit
+        // and merge it inline, skipping the consensus/freeze lifecycle.
+        let artifacts = self
+            .services
+            .mls
+            .create_commit_candidate(provider, signer, &updates)?;
+        self.services.mls.merge_own_commit(provider)?;
+
+        // Score the founders and install the steward list over the settled
+        // roster at the merged epoch. `install_list` sorts and takes the top-sn,
+        // so this handles a subset founding group deterministically too.
+        for (id, _) in founders {
+            self.services.scoring.add_member(id)?;
+        }
+        let (epoch, members) = {
+            let mls = self.mls();
+            (mls.current_epoch()?, mls.members()?)
+        };
+        let settled = self.queues.settled_members(&members, epoch);
+        let sn = self
+            .services
+            .steward_list
+            .config()
+            .compute_list_size(settled.len());
+        self.services
+            .steward_list
+            .install_list(epoch, &settled, sn, 0)?;
+
+        // Deliver the single welcome: attach the ConversationSync, emit
+        // WelcomeReady, and broadcast it for relay.
+        if let Some(welcome_bytes) = artifacts.welcome {
+            self.deliver_welcome(
+                provider,
+                signer,
+                MemberWelcome {
+                    welcome_bytes,
+                    conversation_sync_bytes: Vec::new(),
+                    joiner_identities,
+                },
+            );
+        }
+        Ok(())
     }
 
     /// Build a fully-joined conversation from a welcome: the library opens the

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -368,7 +368,7 @@ where
     /// propagates — the commit merged, so a sync-build failure surfaces a
     /// [`ConversationEvent::Error`] and ships `welcome_bytes` with empty sync
     /// (the joiner attaches to MLS without it).
-    fn deliver_welcome<Pr>(
+    pub(crate) fn deliver_welcome<Pr>(
         &mut self,
         provider: &Pr,
         signer: &impl Signer,

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -16,7 +16,7 @@ use openmls::credentials::CredentialWithKey;
 use openmls_basic_credential::SignatureKeyPair;
 
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
-use de_mls::{Conversation, ConversationState, MockClock};
+use de_mls::{Conversation, ConversationState, MockClock, StewardListConfig};
 use de_mls::{ConversationEvent, ScoringConfig};
 
 use common::{
@@ -31,6 +31,8 @@ type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreSt
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+const DAVE: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
 /// The shared, conversation-agnostic state an integrator keeps once: its
 /// credential + signer, the consensus backend, the identity, and one OpenMLS
@@ -232,4 +234,181 @@ fn join_completes_in_one_call() {
     assert_eq!(joined.members().expect("members").len(), 2);
     let (epoch, _) = joined.epoch_and_retry().expect("epoch");
     assert_eq!(epoch, 1, "joiner lands on the post-add epoch");
+}
+
+/// `create_with_members` seeds the founders at genesis: the group opens at
+/// epoch 1 already whole, mints one welcome for all founders, and marks them
+/// settled — so they steward epoch 1. No polling, no commit-inactivity wait.
+#[test]
+fn create_with_members_seeds_founders_at_genesis() {
+    let alice = Integrator::new();
+    let bob = Integrator::with_key(BOB);
+    let charlie = Integrator::with_key(CHARLIE);
+
+    // The founders mint their key packages into their own providers and hand the
+    // bytes to the creator.
+    let bob_kp = bob.mint_key_package();
+    let charlie_kp = charlie.mint_key_package();
+
+    let config = de_mls::ConversationConfig {
+        steward_list: StewardListConfig::new(1, 5).unwrap(),
+        ..fast_config()
+    };
+
+    let creator: TestConversation = Conversation::create_with_members(
+        "genesis",
+        alice.member_id.member_id_bytes(),
+        &alice.provider,
+        alice.credential.clone(),
+        &test_mls_group_config(),
+        &alice.signer,
+        &alice.consensus,
+        alice.scoring(),
+        alice.clock.clone(),
+        alice.app_id(),
+        config.clone(),
+        &[
+            (bob_kp.member_id(), bob_kp.as_bytes()),
+            (charlie_kp.member_id(), charlie_kp.as_bytes()),
+        ],
+    )
+    .expect("create with members");
+
+    // Genesis is immediate: at epoch 1 with all three members, no polling.
+    let (epoch, _) = creator.epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 1, "the founding commit landed at creation");
+    assert_eq!(creator.members().expect("members").len(), 3);
+    assert_eq!(creator.state(), ConversationState::Working);
+    assert!(
+        creator.is_steward(),
+        "the creator stewards the genesis epoch"
+    );
+
+    // Exactly one welcome, addressing both founders.
+    let welcome = creator
+        .drain_events()
+        .into_iter()
+        .find_map(|e| match e {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally: true,
+            } => Some(welcome),
+            _ => None,
+        })
+        .expect("genesis mints one welcome");
+    assert_eq!(
+        welcome.joiner_identities.len(),
+        2,
+        "one welcome admits both founders"
+    );
+
+    // Each founder opens the single welcome and lands at epoch 1, Working, and a
+    // steward — the property genesis beats the incremental baseline on.
+    for founder in [&bob, &charlie] {
+        let joined: TestConversation = Conversation::join(
+            founder.member_id.member_id_bytes(),
+            &founder.provider,
+            &founder.signer,
+            &welcome.welcome_bytes,
+            &welcome.conversation_sync_bytes,
+            &founder.consensus,
+            founder.scoring(),
+            founder.clock.clone(),
+            founder.app_id(),
+            config.clone(),
+        )
+        .expect("join")
+        .expect("welcome addresses the founder");
+        assert_eq!(joined.id(), "genesis");
+        assert_eq!(joined.state(), ConversationState::Working);
+        assert_eq!(joined.members().expect("members").len(), 3);
+        let (e, _) = joined.epoch_and_retry().expect("epoch");
+        assert_eq!(e, 1, "founder lands on the genesis epoch");
+        assert!(joined.is_steward(), "a founder stewards the genesis epoch");
+    }
+}
+
+/// A founding group larger than `sn_max`: genesis installs a deterministic
+/// subset steward list, and every founder lands on the same one.
+#[test]
+fn create_with_members_founds_a_subset_steward_group() {
+    let alice = Integrator::new();
+    let bob = Integrator::with_key(BOB);
+    let charlie = Integrator::with_key(CHARLIE);
+    let dave = Integrator::with_key(DAVE);
+
+    let bob_kp = bob.mint_key_package();
+    let charlie_kp = charlie.mint_key_package();
+    let dave_kp = dave.mint_key_package();
+
+    // sn_max = 2 with 4 members → the steward list is a genuine 2-of-4 subset.
+    let config = de_mls::ConversationConfig {
+        steward_list: StewardListConfig::new(1, 2).unwrap(),
+        ..fast_config()
+    };
+
+    let creator: TestConversation = Conversation::create_with_members(
+        "genesis-subset",
+        alice.member_id.member_id_bytes(),
+        &alice.provider,
+        alice.credential.clone(),
+        &test_mls_group_config(),
+        &alice.signer,
+        &alice.consensus,
+        alice.scoring(),
+        alice.clock.clone(),
+        alice.app_id(),
+        config.clone(),
+        &[
+            (bob_kp.member_id(), bob_kp.as_bytes()),
+            (charlie_kp.member_id(), charlie_kp.as_bytes()),
+            (dave_kp.member_id(), dave_kp.as_bytes()),
+        ],
+    )
+    .expect("create with members");
+
+    let (epoch, _) = creator.epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 1);
+    assert_eq!(creator.members().expect("members").len(), 4);
+
+    let welcome = creator
+        .drain_events()
+        .into_iter()
+        .find_map(|e| match e {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally: true,
+            } => Some(welcome),
+            _ => None,
+        })
+        .expect("genesis mints one welcome");
+    assert_eq!(welcome.joiner_identities.len(), 3);
+
+    let mut convos = vec![creator];
+    for founder in [&bob, &charlie, &dave] {
+        let joined: TestConversation = Conversation::join(
+            founder.member_id.member_id_bytes(),
+            &founder.provider,
+            &founder.signer,
+            &welcome.welcome_bytes,
+            &welcome.conversation_sync_bytes,
+            &founder.consensus,
+            founder.scoring(),
+            founder.clock.clone(),
+            founder.app_id(),
+            config.clone(),
+        )
+        .expect("join")
+        .expect("welcome addresses the founder");
+        assert_eq!(joined.members().expect("members").len(), 4);
+        convos.push(joined);
+    }
+
+    // Exactly two of the four members steward — the deterministic 2-of-4 subset
+    // the genesis install picked, seen consistently through the shared sync.
+    let steward_count = convos.iter().filter(|c| c.is_steward()).count();
+    assert_eq!(
+        steward_count, 2,
+        "sn_max = 2 founds a 2-member steward subset"
+    );
 }


### PR DESCRIPTION
`Conversation::create_with_members` founds a group with an initial set of members in one step. The creator supplies the founders' key packages, and creation admits them in a single genesis commit: the group opens at epoch 1 already whole, mints one welcome addressing all founders, and marks them settled so they steward epoch 1 — with no consensus round and no commit-inactivity wait. Genesis is the creator's unilateral seed, so it skips the proposal/vote/freeze lifecycle a later `add_member` runs.

It reuses the existing batched add-commit path (`create_commit_candidate` / `merge_own_commit`) plus a deterministic steward-list install that also handles a founding group larger than `sn_max` (a real subset).

Two standalone tests cover the base case (founders settled + stewarding, one welcome) and the subset case (`sn_max = 2`, 4 members → a 2-of-4 steward subset).
