### PR TITLE
feat: create_with_members founds a group with initial members

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use de_mls::defaults::{DefaultConsensusPlugin, InMemoryPeerScoreStorage};
 // The first generic is the consensus backend, the second the peer-score
 // *storage* backend. `consensus` is a `ConsensusPlugin` instance you hold and
 // pass by reference; `scoring` is a `PeerScoringService` built over the storage
-// (see `de_mls::defaults::DefaultPeerScoring`). The steward roster is
+// (see `de_mls::defaults::DefaultPeerScoring`). The steward list is
 // library-owned — you set its size bounds on `config` (a `ConversationConfig`).
 // The third generic is the time source: a `WallClock` impl you provide —
 // wrap `SystemTime` in production, use `MockClock` for virtual-time tests.
@@ -112,14 +112,14 @@ write.
 
 ## Steward list
 
-Who may commit each epoch — the steward roster and its epoch/backup rotation —
+Who may commit each epoch — the steward list and its epoch/backup rotation —
 is fully library-owned. You set only its size bounds (`sn_min` / `sn_max`, the
 `steward_list` field on `ConversationConfig`); de-mls generates the list,
 validates election proposals, runs the election through consensus, and rotates
 the epoch steward.
 
 Generation is deterministic and normative: every member derives the identical
-roster by sorting on `SHA256(epoch ‖ retry_round ‖ member_id ‖
+steward list by sorting on `SHA256(epoch ‖ retry_round ‖ member_id ‖
 conversation_id)`, and a proposal that doesn't reproduce it is rejected by all
 peers (RFC §"Steward list creation"). There is nothing to override — a
 divergent generator would fork the group — so, unlike consensus and scoring,

--- a/src/consensus/apply_result.rs
+++ b/src/consensus/apply_result.rs
@@ -23,7 +23,7 @@ pub enum ConsensusApplyResult {
     /// Nothing left to do. "No follow-up", not "no change" — some of these
     /// paths still adjusted the approved queue.
     NoAction,
-    /// The election passed. Validate the proposed roster, install it, and
+    /// The election passed. Validate the proposed list, install it, and
     /// leave Reelection.
     ElectionAccepted(StewardElectionProposal),
     /// The election failed. Retry it, or escalate once retries are spent.
@@ -177,8 +177,8 @@ pub fn apply_consensus_result(
     Ok(ConsensusApplyResult::NoAction)
 }
 
-/// The election branch of [`apply_consensus_result`]. YES hands the proposed
-/// roster back for validation and install; NO just reports the rejection.
+/// The election branch of [`apply_consensus_result`]. YES hands the proposed steward
+/// list back for validation and install; NO just reports the rejection.
 fn apply_election_result(
     approved: bool,
     election: StewardElectionProposal,

--- a/src/consensus/handle_outcome.rs
+++ b/src/consensus/handle_outcome.rs
@@ -1,5 +1,5 @@
-//! Running the follow-up once a proposal resolves: installing an elected
-//! roster, retrying or escalating a failed election, entering freeze for a
+//! Running the follow-up once a proposal resolves: installing an elected steward
+//! list, retrying or escalating a failed election, entering freeze for a
 //! commit, and applying emergency score changes.
 
 use std::error::Error as StdError;

--- a/src/conversation/config.rs
+++ b/src/conversation/config.rs
@@ -115,7 +115,7 @@ pub struct ConversationConfig {
     /// giving up and emitting [`crate::ConversationEvent::RecoveryExhausted`].
     /// `0` retries forever. See [`DEFAULT_RECOVERY_MAX_ROUNDS`].
     pub recovery_max_rounds: u32,
-    /// Steward-list size bounds (`sn_min` / `sn_max`). The roster itself is
+    /// Steward-list size bounds (`sn_min` / `sn_max`). The list itself is
     /// library-owned; this is the only steward knob the integrator sets.
     pub steward_list: StewardListConfig,
 }

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -20,8 +20,10 @@ use hashgraph_like_consensus::{events::ConsensusEventBus, service::ConsensusServ
 use crate::{
     ConsensusPlugin, Conversation, ConversationConfig, ConversationError, ConversationEvent,
     ConversationQueues, ConversationServices, ConversationStateMachine, PeerScoreStorage,
-    PeerScoringService, StewardListService, WallClock, consensus::outcome_bus::OutcomeBus,
-    mls_crypto::MlsService,
+    PeerScoringService, StewardListService, WallClock,
+    consensus::outcome_bus::OutcomeBus,
+    mls_crypto::{MlsCommitInput, MlsService},
+    protos::de_mls::messages::v1::MemberWelcome,
 };
 
 impl<Cp, Sc, Wc> Conversation<Cp, Sc, Wc>
@@ -30,14 +32,12 @@ where
     Sc: PeerScoreStorage,
     Wc: WallClock,
 {
-    /// Create a brand-new conversation we steward. Starts in `Working` with the
-    /// local member installed as sole steward at epoch 0. The library seeds a
-    /// fresh MLS group into `provider` (which it does not retain) from
-    /// `credential` and `ciphersuite`. `member_id` names the local member — the
-    /// opaque id bytes the protocol matches on. `clock` moves in and becomes
-    /// the conversation's time source — every deadline is measured against
-    /// it; a shared clock (e.g. [`crate::MockClock`]) stays drivable through
-    /// a clone the caller keeps.
+    /// Create a new conversation as the steward.
+    /// If you want a single-steward group, do not pass any `initial_members`.
+    /// If you want to start with a group of members,  provide their
+    ///  `(member_id, key_package_bytes)` in `initial_members` so all are added in a
+    ///  single genesis commit—group starts at epoch 1 with all present.
+    /// In both cases, the creator is installed as a steward and the group is ready to use.
     #[allow(clippy::too_many_arguments)]
     pub fn create<Pr>(
         conversation_id: &str,
@@ -51,6 +51,7 @@ where
         clock: Wc,
         app_id: Arc<[u8]>,
         config: ConversationConfig,
+        initial_members: &[(&[u8], &[u8])],
     ) -> Result<Self, ConversationError>
     where
         Pr: OpenMlsProvider,
@@ -63,7 +64,7 @@ where
             group_config,
             signer,
         )?;
-        Self::assemble(
+        let mut conversation = Self::assemble(
             conversation_id,
             mls,
             scoring,
@@ -73,7 +74,76 @@ where
             config,
             true,
             member_id,
-        )
+        )?;
+        conversation.seed_initial_members(provider, signer, initial_members)?;
+        Ok(conversation)
+    }
+
+    /// Admit all initial members in a single genesis commit,
+    /// merge inline (no proposal or vote), install the steward list, and emit a welcome.
+    /// Their join epochs are unset, making them eligible stewards from epoch 1.
+    fn seed_initial_members<Pr>(
+        &mut self,
+        provider: &Pr,
+        signer: &impl Signer,
+        initial_members: &[(&[u8], &[u8])],
+    ) -> Result<(), ConversationError>
+    where
+        Pr: OpenMlsProvider,
+        <Pr::StorageProvider as StorageProvider<1>>::Error: StdError + Send + Sync + 'static,
+    {
+        if initial_members.is_empty() {
+            return Ok(());
+        }
+        let updates: Vec<MlsCommitInput> = initial_members
+            .iter()
+            .map(|(_, kp)| MlsCommitInput::Add(kp.to_vec()))
+            .collect();
+        let joiner_identities: Vec<Vec<u8>> =
+            initial_members.iter().map(|(id, _)| id.to_vec()).collect();
+
+        // Genesis is the creator's unilateral seed: build the batched add-commit
+        // and merge it inline, skipping the consensus/freeze lifecycle.
+        let artifacts = self
+            .services
+            .mls
+            .create_commit_candidate(provider, signer, &updates)?;
+        self.services.mls.merge_own_commit(provider)?;
+
+        // Score the members and install the steward list over the settled roster
+        // at the merged epoch. `install_list` sorts and takes the top-sn, so this
+        // handles an initial set larger than `sn_max` (a real subset) too.
+        for (id, _) in initial_members {
+            self.services.scoring.add_member(id)?;
+        }
+        let (epoch, members) = {
+            let mls = self.mls();
+            (mls.current_epoch()?, mls.members()?)
+        };
+        let settled = self.queues.settled_members(&members, epoch);
+        let sn = self
+            .services
+            .steward_list
+            .config()
+            .compute_list_size(settled.len());
+        self.services
+            .steward_list
+            .install_list(epoch, &settled, sn, 0)?;
+
+        // Deliver the single welcome: attach the ConversationSync, emit
+        // WelcomeReady, and broadcast it for relay.
+        if let Some(welcome_bytes) = artifacts.welcome {
+            self.deliver_welcome(
+                provider,
+                signer,
+                MemberWelcome {
+                    welcome_bytes,
+                    conversation_sync_bytes: Vec::new(),
+                    joiner_identities,
+                },
+            );
+        }
+        Ok(())
     }
 
     /// Build a fully-joined conversation from a welcome: the library opens the

--- a/src/conversation/construct.rs
+++ b/src/conversation/construct.rs
@@ -110,7 +110,7 @@ where
             .create_commit_candidate(provider, signer, &updates)?;
         self.services.mls.merge_own_commit(provider)?;
 
-        // Score the members and install the steward list over the settled roster
+        // Score the members and install the steward list over the settled members
         // at the merged epoch. `install_list` sorts and takes the top-sn, so this
         // handles an initial set larger than `sn_max` (a real subset) too.
         for (id, _) in initial_members {
@@ -225,7 +225,7 @@ where
         steward_list.set_conversation_id(conversation_id.as_bytes());
         steward_list.set_max_retries(config.max_reelection_attempts);
         // Creator path: bootstrap the list with self as sole steward at
-        // epoch 0. Joiner path leaves the roster empty until `ConversationSync`.
+        // epoch 0. Joiner path leaves the member set empty until `ConversationSync`.
         if is_creation {
             steward_list.install_list(0, std::slice::from_ref(&self_member_id_bytes), 1, 0)?;
             scoring.add_member(&self_member_id_bytes)?;

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -61,7 +61,7 @@ pub(crate) struct ConversationServices<Cp: ConsensusPlugin, Sc: PeerScoreStorage
     pub(crate) mls: MlsService,
     /// Per-conversation peer-score tracker.
     pub(crate) scoring: PeerScoringService<Sc>,
-    /// Per-conversation steward roster.
+    /// Per-conversation steward list.
     pub(crate) steward_list: StewardListService,
     /// Per-conversation consensus service. Owns this conversation's scope
     /// in the shared storage and a private event bus. Built from the
@@ -807,7 +807,7 @@ mod tests {
         Conversation<DefaultConsensusPlugin, InMemoryPeerScoreStorage, crate::MockClock>;
 
     /// Build a conversation with a real creator-side MLS service and the given
-    /// steward roster, returning it alongside the provider that backs the MLS
+    /// steward list, returning it alongside the provider that backs the MLS
     /// group and the signer that seeded it (for paths that sign — the guard
     /// tests early-return before then).
     fn make_conversation_with_steward(

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -140,7 +140,7 @@ where
         let (received, expected) = self.commit_candidate_count();
 
         // Early selection: skip remaining freeze time if all expected stewards
-        // have submitted. Not in recovery — there's no fixed roster to count
+        // have submitted. Not in recovery — there's no fixed member set to count
         // against (any member may commit), so we wait out the window.
         let all_candidates_in = !in_recovery
             && self

--- a/src/conversation/poll.rs
+++ b/src/conversation/poll.rs
@@ -411,7 +411,7 @@ where
     /// propagates — the commit merged, so a sync-build failure surfaces a
     /// [`ConversationEvent::Error`] and ships `welcome_bytes` with empty sync
     /// (the joiner attaches to MLS without it).
-    fn deliver_welcome<Pr>(
+    pub(crate) fn deliver_welcome<Pr>(
         &mut self,
         provider: &Pr,
         signer: &impl Signer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod consensus;
 /// Peer-scoring plug-in: vocabulary, traits, and reference service.
 pub mod peer_scoring;
 
-/// Steward-list plug-in: deterministic roster and rotation queries.
+/// Steward-list plug-in: deterministic list and rotation queries.
 pub mod steward_list;
 
 /// Commit round candidate processing, selection, and commit application.

--- a/src/peer_scoring/helpers.rs
+++ b/src/peer_scoring/helpers.rs
@@ -1,4 +1,4 @@
-//! Pure helpers: scoring/member-roster diff and ECP score-op derivation.
+//! Pure helpers: scoring/member-set diff and ECP score-op derivation.
 
 use std::collections::HashSet;
 
@@ -9,7 +9,7 @@ use crate::{
     {ScoreEvent, ScoreOp, ScoringMemberDiff},
 };
 
-/// Diff between a scoring table snapshot and an MLS member roster.
+/// Diff between a scoring table snapshot and an MLS member set.
 /// Caller applies the diff to its own [`crate::PeerScoringService`].
 pub fn scoring_member_diff(scored: &[Vec<u8>], mls_members: &[Vec<u8>]) -> ScoringMemberDiff {
     let scored_set: HashSet<&[u8]> = scored.iter().map(Vec::as_slice).collect();

--- a/src/peer_scoring/mod.rs
+++ b/src/peer_scoring/mod.rs
@@ -7,7 +7,7 @@
 //! - `storage` — `PeerScoreStorage` trait (integrator-supplied backend).
 //! - `service` — `PeerScoringService`, the library-owned scoring logic.
 //! - `helpers` — pure functions: `scoring_member_diff` (scoring-table vs.
-//!   MLS-roster diff) and `emergency_score_ops` (emergency-vote → score ops).
+//!   member-set diff) and `emergency_score_ops` (emergency-vote → score ops).
 
 mod helpers;
 mod service;

--- a/src/peer_scoring/service.rs
+++ b/src/peer_scoring/service.rs
@@ -51,7 +51,7 @@ impl<S: PeerScoreStorage> PeerScoringService<S> {
     /// Apply an incremental delta to an already-tracked member. Unlike
     /// `add_member` / `apply_snapshot`, this never creates an entry — a
     /// stale op must not resurrect a removed member. The coordinator
-    /// `add_member`s first; a drop means roster and scores are out of sync.
+    /// `add_member`s first; a drop means member set and scores are out of sync.
     pub fn apply_op(&mut self, op: &ScoreOp) -> Result<(), ConversationError> {
         let Some(current) = self.storage.get(&op.member_id).map_err(storage_err)? else {
             tracing::debug!(
@@ -121,8 +121,8 @@ impl<S: PeerScoreStorage> PeerScoringService<S> {
             .collect())
     }
 
-    /// Complete roster of tracked members with their scores (includes
-    /// default-scored members). Used for roster diffing and UI reads.
+    /// Complete set of tracked members with their scores (includes
+    /// default-scored members). Used for member-set diffing and UI reads.
     pub fn all_members_with_scores(&self) -> Result<Vec<(Vec<u8>, i64)>, ConversationError> {
         self.storage.all_scores().map_err(storage_err)
     }

--- a/src/peer_scoring/storage.rs
+++ b/src/peer_scoring/storage.rs
@@ -37,7 +37,7 @@ pub trait PeerScoreStorage {
     fn remove(&mut self, member_id: &[u8]) -> Result<(), Self::Error>;
 
     /// Every tracked member paired with its score. Must be **complete** — the
-    /// library derives the below-threshold set and the scoring/roster diff
+    /// library derives the below-threshold set and the scoring/member-set diff
     /// from this — but order is irrelevant.
     fn all_scores(&self) -> Result<Vec<(Vec<u8>, i64)>, Self::Error>;
 }

--- a/src/steward_list/list.rs
+++ b/src/steward_list/list.rs
@@ -1,7 +1,7 @@
 //! The deterministic steward list — who serves as steward, and in what order.
 //!
 //! [`StewardListConfig`] fixes the size bounds (`sn_min`/`sn_max`);
-//! [`StewardList`] is one elected, ordered roster. Stewards are chosen by
+//! [`StewardList`] is one elected, ordered steward list. Stewards are chosen by
 //! ascending `SHA256(election_epoch || retry_round || member_id ||
 //! conversation_id)`, keeping the first `sn` — the same key every member
 //! computes, so the list is reproducible and unbiased (RFC §"Steward list
@@ -24,7 +24,7 @@ pub struct StewardListConfig {
     /// must vote on who serves.
     pub sn_max: usize,
     /// Whether an election may draw candidates from a subset of members rather
-    /// than the full roster. Read by the coordinator; not used in generation.
+    /// than the full member set. Read by the coordinator; not used in generation.
     pub allow_subset_candidates: bool,
 }
 
@@ -71,7 +71,7 @@ impl StewardListConfig {
         }
     }
 
