### PR TITLE
feat(steward): resend_commit rebroadcasts a held candidate

### DIFF
--- a/src/commit_round/buffer.rs
+++ b/src/commit_round/buffer.rs
@@ -1,9 +1,11 @@
 //! Commit-round candidate buffer: the per-epoch set of commit candidates the
 //! round collects before selection, and the outcome of a buffering attempt.
 
+use prost::Message;
+
 use crate::{
     CommitHash, NoopReason, ProcessResult, compute_commit_hash,
-    protos::de_mls::messages::v1::CommitCandidate,
+    protos::de_mls::messages::v1::{AppMessage, CommitCandidate},
 };
 
 /// Commit-round candidate buffer for deterministic selection: the candidates
@@ -64,6 +66,14 @@ impl CommitRoundBuffer {
         self.candidates.iter().any(|c| c.is_local_candidate)
     }
 
+    /// Wire bytes of our own buffered candidate, ready to rebroadcast, or
+    /// `None` when we hold no local candidate.
+    pub fn local_candidate_bytes(&self) -> Option<Vec<u8>> {
+        let candidate = self.candidates.iter().find(|c| c.is_local_candidate)?;
+        let msg: AppMessage = candidate.candidate_msg.clone().into();
+        Some(msg.encode_to_vec())
+    }
+
     /// Discard all buffered candidates.
     pub fn clear(&mut self) {
         self.candidates.clear();
@@ -114,5 +124,45 @@ impl CommitBufferOutcome {
             Self::DuplicateHash => ProcessResult::Noop(NoopReason::DuplicateBufferedHash),
             Self::CapReached => ProcessResult::Noop(NoopReason::CandidateBufferFull),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(commit_byte: u8) -> CommitCandidate {
+        CommitCandidate {
+            conversation_id: b"g".to_vec(),
+            mls_proposals: vec![vec![0xAB; 8]],
+            commit_message: vec![commit_byte; 32],
+            steward_member_id: vec![0x01],
+        }
+    }
+
+    #[test]
+    fn local_candidate_bytes_offers_only_our_own_candidate() {
+        let mut buffer = CommitRoundBuffer::default();
+        assert!(
+            buffer.local_candidate_bytes().is_none(),
+            "an empty buffer has nothing to resend"
+        );
+
+        // A remote candidate is not ours to rebroadcast.
+        buffer.add(candidate(0x01), false, None, Vec::new(), 1, 4);
+        assert!(
+            buffer.local_candidate_bytes().is_none(),
+            "a remote candidate must not be offered for rebroadcast"
+        );
+
+        // Our own candidate comes back as the AppMessage-wrapped wire bytes.
+        let ours = candidate(0x02);
+        buffer.add(ours.clone(), true, None, Vec::new(), 1, 4);
+        let expected: AppMessage = ours.into();
+        assert_eq!(
+            buffer.local_candidate_bytes(),
+            Some(expected.encode_to_vec()),
+            "resend must reproduce the identical wire bytes"
+        );
     }
 }

--- a/src/conversation/handle.rs
+++ b/src/conversation/handle.rs
@@ -477,6 +477,21 @@ where
         self.mint_and_broadcast_candidate(provider, signer)
     }
 
+    /// Rebroadcast our own commit candidate for the current round instead of
+    /// building a new one — a steward's remedy when its candidate was lost in
+    /// transport. A fresh build would draw new path secrets and fork the round;
+    /// resending replays the same bytes. Needs no provider or signer. `true` if
+    /// a candidate was held and rebroadcast, `false` if we have none.
+    pub fn resend_commit(&self) -> bool {
+        match self.queues.commit_round.local_candidate_bytes() {
+            Some(payload) => {
+                self.broadcast(payload);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Finalize the active commit round.
     pub(crate) fn finalize_commit_round<Pr>(
         &mut self,
@@ -1208,6 +1223,43 @@ mod tests {
             matches!(err, ConversationError::NoProposals),
             "recovery must relax the steward gate, got {err:?}"
         );
+    }
+
+    #[test]
+    fn resend_commit_rebroadcasts_the_held_candidate() {
+        let (mut conversation, _provider, _signer) =
+            make_conversation_with_steward(steward_service_steward(b"test-member-id"));
+
+        // No candidate built yet: nothing to resend, nothing broadcast.
+        assert!(!conversation.resend_commit(), "no held candidate to resend");
+        assert!(conversation.drain_outbound().is_empty());
+
+        // Seed our own candidate into the round, as building one would.
+        let candidate = CommitCandidate {
+            conversation_id: b"g".to_vec(),
+            mls_proposals: vec![vec![0x01; 8]],
+            commit_message: vec![0x02; 32],
+            steward_member_id: b"test-member-id".to_vec(),
+        };
+        let epoch = conversation.mls().current_epoch().unwrap();
+        conversation
+            .queues
+            .commit_round
+            .add(candidate.clone(), true, None, Vec::new(), epoch, 4);
+
+        // Resend puts the AppMessage-wrapped candidate back on the wire.
+        assert!(conversation.resend_commit(), "held candidate is resent");
+        let out = conversation.drain_outbound();
+        assert_eq!(out.len(), 1, "exactly one rebroadcast");
+        let expected: AppMessage = candidate.into();
+        assert_eq!(out[0].payload, expected.encode_to_vec());
+
+        // The candidate stays buffered, so resend can be called again.
+        assert!(
+            conversation.resend_commit(),
+            "candidate still held after resend"
+        );
+        assert_eq!(conversation.drain_outbound().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Adds `Conversation::resend_commit()`: a steward re-broadcasts its already-built commit candidate for the current round instead of building a new one. When a steward's candidate is lost in transport, building a fresh one would draw new path secrets and produce a divergent commit, forking the round — resending replays the exact same bytes.