### PR TITLE
fix(steward): mint commit candidates uniformly, no backup stagger

### DIFF
--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -564,16 +564,8 @@ where
             || self.timing.reelection_recovered;
         let inactivity = if in_recovery {
             self.config.recovery_inactivity_duration
-        } else if self.is_epoch_steward()? {
-            // The primary steward leads: it commits at the commit-inactivity
-            // deadline.
-            self.config.commit_inactivity_duration
         } else {
-            // Backups (and non-stewards) wait an extra recovery window. In the
-            // normal case the primary's commit candidate pulls them into freeze
-            // first, so they never self-drive it; only a silent primary lets
-            // this longer deadline fire and a backup step in.
-            self.config.commit_inactivity_duration + self.config.recovery_inactivity_duration
+            self.config.commit_inactivity_duration
         };
         let Some(event) = self.check_steward_inactivity(proposal_count, inactivity) else {
             return Ok(());


### PR DESCRIPTION
The commit-inactivity deadline branched on `is_epoch_steward`, so a backup steward waited an extra `recovery_inactivity` window before minting its candidate — contradicting the all-stewards-mint model.

Every steward now mints at `commit_inactivity`. `on_freeze_entered` already gates minting on `is_steward` (non-stewards just enter the collection freeze), so the round collects all steward candidates and selects one deterministically — the epoch steward's when present (RFC §Commit validation service). A silent primary is covered by its candidate's absence, not by a takeover timer.

`recovery_inactivity_duration` is unchanged: it still drives the recovery freeze and auto-commit windows and the backup proposal / sync-resend takeovers, which are legitimate backup-waits. Unifying it with `freeze_duration` belongs to the recovery rework, not here.