-    /// Reject inputs `generate`/`validate` can't honor: an empty roster, or an `sn`
+    /// Reject inputs `generate`/`validate` can't honor: an empty member set, or an `sn`
     /// outside the config's valid range for this membership.
     pub fn check_generation_inputs(
         &self,
@@ -88,7 +88,7 @@ impl StewardListConfig {
     }
 }
 
-/// One elected, ordered steward roster, serving epochs
+/// One elected, ordered steward list, serving epochs
 /// `[election_epoch, election_epoch + len)`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StewardList {
@@ -105,7 +105,7 @@ pub struct StewardList {
 impl StewardList {
     /// Elect `sn` stewards: sort `member_ids` by ascending steward hash and keep
     /// the first `sn`. Deterministic — every member derives the same list.
-    /// Errors on an empty roster or an `sn` outside the config bounds.
+    /// Errors on an empty member set or an `sn` outside the config bounds.
     pub fn generate(
         election_epoch: u64,
         conversation_id: &[u8],

--- a/src/steward_list/mod.rs
+++ b/src/steward_list/mod.rs
@@ -1,7 +1,7 @@
-//! Steward list: the library-owned deterministic roster and rotation queries.
+//! Steward list: the library-owned deterministic list and rotation queries.
 //!
 //! - `list` — [`StewardList`] value and [`StewardListConfig`]
-//! - `service` — [`StewardListService`], the stateful per-conversation roster
+//! - `service` — [`StewardListService`], the stateful per-conversation steward list
 
 mod list;
 mod service;

--- a/src/steward_list/service.rs
+++ b/src/steward_list/service.rs
@@ -1,5 +1,5 @@
-//! [`StewardListService`] — the library-owned, SHA256-deterministic steward
-//! roster for one conversation.
+//! [`StewardListService`] — the library-owned, SHA256-deterministic steward list
+//! for one conversation.
 //!
 //! It owns the steward-list protocol: generating and validating the
 //! deterministic list, rotating the epoch/backup steward, proposing elections,
@@ -60,7 +60,7 @@ pub struct StewardListSnapshot {
     max_retries: u32,
 }
 
-/// Per-conversation steward roster. Eligibility flows in via `Fn(&[u8]) -> bool`
+/// Per-conversation steward list. Eligibility flows in via `Fn(&[u8]) -> bool`
 /// on position queries.
 #[derive(Debug)]
 pub struct StewardListService {
@@ -76,7 +76,7 @@ pub struct StewardListService {
 }
 
 impl StewardListService {
-    /// Empty roster — no list until the library installs one (the creator's
+    /// Empty — no list until the library installs one (the creator's
     /// bootstrap list or a joiner's `ConversationSync`). The deterministic-sort
     /// salt is seeded by the library via [`Self::set_conversation_id`] once the
     /// conversation id is known, so the integrator builds this without it.
@@ -469,7 +469,7 @@ mod tests {
     }
 
     #[test]
-    fn steward_members_returns_filtered_roster() {
+    fn steward_members_returns_filtered_list() {
         let mut p = StewardListService::empty(config());
         let mems = members(&[1, 2, 3]);
         p.install_list(0, &mems, 3, 0).unwrap();
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn snapshot_of_empty_service_errors() {
-        // A roster with no installed list has nothing to snapshot.
+        // A service with no installed list has nothing to snapshot.
         let p = StewardListService::empty(config());
         assert!(p.snapshot().is_err());
     }

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -76,12 +76,12 @@ pub(crate) fn make_creator_mls(member_id: &[u8]) -> (TestMls, TestProvider, Sign
     (mls, provider, signer)
 }
 
-/// Steward roster where the local member is NOT a steward (no list installed).
+/// Steward list where the local member is NOT a steward (no list installed).
 pub(crate) fn steward_service_member() -> StewardListService {
     StewardListService::empty(StewardListConfig::new(1, 5).unwrap())
 }
 
-/// Steward roster where `member_id` IS the sole steward.
+/// Steward list where `member_id` IS the sole steward.
 pub(crate) fn steward_service_steward(member_id: &[u8]) -> StewardListService {
     let mut service = StewardListService::empty(StewardListConfig::new(1, 5).unwrap());
     service

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -879,7 +879,7 @@ impl<const N: usize> TestHarness<N> {
     ///
     /// [`Self::epochs_agree`] compares epoch *numbers* and
     /// [`Self::membership_agrees`] compares member-id *sets*, and both report
-    /// `true` across a forked group whose branches share an epoch and roster
+    /// `true` across a forked group whose branches share an epoch and member set
     /// but hold different epoch secrets. The authenticator is the value that
     /// tells them apart, so this is the check that actually detects a fork.
     pub fn converged(&self) -> bool {

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -177,6 +177,7 @@ impl Member {
             integ.clock.clone(),
             integ.app_id(),
             config.clone(),
+            &[],
         )
         .expect("create conversation");
         Self {

--- a/tests/founding_group.rs
+++ b/tests/founding_group.rs
@@ -120,11 +120,12 @@ fn founding_adds_batch_into_one_commit_after_one_inactivity_window() {
 
 /// Immediately after the founding commit, the freshly-added friends are not
 /// yet settled, so the creator remains the sole steward for the whole of
-/// epoch 1. Pins the property a genesis path would change by marking founders
-/// settled — and shows the creator's epoch-1 stewardship is a *consequence* of
+/// epoch 1. Pins the property a genesis path would change by marking the
+/// initial members settled — and shows the creator's epoch-1 stewardship is a
+/// *consequence* of
 /// the settled rule, not a guarantee of creation.
 #[test]
-fn founders_are_not_stewards_in_the_epoch_they_arrive() {
+fn initial_members_are_not_stewards_in_the_epoch_they_arrive() {
     let mut h = TestHarness::<4>::start(
         [ALICE, BOB, CHARLIE, DAVE],
         "settle",
@@ -159,7 +160,7 @@ fn founders_are_not_stewards_in_the_epoch_they_arrive() {
 /// Five members in the tree, four of whom have never run. The creator adds a
 /// sixth. Pins what the four silent leaves contribute to that vote.
 #[test]
-fn silent_founders_are_counted_as_voters_on_the_next_add() {
+fn silent_initial_members_are_counted_as_voters_on_the_next_add() {
     let mut h = TestHarness::<6>::start(
         [ALICE, BOB, CHARLIE, DAVE, ERIN, FRANK],
         "ghost",
@@ -210,7 +211,7 @@ fn silent_founders_are_counted_as_voters_on_the_next_add() {
 /// The two-person case: me and one friend who never opens the welcome. Pins
 /// what the pair can still do — the most common real-world founding shape.
 #[test]
-fn a_single_silent_founder_and_the_next_add() {
+fn a_single_silent_initial_member_and_the_next_add() {
     let mut h = TestHarness::<3>::start(
         [ALICE, BOB, CHARLIE],
         "pair",
@@ -251,7 +252,7 @@ fn a_single_silent_founder_and_the_next_add() {
 /// so it still mints commits, but nothing it sends arrives.
 ///
 /// The guarantee this test pins is recovery — the survivors land the add
-/// without the creator, so a group does not die with its founder.
+/// without the creator, so a group does not die with its creator.
 ///
 /// Known gap, documented but not asserted: the isolated creator merged its own
 /// lost commit and advanced onto a private branch. Both branches report the
@@ -283,7 +284,7 @@ fn survivors_recover_when_the_sole_steward_is_partitioned() {
     assert!(h.member(0).is_epoch_steward(), "creator stewards epoch 1");
     assert!(
         h.converged(),
-        "the founded group is one group to begin with"
+        "the created group is one group to begin with"
     );
 
     h.mute(0);

--- a/tests/protocol_join_lifecycle.rs
+++ b/tests/protocol_join_lifecycle.rs
@@ -94,7 +94,7 @@ fn bootstrap_joiner_reports_sync_applied() {
 /// after `backup_takeover_window`, not before.
 #[test]
 fn backup_steward_resends_sync_when_epoch_steward_silent() {
-    // sn_max = 5 → the full settled roster is the steward list. Evicting one
+    // sn_max = 5 → the full settled members is the steward list. Evicting one
     // member advances an epoch so the remaining joiners settle into stewards,
     // leaving an epoch steward and a backup.
     let cfg = ConversationConfig {

--- a/tests/protocol_steward.rs
+++ b/tests/protocol_steward.rs
@@ -87,7 +87,7 @@ fn assert_no_election_storm<const N: usize>(h: &TestHarness<N>) {
 #[test]
 fn backup_steward_proposes_buffered_joiner_when_epoch_steward_silent() {
     // sn_max = 5 ≥ membership at every size here, so the steward list is always
-    // the full roster and growing back to 3 fires no subset election — the test
+    // the full member set and growing back to 3 fires no subset election — the test
     // isolates the backup *proposal* takeover, not election.
     let cfg = ConversationConfig {
         backup_takeover_window: Duration::from_millis(100),

--- a/tests/standalone_construction.rs
+++ b/tests/standalone_construction.rs
@@ -17,7 +17,7 @@ use openmls_basic_credential::SignatureKeyPair;
 
 use de_mls::defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage};
 use de_mls::{Conversation, ConversationState, MockClock};
-use de_mls::{ConversationEvent, ScoringConfig};
+use de_mls::{ConversationEvent, ScoringConfig, StewardListConfig};
 
 use common::{
     MintedKeyPackage, TestProvider, make_scoring, mint_key_package, test_credential,
@@ -32,6 +32,8 @@ type TestConversation = Conversation<DefaultConsensusPlugin, InMemoryPeerScoreSt
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+const DAVE: &str = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6";
 
 /// The shared, conversation-agnostic state an integrator keeps once: its
 /// credential + signer, the consensus backend, the identity, and one OpenMLS
@@ -98,6 +100,7 @@ fn create_builds_a_working_steward_session_without_user() {
         integrator.clock.clone(),
         integrator.app_id(),
         de_mls::ConversationConfig::default(),
+        &[],
     )
     .expect("create");
 
@@ -140,6 +143,7 @@ fn join_completes_in_one_call() {
         alice.clock.clone(),
         alice.app_id(),
         fast_config(),
+        &[],
     )
     .expect("create");
 
@@ -221,4 +225,176 @@ fn join_completes_in_one_call() {
     assert_eq!(joined.members().expect("members").len(), 2);
     let (epoch, _) = joined.epoch_and_retry().expect("epoch");
     assert_eq!(epoch, 1, "joiner lands on the post-add epoch");
+}
+
+#[test]
+fn create_with_members_seeds_initial_members_at_genesis() {
+    let alice = Integrator::new();
+    let bob = Integrator::with_key(BOB);
+    let charlie = Integrator::with_key(CHARLIE);
+
+    // The initial members mint their key packages into their own providers and
+    // hand the bytes to the creator.
+    let bob_kp = bob.mint_key_package();
+    let charlie_kp = charlie.mint_key_package();
+
+    let config = de_mls::ConversationConfig {
+        steward_list: StewardListConfig::new(1, 5).unwrap(),
+        ..fast_config()
+    };
+
+    let creator: TestConversation = Conversation::create(
+        "genesis",
+        alice.member_id.member_id_bytes(),
+        &alice.provider,
+        alice.credential.clone(),
+        &test_mls_group_config(),
+        &alice.signer,
+        &alice.consensus,
+        alice.scoring(),
+        alice.clock.clone(),
+        alice.app_id(),
+        config.clone(),
+        &[
+            (bob_kp.member_id(), bob_kp.as_bytes()),
+            (charlie_kp.member_id(), charlie_kp.as_bytes()),
+        ],
+    )
+    .expect("create with members");
+
+    // Genesis is immediate: at epoch 1 with all three members, no polling.
+    let (epoch, _) = creator.epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 1, "the genesis commit landed at creation");
+    assert_eq!(creator.members().expect("members").len(), 3);
+    assert_eq!(creator.state(), ConversationState::Working);
+    assert!(
+        creator.is_steward(),
+        "the creator stewards the genesis epoch"
+    );
+
+    // Exactly one welcome, addressing both initial members.
+    let welcome = creator
+        .drain_events()
+        .into_iter()
+        .find_map(|e| match e {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally: true,
+            } => Some(welcome),
+            _ => None,
+        })
+        .expect("genesis mints one welcome");
+    assert_eq!(
+        welcome.joiner_identities.len(),
+        2,
+        "one welcome admits both initial members"
+    );
+
+    // Each initial member opens the single welcome and lands at epoch 1, Working,
+    // and a steward — the property genesis beats the incremental baseline on.
+    for member in [&bob, &charlie] {
+        let joined: TestConversation = Conversation::join(
+            member.member_id.member_id_bytes(),
+            &member.provider,
+            &member.signer,
+            &welcome.welcome_bytes,
+            &welcome.conversation_sync_bytes,
+            &member.consensus,
+            member.scoring(),
+            member.clock.clone(),
+            member.app_id(),
+            config.clone(),
+        )
+        .expect("join")
+        .expect("welcome addresses the member");
+        assert_eq!(joined.id(), "genesis");
+        assert_eq!(joined.state(), ConversationState::Working);
+        assert_eq!(joined.members().expect("members").len(), 3);
+        let (e, _) = joined.epoch_and_retry().expect("epoch");
+        assert_eq!(e, 1, "member lands on the genesis epoch");
+        assert!(joined.is_steward(), "an initial member stewards genesis");
+    }
+}
+
+#[test]
+fn create_with_members_founds_a_subset_steward_group() {
+    let alice = Integrator::new();
+    let bob = Integrator::with_key(BOB);
+    let charlie = Integrator::with_key(CHARLIE);
+    let dave = Integrator::with_key(DAVE);
+
+    let bob_kp = bob.mint_key_package();
+    let charlie_kp = charlie.mint_key_package();
+    let dave_kp = dave.mint_key_package();
+
+    // sn_max = 2 with 4 members → the steward list is a genuine 2-of-4 subset.
+    let config = de_mls::ConversationConfig {
+        steward_list: StewardListConfig::new(1, 2).unwrap(),
+        ..fast_config()
+    };
+
+    let creator: TestConversation = Conversation::create(
+        "genesis-subset",
+        alice.member_id.member_id_bytes(),
+        &alice.provider,
+        alice.credential.clone(),
+        &test_mls_group_config(),
+        &alice.signer,
+        &alice.consensus,
+        alice.scoring(),
+        alice.clock.clone(),
+        alice.app_id(),
+        config.clone(),
+        &[
+            (bob_kp.member_id(), bob_kp.as_bytes()),
+            (charlie_kp.member_id(), charlie_kp.as_bytes()),
+            (dave_kp.member_id(), dave_kp.as_bytes()),
+        ],
+    )
+    .expect("create with members");
+
+    let (epoch, _) = creator.epoch_and_retry().expect("epoch");
+    assert_eq!(epoch, 1);
+    assert_eq!(creator.members().expect("members").len(), 4);
+
+    let welcome = creator
+        .drain_events()
+        .into_iter()
+        .find_map(|e| match e {
+            ConversationEvent::WelcomeReady {
+                welcome,
+                minted_locally: true,
+            } => Some(welcome),
+            _ => None,
+        })
+        .expect("genesis mints one welcome");
+    assert_eq!(welcome.joiner_identities.len(), 3);
+
+    let mut convos = vec![creator];
+    for member in [&bob, &charlie, &dave] {
+        let joined: TestConversation = Conversation::join(
+            member.member_id.member_id_bytes(),
+            &member.provider,
+            &member.signer,
+            &welcome.welcome_bytes,
+            &welcome.conversation_sync_bytes,
+            &member.consensus,
+            member.scoring(),
+            member.clock.clone(),
+            member.app_id(),
+            config.clone(),
+        )
+        .expect("join")
+        .expect("welcome addresses the member");
+        assert_eq!(joined.members().expect("members").len(), 4);
+        convos.push(joined);
+    }
+
+    // Exactly two of the four members steward — the deterministic 2-of-4 subset
+    // the genesis install picked, seen consistently through the shared sync.
+    let steward_count = convos.iter().filter(|c| c.is_steward()).count();
+    assert_eq!(
+        steward_count, 2,
+        "sn_max = 2 founds a 2-member steward subset"
+    );
 }


### PR DESCRIPTION
`Conversation::create_with_members` founds a group with an initial set of members in one step. The creator supplies the members' key packages, and creation admits them in a single genesis commit: the group opens at epoch 1 already whole, mints one welcome addressing all of them, and marks them settled so they steward epoch 1 — with no consensus round and no commit-inactivity wait. Genesis is the creator's unilateral seed, so it skips the proposal/vote/freeze lifecycle a later `add_member` runs.

It reuses the existing batched add-commit path (`create_commit_candidate` / `merge_own_commit`) plus a deterministic steward-list install that also handles an initial set larger than `sn_max` (a real subset). Two standalone tests cover the base case (members settled + stewarding, one welcome) and the subset case (`sn_max = 2`, 4 members → a 2-of-4 steward subset).

A second commit is terminology-only: `roster` becomes "steward list" or "member set" per context, and `founder(s)` becomes "initial member(s)" — the review feedback that `founders` read as the group's creator rather than the seeded members. No behaviour change.
