### PR TITLE
feat(mls): expose sender signing key

### DIFF
--- a/src/conversation/inbound.rs
+++ b/src/conversation/inbound.rs
@@ -104,7 +104,7 @@ where
     //    rogue MLS proposals on the app subtopic from polluting state.
     let Some(DecryptedMessage {
         payload: app_bytes,
-        sender,
+        member,
     }) = mls.decrypt_application_only(provider, payload)?
     else {
         tracing::debug!(
@@ -119,19 +119,14 @@ where
     // Per-variant pre-checks; whatever survives converges on the `try_into`
     // conversion below.
     match &mut app_msg.payload {
-        // Stamp the MLS-authenticated sender (the verified leaf credential
-        // content) onto conversation messages.
-        Some(app_message::Payload::ConversationMessage(cm)) => {
-            cm.sender_credential = sender.clone();
-        }
         // Fast-path proposals must originate from the self-removal target.
         Some(app_message::Payload::Proposal(proposal))
-            if !authorize_fast_path_proposal(proposal, &sender) =>
+            if !authorize_fast_path_proposal(proposal, &member.member_id) =>
         {
             warn!(
                 conversation = conversation.name(),
                 proposal_id = proposal.proposal_id,
-                sender = ?sender,
+                sender = ?member.member_id,
                 owner = ?proposal.proposal_owner,
                 "fast-path proposal rejected: sender is not the self-removal target"
             );
@@ -140,7 +135,9 @@ where
         // A sync re-send request: the MLS-authenticated sender is the
         // requester, so capture it here rather than trust a wire field.
         Some(app_message::Payload::ConversationSyncRequest(_)) => {
-            return Ok(ProcessResult::ConversationSyncRequested { requester: sender });
+            return Ok(ProcessResult::ConversationSyncRequested {
+                requester: member.member_id,
+            });
         }
         // Drop BanRequests whose target isn't in the conversation — saves a
         // useless consensus round.

--- a/src/conversation/messaging.rs
+++ b/src/conversation/messaging.rs
@@ -67,7 +67,6 @@ where
             message,
             sender: self.self_member_id.to_vec(),
             conversation_id: self.conversation_id.clone(),
-            ..Default::default()
         }
         .into();
         let payload = self.mls_mut().build_message(provider, signer, &app_msg)?;

--- a/src/conversation/query.rs
+++ b/src/conversation/query.rs
@@ -95,6 +95,12 @@ where
         Ok(self.mls().members()?)
     }
 
+    /// Signature public key bound to `member_id`'s MLS leaf, or `None` if it is
+    /// not a current member.
+    pub fn member_signature_key(&self, member_id: &[u8]) -> Option<Vec<u8>> {
+        self.mls().member_signature_key(member_id)
+    }
+
     pub fn member_scores(&self) -> Result<Vec<(Vec<u8>, i64)>, ConversationError> {
         self.services.scoring.all_members_with_scores()
     }

--- a/src/mls_crypto/error.rs
+++ b/src/mls_crypto/error.rs
@@ -73,7 +73,7 @@ pub enum MlsError {
     #[error("No pending staged commit for group: {0}")]
     NoPendingStagedCommit(String),
 
-    #[error("Remove proposal references leaf index {0} with no active credential")]
+    #[error("Leaf index {0} resolves to no active member in the group")]
     UnknownLeafIndex(u32),
 }
 

--- a/src/mls_crypto/mod.rs
+++ b/src/mls_crypto/mod.rs
@@ -15,6 +15,6 @@ mod types;
 pub use error::MlsError;
 pub use service::MlsService;
 pub use types::{
-    CommitArtifacts, DecryptedMessage, MlsCommitInput, MlsMessageKind, MlsProposalOutput,
-    StagedCandidateResult,
+    CommitArtifacts, DecryptedMessage, MemberIdentity, MlsCommitInput, MlsMessageKind,
+    MlsProposalOutput, StagedCandidateResult,
 };

--- a/src/mls_crypto/service.rs
+++ b/src/mls_crypto/service.rs
@@ -20,13 +20,14 @@ use openmls::group::{
 use openmls::key_packages::KeyPackageIn;
 use openmls::prelude::{
     ContentType, DeserializeBytes, MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent,
-    ProtocolMessage, ProtocolVersion,
+    ProtocolMessage, ProtocolVersion, Sender,
 };
 use openmls_traits::storage::StorageProvider;
 use openmls_traits::{OpenMlsProvider, signatures::Signer};
 use prost::Message;
 use tracing::warn;
 
+use crate::mls_crypto::types::MemberIdentity;
 use crate::{
     Extensions, GroupContext,
     mls_crypto::{
@@ -500,15 +501,39 @@ impl MlsService {
         }
 
         let processed = group.process_message(provider, protocol_message)?;
-        let sender_id = processed.credential().serialized_content().to_vec();
+
+        let (member_id, signature_key) = match processed.sender() {
+            Sender::Member(leaf_index) => {
+                let m = group
+                    .member_at(*leaf_index)
+                    .ok_or(MlsError::UnknownLeafIndex(leaf_index.u32()))?;
+
+                (m.credential.serialized_content().to_vec(), m.signature_key)
+            }
+            _ => return Ok(None),
+        };
 
         match processed.into_content() {
             ProcessedMessageContent::ApplicationMessage(app) => Ok(Some(DecryptedMessage {
                 payload: app.into_bytes(),
-                sender: sender_id,
+                member: MemberIdentity {
+                    member_id,
+                    signature_key,
+                },
             })),
             _ => Ok(None),
         }
+    }
+
+    /// The signature public key bound to `member_id`'s current leaf, or `None`
+    /// if no current member carries that credential identity. Assumes member-id
+    /// uniqueness (the same invariant [`Self::is_member`] and [`Self::members`]
+    /// rely on); with duplicate identities it returns the first leaf's key.
+    pub fn member_signature_key(&self, member_id: &[u8]) -> Option<Vec<u8>> {
+        self.group
+            .members()
+            .find(|m| m.credential.serialized_content() == member_id)
+            .map(|m| m.signature_key)
     }
 
     /// Peek a wire message's outer kind without processing or signature-checking
@@ -531,7 +556,7 @@ impl MlsService {
 }
 
 #[cfg(test)]
-mod stage_preserves_own_tests {
+mod service_tests {
     use super::*;
     use crate::test_fixtures::{TEST_SUITE, TestProvider, make_creator_mls};
     use openmls::credentials::{BasicCredential, CredentialWithKey};

--- a/src/mls_crypto/types.rs
+++ b/src/mls_crypto/types.rs
@@ -30,9 +30,9 @@ pub enum MlsMessageKind {
     Other,
 }
 
-/// The MLS-authenticated identity of a message's sender: the leaf `member_id`
-/// (credential content, equal to `mls_member.credential.serialized_content()`)
-/// and the `signature_key` that leaf signs with.
+/// The sender of a decrypted message, drawn from its MLS leaf: the
+/// `signature_key` MLS verified signed this message, and the `member_id`
+/// that is `mls_member.credential.serialized_content()`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MemberIdentity {
     pub member_id: Vec<u8>,
@@ -40,7 +40,7 @@ pub struct MemberIdentity {
 }
 
 /// A decrypted inbound application message: the plaintext `payload` and the
-/// MLS-authenticated `member` that sent it.
+/// `member` whose `signature_key` signed it.
 #[derive(Clone, Debug)]
 pub struct DecryptedMessage {
     pub payload: Vec<u8>,

--- a/src/mls_crypto/types.rs
+++ b/src/mls_crypto/types.rs
@@ -30,12 +30,21 @@ pub enum MlsMessageKind {
     Other,
 }
 
+/// The MLS-authenticated identity of a message's sender: the leaf `member_id`
+/// (credential content, equal to `mls_member.credential.serialized_content()`)
+/// and the `signature_key` that leaf signs with.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MemberIdentity {
+    pub member_id: Vec<u8>,
+    pub signature_key: Vec<u8>,
+}
+
 /// A decrypted inbound application message: the plaintext `payload` and the
-/// `sender`'s MLS-authenticated leaf credential.
+/// MLS-authenticated `member` that sent it.
 #[derive(Clone, Debug)]
 pub struct DecryptedMessage {
     pub payload: Vec<u8>,
-    pub sender: Vec<u8>,
+    pub member: MemberIdentity,
 }
 
 /// Outcome of staging a remote commit candidate.

--- a/src/protos/messages/v1/application.proto
+++ b/src/protos/messages/v1/application.proto
@@ -17,8 +17,6 @@ message AppMessage {
     ProposalAdded proposal_added = 7;
     CommitCandidate commit_candidate = 8;
     ConversationSync conversation_sync = 9;
-    // Plaintext broadcast of a freshly minted welcome so every member —
-    // not just the committing steward — can deliver it to the joiners.
     MemberWelcome member_welcome = 10;
     EventMembershipChange membership_change = 11;
     ConversationSyncRequest conversation_sync_request = 12;
@@ -34,7 +32,6 @@ message ConversationMessage {
   bytes message = 1;
   bytes sender = 2;
   string conversation_id = 3;
-  bytes sender_credential = 4;
 }
 
 message EventMembershipChange {

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -232,6 +232,12 @@ impl Member {
         self.integ.member_id.member_id_bytes()
     }
 
+    /// This member's MLS signature public key — the key its leaf is bound to.
+    /// Ground truth for asserting what peers resolve via `member_signature_key`.
+    pub fn signing_pubkey(&self) -> Vec<u8> {
+        self.integ.signer.to_public_vec()
+    }
+
     /// Reelection retry round; `0` while no recovery election is in flight or
     /// the member hasn't joined.
     pub fn retry_round(&self) -> u32 {
@@ -360,6 +366,14 @@ impl Member {
             .and_then(|c| c.members().ok())
             .map(|m| m.len())
             .unwrap_or(0)
+    }
+
+    /// Signature key this member's tree binds to `member_id`, or `None` when
+    /// `member_id` is not a current member (or this member hasn't joined).
+    pub fn member_signature_key(&self, member_id: &[u8]) -> Option<Vec<u8>> {
+        self.convo
+            .as_ref()
+            .and_then(|c| c.member_signature_key(member_id))
     }
 
     /// Every [`ConversationEvent`] this member has emitted, in order.

--- a/tests/protocol_messaging.rs
+++ b/tests/protocol_messaging.rs
@@ -9,6 +9,7 @@ use de_mls::{ConversationState, StewardListConfig};
 
 const ALICE: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 const BOB: &str = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const CHARLIE: &str = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 
 #[test]
 fn chat_message_delivered_to_peer() {
@@ -43,5 +44,71 @@ fn chat_message_delivered_to_peer() {
     assert!(
         !h.member(0).got_chat(b"Hello from alice"),
         "sender must not receive its own chat"
+    );
+}
+
+/// A receiving peer can resolve the MLS-authenticated signature key of a chat's
+/// attributed sender via `member_signature_key(sender)`, and it matches the key
+/// that sender actually signs with — the realistic sender-authentication path.
+#[test]
+fn received_chat_sender_signature_key_resolves_to_the_signer() {
+    let mut h = TestHarness::<3>::bootstrap(
+        [ALICE, BOB, CHARLIE],
+        "sig-key",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    assert!(h.all_working());
+    assert!(h.converged(), "group forked during bootstrap");
+
+    h.member_mut(0).send_message(b"signed by alice".to_vec());
+    h.process_until("bob and charlie receive alice's chat", |h| {
+        h.member(1).got_chat(b"signed by alice") && h.member(2).got_chat(b"signed by alice")
+    });
+
+    let alice_key = h.member(0).signing_pubkey();
+    // Each receiver reads the attributed sender and resolves its signing key,
+    // landing on alice's real key.
+    for receiver in [1usize, 2] {
+        let chat = &h.member(receiver).received()[0];
+        assert_eq!(chat.sender, h.member(0).member_id_bytes());
+        assert_eq!(
+            h.member(receiver).member_signature_key(&chat.sender),
+            Some(alice_key.clone()),
+            "receiver {receiver} resolved the wrong signing key for alice",
+        );
+    }
+}
+
+/// Every member resolves every member's signing key identically and correctly,
+/// and an id belonging to no current member resolves to `None`.
+#[test]
+fn member_signature_key_agrees_across_the_group() {
+    let h = TestHarness::<3>::bootstrap(
+        [ALICE, BOB, CHARLIE],
+        "sig-key-all",
+        fast_config(),
+        StewardListConfig::new(1, 5).unwrap(),
+    );
+    assert!(h.all_working());
+    assert!(h.membership_agrees(), "members disagree on the member set");
+
+    for subject in 0..3 {
+        let id = h.member(subject).member_id_bytes().to_vec();
+        let expected = h.member(subject).signing_pubkey();
+        for viewer in 0..3 {
+            assert_eq!(
+                h.member(viewer).member_signature_key(&id),
+                Some(expected.clone()),
+                "member {viewer} resolved the wrong signing key for member {subject}",
+            );
+        }
+    }
+
+    // An id that belongs to no current member has no key.
+    assert_eq!(
+        h.member(0).member_signature_key(b"stranger-not-in-group"),
+        None,
+        "a non-member id must not resolve to a signing key",
     );
 }


### PR DESCRIPTION
Resolve each member's MLS signature public key and expose it to the integrator, so a receiver can authenticate who signed an inbound message.

The sender is now resolved from the processed message's leaf (`Sender::Member` → `member_at`) at decrypt time, carrying both the credential `member_id` and its `signature_key` in a new `MemberIdentity` on `DecryptedMessage`. A `member_signature_key(member_id)` query is added on both `MlsService` and `Conversation` to look up any current member's signing key.

This drops the per-message `sender_credential` field from `ConversationMessage`: the signing key is exposed through the query keyed by the authenticated sender rather than stamped onto every chat.

Adds tests asserting a receiver resolves a chat sender's key to the real signer, that every member agrees on every member's key, and that a non-member id resolves to `None`.

Corresponding issue: https://github.com/vacp2p/de-mls/issues/136